### PR TITLE
Promote AssetCatalog manifest-load logs to warn level

### DIFF
--- a/src/AssetManager/AssetCatalog.cpp
+++ b/src/AssetManager/AssetCatalog.cpp
@@ -184,7 +184,10 @@ bool AssetCatalog::Build(const std::string& basePath, sol::state& lua, std::opti
         if (SDL_IOStream* probe = SDL_IOFromFile(manifestStr.c_str(), "rb"); probe != nullptr)
         {
             SDL_CloseIO(probe);
-            Logger::Info("AssetCatalog: baked manifest found, loading (scan skipped): " + manifestStr);
+            // Warn-level on purpose — same rationale as the "loaded N entries" line below: this is
+            // the bootstrap path a shipped (warn-level) build needs visible so the manifest-vs-scan
+            // gate is observable in CI + on-device support repros.
+            Logger::Warn("AssetCatalog: baked manifest found, loading (scan skipped): " + manifestStr);
             return LoadManifest(manifestStr, lua, basePath);
         }
         Logger::Warn("AssetCatalog: manifest load allowed but no asset_manifest.lua at root; scanning.");
@@ -388,7 +391,12 @@ bool AssetCatalog::LoadManifest(const std::string& manifestPath, sol::state& lua
     }
 
     from_manifest_ = true;
-    Logger::Info("AssetCatalog: loaded " + std::to_string(entries_.size()) + " entries from manifest " + manifestPath +
+    // Warn-level on purpose: this is the single bootstrap signal that a shipped build is loading
+    // its baked catalog (vs scanning). Shipped builds default to warn-level logging (per
+    // BuildConfigUnificationPlan phase 3), so an Info log here would be suppressed and the
+    // android-emulator gate's manifest-load assertion would never match. Keep as a single line
+    // per launch — it's a startup confirmation, not noise.
+    Logger::Warn("AssetCatalog: loaded " + std::to_string(entries_.size()) + " entries from manifest " + manifestPath +
         (ok ? "" : " (with malformed entries skipped)"));
     return ok;
 }


### PR DESCRIPTION
## Summary
Shipped Android builds default to warn-level logging (per
BuildConfigUnificationPlan phase 3, enforced by the `if (ANDROID)` block in
CMakeLists.txt). Two `AssetCatalog` bootstrap signals were Info-level and
therefore suppressed in shipped logcat:

- `AssetCatalog: baked manifest found, loading (scan skipped): <path>`
- `AssetCatalog: loaded N entries from manifest <path>`

Net effect: the android-emulator runtime-smoke gate's grep for
`AssetCatalog: loaded .* entries from manifest` could **never** match —
gate failed regardless of whether the catalog actually loaded.

## Fix
Lift both lines from Info → Warn. These are single-line-per-launch
startup-confirmation signals, same justification as a `"Server started on
port X"` warn log. Inline comments at both call sites document why.

## Validation
Dispatched android-emulator.yml against this branch (run 26690523562):

```
W Octarine: AssetCatalog: baked manifest found, loading (scan skipped): asset_manifest.lua
W Octarine: AssetCatalog: loaded 26 entries from manifest asset_manifest.lua
PASS: emulator launch reached manifest-load
```

End-to-end Android smoke now green. The asset pipeline is confirmed working
on Android with no AAssetManager rewiring needed — `SDL_IOFromFile` already
resolves relative paths against the APK asset root correctly.

## Out of scope / follow-up
Logcat also shows `W Octarine: AudioSystem: Clip not found: helicopter`
during gameplay despite `helicopter` being in the manifest. Separate
downstream bug in audio asset loading on Android (likely SDL_mixer path
resolution). Warning only, engine continues; tracked as a follow-up.

## Test plan
- [x] PR-trigger CI green (android/package/build/benchmark).
- [x] android-emulator dispatch on this branch: PASS (gate now satisfied).
- [ ] Post-merge: scheduled nightly android-emulator on main stays green.