### PR TITLE
Fix android-emulator workflow-load failure (env in jobs.name)

### DIFF
--- a/.github/workflows/android-emulator.yml
+++ b/.github/workflows/android-emulator.yml
@@ -24,7 +24,12 @@ env:
 
 jobs:
   emulator:
-    name: android-emulator (x86_64, api ${{ env.OCTARINE_API_LEVEL }})
+    # Hardcoded API level in the name: `env.*` context is NOT available in `jobs.<id>.name` at
+    # workflow-load time (per GHA expression docs — only github/needs/vars/inputs/matrix/strategy
+    # are valid here). Using `${{ env.OCTARINE_API_LEVEL }}` makes GitHub reject the whole
+    # workflow with a "workflow file issue" and no jobs ever start. Keep the env var for use
+    # inside steps below; mirror its value into this label by hand when bumping.
+    name: android-emulator (x86_64, api 35)
     # ubuntu-latest 4-core enables KVM, which the reactivecircus/android-emulator-runner action
     # needs for headless x86_64 boot. macOS runners ship without KVM and would fall back to a slow
     # software emulator.


### PR DESCRIPTION
## Summary
- `env.OCTARINE_API_LEVEL` interpolation in `jobs.emulator.name` is rejected at workflow-load (GHA only allows github/needs/vars/inputs/matrix/strategy contexts in that field).
- Result: GitHub rejected the whole workflow with "workflow file issue" and zero jobs ever started; the emulator runtime smoke never ran.
- First surfaced on actual push to main after #31; earlier non-main pushes hid it as a UX quirk.

## Fix
Hardcode the API level in the job name (`api 35`). Env var stays for step bodies. Inline comment calls out the manual-mirror requirement when bumping.

## Test plan
- [x] CI: this PR's PR-trigger runs of android/package/build/benchmark stay green.
- [ ] Post-merge: push-to-main fires android-emulator.yml and the job actually starts this time.