### PR TITLE
Track Lua API stub at repo root and gate CI on drift

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,25 @@ jobs:
         if: matrix.platform == 'linux' && matrix.preset == 'editor-release'
         run: ctest --test-dir build/${{ matrix.preset }} --output-on-failure
 
+      - name: Check Lua API stub drift
+        id: lua_drift
+        if: matrix.platform == 'linux' && matrix.preset == 'editor-release'
+        shell: bash
+        run: |
+          if ! git diff --quiet -- lua_api.smoke.lua; then
+            echo "::error::lua_api.smoke.lua drifted. Run OctarineLuaApiTest (editor preset) locally and commit the regenerated file."
+            git diff -- lua_api.smoke.lua | head -200
+            exit 1
+          fi
+
+      - name: Upload regenerated Lua API stub on drift
+        if: always() && steps.lua_drift.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: lua_api.smoke.lua-from-ci
+          path: lua_api.smoke.lua
+          if-no-files-found: error
+
       - name: Stage runtime DLLs (Windows)
         if: matrix.platform == 'windows'
         shell: pwsh

--- a/.gitignore
+++ b/.gitignore
@@ -1012,5 +1012,6 @@ imgui.ini
 
 # Ignore auto-cloned game repo for benchmarking
 .benchmark_game/
-# Lua API smoke-test artifact (written to cwd by OctarineLuaApiTest)
-lua_api.smoke.lua
+
+# Local agent/LLM scratchpad — agent-facing docs, notes, indexes (not part of the project)
+.agent/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -414,6 +414,10 @@ if (OCTARINE_ENABLE_TESTS)
 
     # Mirror the main target's feature defines so the shared sources compile identically.
     target_compile_definitions(OctarineLuaApiTest PRIVATE GLM_FORCE_INTRINSICS)
+    # Smoke test writes its EmmyLua stub here so a repo-root copy stays in sync with the live bindings;
+    # CI diffs it against the tracked file to fail on drift.
+    target_compile_definitions(OctarineLuaApiTest PRIVATE
+            LUA_API_SMOKE_OUTPUT="${CMAKE_CURRENT_SOURCE_DIR}/lua_api.smoke.lua")
     if (OCTARINE_WITH_IMGUI)
         target_compile_definitions(OctarineLuaApiTest PRIVATE OCTARINE_WITH_IMGUI)
     endif ()

--- a/lua_api.smoke.lua
+++ b/lua_api.smoke.lua
@@ -1,0 +1,830 @@
+-- AUTO-GENERATED Octarine Lua API surface. Do not edit by hand.
+-- Introspected from the live sol::state after all bindings install.
+-- Regenerate by setting OCTARINE_DUMP_LUA_API=<path> and launching the engine.
+---@meta
+---@diagnostic disable: lowercase-global, missing-return
+
+---@class ImGui
+ImGui = {}
+
+function ImGui.AlignTextToFramePadding(...) end
+
+function ImGui.ArrowButton(...) end
+
+function ImGui.Begin(...) end
+
+function ImGui.BeginChild(...) end
+
+function ImGui.BeginChildEx(...) end
+
+function ImGui.BeginChildFrame(...) end
+
+function ImGui.BeginCombo(...) end
+
+function ImGui.BeginGroup(...) end
+
+function ImGui.BeginItemTooltip(...) end
+
+function ImGui.BeginListBox(...) end
+
+function ImGui.BeginMainMenuBar(...) end
+
+function ImGui.BeginMenu(...) end
+
+function ImGui.BeginMenuBar(...) end
+
+function ImGui.BeginPopup(...) end
+
+function ImGui.BeginPopupContextItem(...) end
+
+function ImGui.BeginPopupContextVoid(...) end
+
+function ImGui.BeginPopupContextWindow(...) end
+
+function ImGui.BeginPopupModal(...) end
+
+function ImGui.BeginTabBar(...) end
+
+function ImGui.BeginTabItem(...) end
+
+function ImGui.BeginTooltip(...) end
+
+function ImGui.Bullet(...) end
+
+function ImGui.BulletText(...) end
+
+function ImGui.Button(...) end
+
+function ImGui.CalcItemWidth(...) end
+
+function ImGui.CalcTextSize(...) end
+
+function ImGui.CaptureKeyboardFromApp(...) end
+
+function ImGui.CaptureMouseFromApp(...) end
+
+function ImGui.Checkbox(...) end
+
+function ImGui.CheckboxFlags(...) end
+
+function ImGui.CloseCurrentPopup(...) end
+
+function ImGui.CollapsingHeader(...) end
+
+function ImGui.ColorButton(...) end
+
+function ImGui.ColorConvertHSVtoRGB(...) end
+
+function ImGui.ColorConvertRGBtoHSV(...) end
+
+function ImGui.ColorEdit3(...) end
+
+function ImGui.ColorEdit4(...) end
+
+function ImGui.ColorPicker3(...) end
+
+function ImGui.ColorPicker4(...) end
+
+function ImGui.Columns(...) end
+
+function ImGui.Combo(...) end
+
+function ImGui.DockSpace(...) end
+
+function ImGui.DragFloat(...) end
+
+function ImGui.DragFloat2(...) end
+
+function ImGui.DragFloat3(...) end
+
+function ImGui.DragFloat4(...) end
+
+function ImGui.DragInt(...) end
+
+function ImGui.DragInt2(...) end
+
+function ImGui.DragInt3(...) end
+
+function ImGui.DragInt4(...) end
+
+function ImGui.Dummy(...) end
+
+function ImGui.End(...) end
+
+function ImGui.EndChild(...) end
+
+function ImGui.EndChildFrame(...) end
+
+function ImGui.EndCombo(...) end
+
+function ImGui.EndGroup(...) end
+
+function ImGui.EndListBox(...) end
+
+function ImGui.EndMainMenuBar(...) end
+
+function ImGui.EndMenu(...) end
+
+function ImGui.EndMenuBar(...) end
+
+function ImGui.EndPopup(...) end
+
+function ImGui.EndTabBar(...) end
+
+function ImGui.EndTabItem(...) end
+
+function ImGui.EndTooltip(...) end
+
+function ImGui.GetClipboardText(...) end
+
+function ImGui.GetColumnIndex(...) end
+
+function ImGui.GetColumnOffset(...) end
+
+function ImGui.GetColumnWidth(...) end
+
+function ImGui.GetColumnsCount(...) end
+
+function ImGui.GetContentRegionAvail(...) end
+
+function ImGui.GetCursorPos(...) end
+
+function ImGui.GetCursorPosX(...) end
+
+function ImGui.GetCursorPosY(...) end
+
+function ImGui.GetCursorScreenPos(...) end
+
+function ImGui.GetCursorStartPos(...) end
+
+function ImGui.GetFont(...) end
+
+function ImGui.GetFontSize(...) end
+
+function ImGui.GetFontTexUvWhitePixel(...) end
+
+function ImGui.GetFrameCount(...) end
+
+function ImGui.GetFrameHeight(...) end
+
+function ImGui.GetFrameHeightWithSpacing(...) end
+
+function ImGui.GetID(...) end
+
+function ImGui.GetItemRectMax(...) end
+
+function ImGui.GetItemRectMin(...) end
+
+function ImGui.GetItemRectSize(...) end
+
+function ImGui.GetKeyIndex(...) end
+
+function ImGui.GetKeyPressedAmount(...) end
+
+function ImGui.GetMouseCursor(...) end
+
+function ImGui.GetMouseDragDelta(...) end
+
+function ImGui.GetMousePos(...) end
+
+function ImGui.GetMousePosOnOpeningCurrentPopup(...) end
+
+function ImGui.GetScrollMaxX(...) end
+
+function ImGui.GetScrollMaxY(...) end
+
+function ImGui.GetScrollX(...) end
+
+function ImGui.GetScrollY(...) end
+
+function ImGui.GetStyleColorName(...) end
+
+function ImGui.GetStyleColorVec4(...) end
+
+function ImGui.GetTextLineHeight(...) end
+
+function ImGui.GetTextLineHeightWithSpacing(...) end
+
+function ImGui.GetTime(...) end
+
+function ImGui.GetTreeNodeToLabelSpacing(...) end
+
+function ImGui.GetWindowDockID(...) end
+
+function ImGui.GetWindowHeight(...) end
+
+function ImGui.GetWindowPos(...) end
+
+function ImGui.GetWindowSize(...) end
+
+function ImGui.GetWindowWidth(...) end
+
+function ImGui.Indent(...) end
+
+function ImGui.InputDouble(...) end
+
+function ImGui.InputFloat(...) end
+
+function ImGui.InputFloat2(...) end
+
+function ImGui.InputFloat3(...) end
+
+function ImGui.InputFloat4(...) end
+
+function ImGui.InputInt(...) end
+
+function ImGui.InputInt2(...) end
+
+function ImGui.InputInt3(...) end
+
+function ImGui.InputInt4(...) end
+
+function ImGui.InputText(...) end
+
+function ImGui.InputTextMultiline(...) end
+
+function ImGui.InputTextWithHint(...) end
+
+function ImGui.InvisibleButton(...) end
+
+function ImGui.IsAnyItemActive(...) end
+
+function ImGui.IsAnyItemFocused(...) end
+
+function ImGui.IsAnyItemHovered(...) end
+
+function ImGui.IsAnyMouseDown(...) end
+
+function ImGui.IsItemActivated(...) end
+
+function ImGui.IsItemActive(...) end
+
+function ImGui.IsItemClicked(...) end
+
+function ImGui.IsItemDeactivated(...) end
+
+function ImGui.IsItemDeactivatedAfterEdit(...) end
+
+function ImGui.IsItemEdited(...) end
+
+function ImGui.IsItemFocused(...) end
+
+function ImGui.IsItemHovered(...) end
+
+function ImGui.IsItemToggledOpen(...) end
+
+function ImGui.IsItemVisible(...) end
+
+function ImGui.IsKeyDown(...) end
+
+function ImGui.IsKeyPressed(...) end
+
+function ImGui.IsKeyReleased(...) end
+
+function ImGui.IsMouseClicked(...) end
+
+function ImGui.IsMouseDoubleClicked(...) end
+
+function ImGui.IsMouseDown(...) end
+
+function ImGui.IsMouseDragging(...) end
+
+function ImGui.IsMouseHoveringRect(...) end
+
+function ImGui.IsMousePosValid(...) end
+
+function ImGui.IsMouseReleased(...) end
+
+function ImGui.IsPopupOpen(...) end
+
+function ImGui.IsRectVisible(...) end
+
+function ImGui.IsWindowAppearing(...) end
+
+function ImGui.IsWindowCollapsed(...) end
+
+function ImGui.IsWindowDocked(...) end
+
+function ImGui.IsWindowFocused(...) end
+
+function ImGui.IsWindowHovered(...) end
+
+function ImGui.LabelText(...) end
+
+function ImGui.ListBox(...) end
+
+function ImGui.LogButtons(...) end
+
+function ImGui.LogFinish(...) end
+
+function ImGui.LogText(...) end
+
+function ImGui.LogToClipboard(...) end
+
+function ImGui.LogToFile(...) end
+
+function ImGui.LogToTTY(...) end
+
+function ImGui.MenuItem(...) end
+
+function ImGui.MenuItemToggle(...) end
+
+function ImGui.NewLine(...) end
+
+function ImGui.NextColumn(...) end
+
+function ImGui.OpenPopup(...) end
+
+function ImGui.OpenPopupOnItemClick(...) end
+
+function ImGui.PopAllowKeyboardFocus(...) end
+
+function ImGui.PopButtonRepeat(...) end
+
+function ImGui.PopClipRect(...) end
+
+function ImGui.PopFont(...) end
+
+function ImGui.PopID(...) end
+
+function ImGui.PopItemWidth(...) end
+
+function ImGui.PopStyleColor(...) end
+
+function ImGui.PopStyleVar(...) end
+
+function ImGui.PopTextWrapPos(...) end
+
+function ImGui.ProgressBar(...) end
+
+function ImGui.PushAllowKeyboardFocus(...) end
+
+function ImGui.PushButtonRepeat(...) end
+
+function ImGui.PushClipRect(...) end
+
+function ImGui.PushFont(...) end
+
+function ImGui.PushID(...) end
+
+function ImGui.PushItemWidth(...) end
+
+function ImGui.PushStyleColor(...) end
+
+function ImGui.PushStyleVar(...) end
+
+function ImGui.PushTextWrapPos(...) end
+
+function ImGui.RadioButton(...) end
+
+function ImGui.ResetMouseDragDelta(...) end
+
+function ImGui.SameLine(...) end
+
+function ImGui.Selectable(...) end
+
+function ImGui.Separator(...) end
+
+function ImGui.SetClipboardText(...) end
+
+function ImGui.SetColorEditOptions(...) end
+
+function ImGui.SetColumnOffset(...) end
+
+function ImGui.SetColumnWidth(...) end
+
+function ImGui.SetCursorPos(...) end
+
+function ImGui.SetCursorPosX(...) end
+
+function ImGui.SetCursorPosY(...) end
+
+function ImGui.SetCursorScreenPos(...) end
+
+function ImGui.SetItemDefaultFocus(...) end
+
+function ImGui.SetItemTooltip(...) end
+
+function ImGui.SetKeyboardFocusHere(...) end
+
+function ImGui.SetMouseCursor(...) end
+
+function ImGui.SetNextItemAllowOverlap(...) end
+
+function ImGui.SetNextItemOpen(...) end
+
+function ImGui.SetNextItemWidth(...) end
+
+function ImGui.SetNextWindowBgAlpha(...) end
+
+function ImGui.SetNextWindowCollapsed(...) end
+
+function ImGui.SetNextWindowContentSize(...) end
+
+function ImGui.SetNextWindowDockID(...) end
+
+function ImGui.SetNextWindowFocus(...) end
+
+function ImGui.SetNextWindowPos(...) end
+
+function ImGui.SetNextWindowSize(...) end
+
+function ImGui.SetNextWindowSizeConstraints(...) end
+
+function ImGui.SetScrollFromPosX(...) end
+
+function ImGui.SetScrollFromPosY(...) end
+
+function ImGui.SetScrollHereX(...) end
+
+function ImGui.SetScrollHereY(...) end
+
+function ImGui.SetScrollX(...) end
+
+function ImGui.SetScrollY(...) end
+
+function ImGui.SetTabItemClosed(...) end
+
+function ImGui.SetTooltip(...) end
+
+function ImGui.SetWindowCollapsed(...) end
+
+function ImGui.SetWindowFocus(...) end
+
+function ImGui.SetWindowFontScale(...) end
+
+function ImGui.SetWindowPos(...) end
+
+function ImGui.SetWindowSize(...) end
+
+function ImGui.SliderAngle(...) end
+
+function ImGui.SliderFloat(...) end
+
+function ImGui.SliderFloat2(...) end
+
+function ImGui.SliderFloat3(...) end
+
+function ImGui.SliderFloat4(...) end
+
+function ImGui.SliderInt(...) end
+
+function ImGui.SliderInt2(...) end
+
+function ImGui.SliderInt3(...) end
+
+function ImGui.SliderInt4(...) end
+
+function ImGui.SmallButton(...) end
+
+function ImGui.Spacing(...) end
+
+function ImGui.Text(...) end
+
+function ImGui.TextColored(...) end
+
+function ImGui.TextDisabled(...) end
+
+function ImGui.TextUnformatted(...) end
+
+function ImGui.TextWrapped(...) end
+
+function ImGui.TreeNode(...) end
+
+function ImGui.TreeNodeEx(...) end
+
+function ImGui.TreePop(...) end
+
+function ImGui.TreePush(...) end
+
+function ImGui.Unindent(...) end
+
+function ImGui.VSliderFloat(...) end
+
+function ImGui.VSliderInt(...) end
+
+function ImGui.Value(...) end
+
+
+---@class ImGuiChildFlags
+ImGuiChildFlags = {}
+
+
+---@class ImGuiCol
+ImGuiCol = {}
+
+
+---@class ImGuiColorEditFlags
+ImGuiColorEditFlags = {}
+
+
+---@class ImGuiComboFlags
+ImGuiComboFlags = {}
+
+
+---@class ImGuiCond
+ImGuiCond = {}
+
+
+---@class ImGuiDir
+ImGuiDir = {}
+
+
+---@class ImGuiFocusedFlags
+ImGuiFocusedFlags = {}
+
+
+---@class ImGuiHoveredFlags
+ImGuiHoveredFlags = {}
+
+
+---@class ImGuiInputTextFlags
+ImGuiInputTextFlags = {}
+
+
+---@class ImGuiItemFlags
+ImGuiItemFlags = {}
+
+
+---@class ImGuiKey
+ImGuiKey = {}
+
+
+---@class ImGuiMouseButton
+ImGuiMouseButton = {}
+
+
+---@class ImGuiMouseCursor
+ImGuiMouseCursor = {}
+
+
+---@class ImGuiPopupFlags
+ImGuiPopupFlags = {}
+
+
+---@class ImGuiSelectableFlags
+ImGuiSelectableFlags = {}
+
+
+---@class ImGuiStyleVar
+ImGuiStyleVar = {}
+
+
+---@class ImGuiTabBarFlags
+ImGuiTabBarFlags = {}
+
+
+---@class ImGuiTabItemFlags
+ImGuiTabItemFlags = {}
+
+
+---@class ImGuiTreeNodeFlags
+ImGuiTreeNodeFlags = {}
+
+
+---@class ImGuiWindowFlags
+ImGuiWindowFlags = {}
+
+
+function acquire_scene_assets(...) end
+
+---@class animation_component
+animation_component = {}
+
+
+---@class audio_source_component
+audio_source_component = {}
+
+
+function blam(...) end
+
+---@class box_collider_component
+box_collider_component = {}
+
+
+---@class camera_follow_component
+camera_follow_component = {}
+
+
+function clear_scene(...) end
+
+---@class color
+color = {}
+
+
+---@class entity
+entity = {}
+
+
+function find_entity_by_name(...) end
+
+function fire_projectile(...) end
+
+function get_asset_path(...) end
+
+function get_camera_position(...) end
+
+function get_game_map_dimensions(...) end
+
+function get_name(...) end
+
+function get_position(...) end
+
+---@class health_component
+health_component = {}
+
+
+---@class input
+input = {}
+
+function input.bind(...) end
+
+function input.is_action_down(...) end
+
+function input.is_action_pressed(...) end
+
+function input.is_action_released(...) end
+
+function input.is_focused(...) end
+
+function input.is_hovered(...) end
+
+function input.is_key_down(...) end
+
+function input.is_key_pressed(...) end
+
+function input.is_key_released(...) end
+
+function input.is_mouse_down(...) end
+
+function input.is_mouse_pressed(...) end
+
+function input.is_mouse_released(...) end
+
+function input.mouse_position(...) end
+
+function input.mouse_wheel(...) end
+
+function input.on_key_down(...) end
+
+function input.on_key_up(...) end
+
+function input.on_mouse_down(...) end
+
+function input.on_mouse_up(...) end
+
+function input.on_mouse_wheel(...) end
+
+function input.unbind(...) end
+
+
+function load_asset(...) end
+
+function load_entity(...) end
+
+function load_scene(...) end
+
+function log(...) end
+
+function log_e(...) end
+
+function log_i(...) end
+
+function log_w(...) end
+
+---@class name_component
+name_component = {}
+
+
+function play_sound(...) end
+
+---@class position_component
+position_component = {}
+
+
+---@class projectile_emitter_component
+projectile_emitter_component = {}
+
+
+function quit_game(...) end
+
+function read_file_lines(...) end
+
+---@class registry
+registry = {}
+
+function registry.get_animation(...) end
+
+function registry.get_audio_source(...) end
+
+function registry.get_box_collider(...) end
+
+function registry.get_camera_follow(...) end
+
+function registry.get_health(...) end
+
+function registry.get_name(...) end
+
+function registry.get_parent(...) end
+
+function registry.get_position(...) end
+
+function registry.get_projectile_emitter(...) end
+
+function registry.get_rigidbody(...) end
+
+function registry.get_rotation(...) end
+
+function registry.get_scale(...) end
+
+function registry.get_script(...) end
+
+function registry.get_sprite(...) end
+
+function registry.get_square(...) end
+
+function registry.get_text_label(...) end
+
+function registry.get_ui_button(...) end
+
+function registry.has_animation(...) end
+
+function registry.has_audio_source(...) end
+
+function registry.has_box_collider(...) end
+
+function registry.has_camera_follow(...) end
+
+function registry.has_health(...) end
+
+function registry.has_name(...) end
+
+function registry.has_position(...) end
+
+function registry.has_projectile_emitter(...) end
+
+function registry.has_rigidbody(...) end
+
+function registry.has_rotation(...) end
+
+function registry.has_scale(...) end
+
+function registry.has_script(...) end
+
+function registry.has_sprite(...) end
+
+function registry.has_square(...) end
+
+function registry.has_text_label(...) end
+
+function registry.has_ui_button(...) end
+
+
+function reload_scene(...) end
+
+---@class rigidbody_component
+rigidbody_component = {}
+
+
+---@class rotation_component
+rotation_component = {}
+
+
+---@class scale_component
+scale_component = {}
+
+
+---@class script_component
+script_component = {}
+
+
+function set_game_map_dimensions(...) end
+
+function set_name(...) end
+
+function set_position(...) end
+
+function set_sprite_src_rect(...) end
+
+---@class sprite_component
+sprite_component = {}
+
+
+---@class square_primitive_component
+square_primitive_component = {}
+
+
+function stop_scene(...) end
+
+---@class text_label_component
+text_label_component = {}
+
+
+---@class ui_button_component
+ui_button_component = {}
+
+
+---@class vec2
+vec2 = {}
+
+

--- a/src/Lua/LuaApiManifest.cpp
+++ b/src/Lua/LuaApiManifest.cpp
@@ -16,6 +16,18 @@ namespace
         sol::object value;
     };
 
+    // Sol2 leaks internal metatable bookkeeping entries (the ♻ recycle marker, and class names that
+    // contain raw typeid strings like `glm::vec<2, float, glm::packed_highp>`) into the global table.
+    // Those mangled names are platform-specific (MSVC vs libstdc++ stringify templates differently)
+    // and would cause endless CI drift; they are also not real Lua surface. Skip anything that is
+    // obviously not a valid Lua identifier path.
+    bool IsSolInternalName(const std::string& name)
+    {
+        return name.find("\xe2\x99\xbb") != std::string::npos  // ♻ U+267B
+            || name.find("::") != std::string::npos
+            || name.find('<') != std::string::npos;
+    }
+
     // Collect string-keyed entries of a table, sorted by name for stable output.
     std::vector<NamedObject> SortedEntries(const sol::table& table)
     {
@@ -63,6 +75,7 @@ namespace
         for (const auto& member : SortedEntries(table))
         {
             if (member.name.rfind("__", 0) == 0) continue; // skip metamethods (__index, ...)
+            if (IsSolInternalName(member.name)) continue;
             if (member.value.get_type() == sol::type::function)
             {
                 EmitFunction(out, name + "." + member.name);
@@ -106,6 +119,7 @@ namespace LuaApiManifest
             if (key.get_type() != sol::type::string) continue;
             const std::string name = key.as<std::string>();
             if (before.contains(name)) continue;
+            if (IsSolInternalName(name)) continue;
             added.push_back({name, value});
         }
         std::sort(added.begin(), added.end(),

--- a/tests/LuaApiSmokeTest.cpp
+++ b/tests/LuaApiSmokeTest.cpp
@@ -140,7 +140,12 @@ int main()
     Check(TableHasFunction(lua, "input", "is_key_down"), "input.is_key_down (InputSystem surface)");
 
     std::cout << "[manifest] generator runs\n";
-    Check(LuaApiManifest::Write(lua, preBinding, "lua_api.smoke.lua"), "manifest written");
+#ifdef LUA_API_SMOKE_OUTPUT
+    const std::string smokeOutPath = LUA_API_SMOKE_OUTPUT;
+#else
+    const std::string smokeOutPath = "lua_api.smoke.lua";
+#endif
+    Check(LuaApiManifest::Write(lua, preBinding, smokeOutPath), "manifest written");
 
     if (g_failures == 0)
     {


### PR DESCRIPTION
## Summary

- `OctarineLuaApiTest` now writes `lua_api.smoke.lua` to the source tree via the new `LUA_API_SMOKE_OUTPUT` compile def; the file is tracked in git.
- New CI step (linux + editor-release leg) fails the build if the regenerated stub differs from the committed copy, with a diff snippet and an artifact upload of the regenerated file for inspection.
- `LuaApiManifest::Write` filters sol2-internal metatable entries — typeid-stringified names containing `::` or `<`, and the `♻` recycle marker — so the stub is stable across MSVC and libstdc++ (those names mangle differently per compiler).
- `.agent/` added to `.gitignore` as a local-only scratchpad for agent/LLM-facing docs that should not ship with the repo.

## Test plan

- [x] Linux + editor-release ctest passes (`LuaApiSmokeTest` + `AssetPipelineTest`)
- [x] Stub drift check passes on a fresh CI run with the committed `lua_api.smoke.lua`
- [x] All 6 matrix legs (linux/windows/macos × editor-release/player-release) green
- [x] Intentional break test: commented out `registerComponent<HealthComponent>()` on a throwaway branch, dispatched CI ([run 26689906913](https://github.com/mblackman/Octarine-Engine/actions/runs/26689906913)) — linux drift gate fired with diff showing `health_component` class removed, exit 1 as designed