### PR TITLE
Emit components.json and modules.json from the Lua API smoke test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,23 +61,27 @@ jobs:
         if: matrix.platform == 'linux' && matrix.preset == 'editor-release'
         run: ctest --test-dir build/${{ matrix.preset }} --output-on-failure
 
-      - name: Check Lua API stub drift
+      - name: Check Lua API artifact drift
         id: lua_drift
         if: matrix.platform == 'linux' && matrix.preset == 'editor-release'
         shell: bash
         run: |
-          if ! git diff --quiet -- lua_api.smoke.lua; then
-            echo "::error::lua_api.smoke.lua drifted. Run OctarineLuaApiTest (editor preset) locally and commit the regenerated file."
-            git diff -- lua_api.smoke.lua | head -200
+          paths="lua_api.smoke.lua components.json modules.json"
+          if ! git diff --quiet -- $paths; then
+            echo "::error::One of $paths drifted. Run OctarineLuaApiTest (editor preset) locally and commit the regenerated files."
+            git diff -- $paths | head -400
             exit 1
           fi
 
-      - name: Upload regenerated Lua API stub on drift
+      - name: Upload regenerated Lua API artifacts on drift
         if: always() && steps.lua_drift.outcome == 'failure'
         uses: actions/upload-artifact@v4
         with:
-          name: lua_api.smoke.lua-from-ci
-          path: lua_api.smoke.lua
+          name: lua-api-artifacts-from-ci
+          path: |
+            lua_api.smoke.lua
+            components.json
+            modules.json
           if-no-files-found: error
 
       - name: Stage runtime DLLs (Windows)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -414,10 +414,12 @@ if (OCTARINE_ENABLE_TESTS)
 
     # Mirror the main target's feature defines so the shared sources compile identically.
     target_compile_definitions(OctarineLuaApiTest PRIVATE GLM_FORCE_INTRINSICS)
-    # Smoke test writes its EmmyLua stub here so a repo-root copy stays in sync with the live bindings;
-    # CI diffs it against the tracked file to fail on drift.
+    # Smoke test writes its EmmyLua stub + JSON indexes here so repo-root copies stay in sync with
+    # the live bindings; CI diffs all three against tracked files to fail on drift.
     target_compile_definitions(OctarineLuaApiTest PRIVATE
-            LUA_API_SMOKE_OUTPUT="${CMAKE_CURRENT_SOURCE_DIR}/lua_api.smoke.lua")
+            LUA_API_SMOKE_OUTPUT="${CMAKE_CURRENT_SOURCE_DIR}/lua_api.smoke.lua"
+            LUA_API_COMPONENTS_OUTPUT="${CMAKE_CURRENT_SOURCE_DIR}/components.json"
+            LUA_API_MODULES_OUTPUT="${CMAKE_CURRENT_SOURCE_DIR}/modules.json")
     if (OCTARINE_WITH_IMGUI)
         target_compile_definitions(OctarineLuaApiTest PRIVATE OCTARINE_WITH_IMGUI)
     endif ()

--- a/components.json
+++ b/components.json
@@ -1,0 +1,101 @@
+{
+  "_generated_by": "OctarineLuaApiTest via LuaApiManifest::WriteComponentsJson",
+  "components": [
+    {
+      "lua_key": "animation",
+      "usertype": "animation_component",
+      "has_accessor": "registry.has_animation",
+      "get_accessor": "registry.get_animation"
+    },
+    {
+      "lua_key": "audio_source",
+      "usertype": "audio_source_component",
+      "has_accessor": "registry.has_audio_source",
+      "get_accessor": "registry.get_audio_source"
+    },
+    {
+      "lua_key": "box_collider",
+      "usertype": "box_collider_component",
+      "has_accessor": "registry.has_box_collider",
+      "get_accessor": "registry.get_box_collider"
+    },
+    {
+      "lua_key": "camera_follow",
+      "usertype": "camera_follow_component",
+      "has_accessor": "registry.has_camera_follow",
+      "get_accessor": "registry.get_camera_follow"
+    },
+    {
+      "lua_key": "health",
+      "usertype": "health_component",
+      "has_accessor": "registry.has_health",
+      "get_accessor": "registry.get_health"
+    },
+    {
+      "lua_key": "name",
+      "usertype": "name_component",
+      "has_accessor": "registry.has_name",
+      "get_accessor": "registry.get_name"
+    },
+    {
+      "lua_key": "position",
+      "usertype": "position_component",
+      "has_accessor": "registry.has_position",
+      "get_accessor": "registry.get_position"
+    },
+    {
+      "lua_key": "projectile_emitter",
+      "usertype": "projectile_emitter_component",
+      "has_accessor": "registry.has_projectile_emitter",
+      "get_accessor": "registry.get_projectile_emitter"
+    },
+    {
+      "lua_key": "rigidbody",
+      "usertype": "rigidbody_component",
+      "has_accessor": "registry.has_rigidbody",
+      "get_accessor": "registry.get_rigidbody"
+    },
+    {
+      "lua_key": "rotation",
+      "usertype": "rotation_component",
+      "has_accessor": "registry.has_rotation",
+      "get_accessor": "registry.get_rotation"
+    },
+    {
+      "lua_key": "scale",
+      "usertype": "scale_component",
+      "has_accessor": "registry.has_scale",
+      "get_accessor": "registry.get_scale"
+    },
+    {
+      "lua_key": "script",
+      "usertype": "script_component",
+      "has_accessor": "registry.has_script",
+      "get_accessor": "registry.get_script"
+    },
+    {
+      "lua_key": "sprite",
+      "usertype": "sprite_component",
+      "has_accessor": "registry.has_sprite",
+      "get_accessor": "registry.get_sprite"
+    },
+    {
+      "lua_key": "square",
+      "usertype": "square_primitive_component",
+      "has_accessor": "registry.has_square",
+      "get_accessor": "registry.get_square"
+    },
+    {
+      "lua_key": "text_label",
+      "usertype": "text_label_component",
+      "has_accessor": "registry.has_text_label",
+      "get_accessor": "registry.get_text_label"
+    },
+    {
+      "lua_key": "ui_button",
+      "usertype": "ui_button_component",
+      "has_accessor": "registry.has_ui_button",
+      "get_accessor": "registry.get_ui_button"
+    }
+  ]
+}

--- a/modules.json
+++ b/modules.json
@@ -1,0 +1,40 @@
+{
+  "_generated_by": "OctarineLuaApiTest via LuaApiManifest::WriteModulesJson",
+  "modules": [
+    {
+      "name": "Log",
+      "binding_header": "src/Lua/Modules/LogModuleLuaBinding.h",
+      "globals": ["log", "log_e", "log_i", "log_w"]
+    },
+    {
+      "name": "Io",
+      "binding_header": "src/Lua/Modules/IoModuleLuaBinding.h",
+      "globals": ["read_file_lines"]
+    },
+    {
+      "name": "Assets",
+      "binding_header": "src/Lua/Modules/AssetsModuleLuaBinding.h",
+      "globals": ["get_asset_path"]
+    },
+    {
+      "name": "Audio",
+      "binding_header": "src/Lua/Modules/AudioModuleLuaBinding.h",
+      "globals": ["play_sound"]
+    },
+    {
+      "name": "Entity",
+      "binding_header": "src/Lua/Modules/EntityModuleLuaBinding.h",
+      "globals": ["blam", "find_entity_by_name", "get_name", "get_position", "registry", "set_name", "set_position", "set_sprite_src_rect"]
+    },
+    {
+      "name": "Scene",
+      "binding_header": "src/Lua/Modules/SceneModuleLuaBinding.h",
+      "globals": ["acquire_scene_assets", "clear_scene", "load_asset", "load_entity", "load_scene", "reload_scene", "stop_scene"]
+    },
+    {
+      "name": "Game",
+      "binding_header": "src/Lua/Modules/GameModuleLuaBinding.h",
+      "globals": ["fire_projectile", "get_camera_position", "get_game_map_dimensions", "quit_game", "set_game_map_dimensions"]
+    }
+  ]
+}

--- a/src/Lua/LuaApiManifest.cpp
+++ b/src/Lua/LuaApiManifest.cpp
@@ -1,12 +1,15 @@
 #include "Lua/LuaApiManifest.h"
 
 #include <algorithm>
+#include <cstdio>
 #include <cstdlib>
 #include <fstream>
 #include <utility>
 #include <vector>
 
 #include "General/Logger.h"
+#include "Lua/Bindings/LuaComponentRegistry.h"
+#include "Lua/Modules/LuaModuleRegistry.h"
 
 namespace
 {
@@ -172,5 +175,117 @@ namespace LuaApiManifest
 #endif
         const std::string outPath = (value == "1") ? "lua_api.lua" : value;
         return Write(lua, before, outPath);
+    }
+
+    namespace
+    {
+        // Minimal JSON string escaping. Component/module identifiers and global names are plain
+        // ASCII Lua keys so this only ever needs to deal with the standard control chars; spelling
+        // out a few cases beats pulling in a JSON dep just for this manifest.
+        void WriteJsonString(std::ofstream& out, const std::string& s)
+        {
+            out << '"';
+            for (const char c : s)
+            {
+                switch (c)
+                {
+                    case '"': out << "\\\""; break;
+                    case '\\': out << "\\\\"; break;
+                    case '\n': out << "\\n"; break;
+                    case '\r': out << "\\r"; break;
+                    case '\t': out << "\\t"; break;
+                    default:
+                        if (static_cast<unsigned char>(c) < 0x20)
+                        {
+                            char buf[8];
+                            std::snprintf(buf, sizeof(buf), "\\u%04x", c);
+                            out << buf;
+                        }
+                        else
+                        {
+                            out << c;
+                        }
+                }
+            }
+            out << '"';
+        }
+    } // namespace
+
+    bool WriteComponentsJson(const std::string& outPath)
+    {
+        std::ofstream out(outPath);
+        if (!out.is_open())
+        {
+            Logger::Error("LuaApiManifest: could not open '" + outPath + "' for writing.");
+            return false;
+        }
+
+        // Snapshot entries and sort by lua_key for stable output.
+        auto entries = LuaComponentRegistry::all();
+        std::sort(entries.begin(), entries.end(),
+                  [](const auto& a, const auto& b) { return a.luaKey < b.luaKey; });
+
+        out << "{\n  \"_generated_by\": \"OctarineLuaApiTest via LuaApiManifest::WriteComponentsJson\",\n";
+        out << "  \"components\": [\n";
+        for (std::size_t i = 0; i < entries.size(); ++i)
+        {
+            const auto& e = entries[i];
+            out << "    {\n      \"lua_key\": ";
+            WriteJsonString(out, e.luaKey);
+            out << ",\n      \"usertype\": ";
+            WriteJsonString(out, e.usertypeName);
+            out << ",\n      \"has_accessor\": ";
+            WriteJsonString(out, "registry.has_" + e.luaKey);
+            out << ",\n      \"get_accessor\": ";
+            WriteJsonString(out, "registry.get_" + e.luaKey);
+            out << "\n    }";
+            if (i + 1 < entries.size()) out << ",";
+            out << "\n";
+        }
+        out << "  ]\n}\n";
+
+        Logger::Info("LuaApiManifest: wrote " + std::to_string(entries.size()) + " components to " + outPath);
+        return true;
+    }
+
+    bool WriteModulesJson(const std::string& outPath)
+    {
+        std::ofstream out(outPath);
+        if (!out.is_open())
+        {
+            Logger::Error("LuaApiManifest: could not open '" + outPath + "' for writing.");
+            return false;
+        }
+
+        // Preserve install order — that order matters for setup-ordering gotchas, so capturing it
+        // makes modules.json useful when diagnosing "what installed before what."
+        const auto& modules = LuaModuleRegistry::all();
+
+        out << "{\n  \"_generated_by\": \"OctarineLuaApiTest via LuaApiManifest::WriteModulesJson\",\n";
+        out << "  \"modules\": [\n";
+        for (std::size_t i = 0; i < modules.size(); ++i)
+        {
+            const auto& m = modules[i];
+            out << "    {\n      \"name\": ";
+            WriteJsonString(out, m.name);
+            out << ",\n      \"binding_header\": ";
+            WriteJsonString(out, "src/Lua/Modules/" + m.name + "ModuleLuaBinding.h");
+            out << ",\n      \"globals\": [";
+            // Sort globals within a module for stable output (module order is install order; globals within are unordered).
+            std::vector<std::string> globals = m.globals;
+            std::sort(globals.begin(), globals.end());
+            for (std::size_t g = 0; g < globals.size(); ++g)
+            {
+                if (g > 0) out << ", ";
+                WriteJsonString(out, globals[g]);
+            }
+            out << "]\n    }";
+            if (i + 1 < modules.size()) out << ",";
+            out << "\n";
+        }
+        out << "  ]\n}\n";
+
+        Logger::Info("LuaApiManifest: wrote " + std::to_string(modules.size()) + " modules to " + outPath);
+        return true;
     }
 } // namespace LuaApiManifest

--- a/src/Lua/LuaApiManifest.h
+++ b/src/Lua/LuaApiManifest.h
@@ -24,4 +24,14 @@ namespace LuaApiManifest
     // Value is the output path; the literal "1" maps to "lua_api.lua" in the working directory.
     // No-op (returns false) when the var is unset. Called from Game::Setup.
     bool MaybeDumpFromEnv(sol::state& lua, const std::unordered_set<std::string>& before);
+
+    // Emit a machine-readable JSON index of every component registered with LuaComponentRegistry:
+    // lua_key, usertype name, and accessor function names exposed on the `registry` table. Agents
+    // grep this instead of crawling src/Lua/Bindings/. Returns false if the file cannot be opened.
+    bool WriteComponentsJson(const std::string& outPath);
+
+    // Emit a machine-readable JSON index of every Lua free-function module registered with
+    // LuaModuleRegistry: module name + the globals it installed into sol::state. Returns false
+    // if the file cannot be opened.
+    bool WriteModulesJson(const std::string& outPath);
 } // namespace LuaApiManifest

--- a/src/Lua/Modules/LuaModuleRegistry.h
+++ b/src/Lua/Modules/LuaModuleRegistry.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+// Per-module record of the free-function globals a Lua module installs into the sol::state.
+// Populated by OctarineLuaApiTest by snapshotting globals around each module's install call.
+// LuaApiManifest::WriteModulesJson consumes it to emit modules.json — the machine-readable index
+// agents grep for "what Lua globals does each module own."
+class LuaModuleRegistry
+{
+public:
+    struct Entry
+    {
+        std::string name;
+        std::vector<std::string> globals;
+    };
+
+    static void registerModule(std::string name, std::vector<std::string> globals)
+    {
+        entries().push_back({std::move(name), std::move(globals)});
+    }
+
+    static const std::vector<Entry>& all() { return entries(); }
+
+    static void clear() { entries().clear(); }
+
+private:
+    static std::vector<Entry>& entries()
+    {
+        static std::vector<Entry> instance;
+        return instance;
+    }
+};

--- a/src/Lua/Modules/RegisterAllModules.cpp
+++ b/src/Lua/Modules/RegisterAllModules.cpp
@@ -9,13 +9,17 @@
 #include "Lua/Modules/LuaModule.h"
 #include "Lua/Modules/SceneModuleLuaBinding.h"
 
+const std::vector<LuaModuleDescriptor> kLuaModules = {
+    {"Log",    &LuaModuleBinding<LogModule>::install},
+    {"Io",     &LuaModuleBinding<IoModule>::install},
+    {"Assets", &LuaModuleBinding<AssetsModule>::install},
+    {"Audio",  &LuaModuleBinding<AudioModule>::install},
+    {"Entity", &LuaModuleBinding<EntityModule>::install},
+    {"Scene",  &LuaModuleBinding<SceneModule>::install},
+    {"Game",   &LuaModuleBinding<GameModule>::install},
+};
+
 void RegisterAllLuaModules(sol::state& lua, Game& game)
 {
-    LuaModuleBinding<LogModule>::install(lua, game);
-    LuaModuleBinding<IoModule>::install(lua, game);
-    LuaModuleBinding<AssetsModule>::install(lua, game);
-    LuaModuleBinding<AudioModule>::install(lua, game);
-    LuaModuleBinding<EntityModule>::install(lua, game);
-    LuaModuleBinding<SceneModule>::install(lua, game);
-    LuaModuleBinding<GameModule>::install(lua, game);
+    for (const auto& m : kLuaModules) m.install(lua, game);
 }

--- a/src/Lua/Modules/RegisterAllModules.h
+++ b/src/Lua/Modules/RegisterAllModules.h
@@ -2,6 +2,20 @@
 
 #include <sol/sol.hpp>
 
+#include <vector>
+
 class Game;
+
+// Descriptor for a single Lua free-function module. The install function pointer matches
+// LuaModuleBinding<M>::install (sol::state&, Game&); the name is used by the modules.json index.
+struct LuaModuleDescriptor
+{
+    const char* name;
+    void (*install)(sol::state&, Game&);
+};
+
+// Authoritative install order. RegisterAllLuaModules iterates this; OctarineLuaApiTest iterates
+// the same list with per-module snapshots to discover which globals each module installs.
+extern const std::vector<LuaModuleDescriptor> kLuaModules;
 
 void RegisterAllLuaModules(sol::state& lua, Game& game);

--- a/tests/LuaApiSmokeTest.cpp
+++ b/tests/LuaApiSmokeTest.cpp
@@ -26,6 +26,7 @@
 #include "Lua/Bindings/LuaSystemRegistry.h"
 #include "Lua/Bindings/RegisterAllBindings.h"
 #include "Lua/LuaApiManifest.h"
+#include "Lua/Modules/LuaModuleRegistry.h"
 #include "Lua/Modules/RegisterAllModules.h"
 #include "Systems/InputSystem.h"
 #include "Systems/ScriptSystem.h"
@@ -79,7 +80,21 @@ int main()
     ScriptSystem scriptSystem;
     scriptSystem.CreateLuaBindings(lua); // primitives + component usertypes
 
-    RegisterAllLuaModules(lua, game); // free-function globals + the `registry` accessor table
+    // Install modules one at a time, snapshotting globals around each call so LuaModuleRegistry
+    // ends up with an exact "what globals did each module install" record — fed to modules.json.
+    LuaModuleRegistry::clear();
+    for (const auto& m : kLuaModules)
+    {
+        const auto before = LuaApiManifest::SnapshotGlobals(lua);
+        m.install(lua, game);
+        const auto after = LuaApiManifest::SnapshotGlobals(lua);
+        std::vector<std::string> added;
+        for (const auto& name : after)
+        {
+            if (before.find(name) == before.end()) added.push_back(name);
+        }
+        LuaModuleRegistry::registerModule(m.name, std::move(added));
+    }
 
     InputSystem inputSystem;
     LuaSystemRegistry::clear();
@@ -122,15 +137,13 @@ int main()
     }
 #endif
 
-    std::cout << "[modules] one sentinel global per module\n";
-    // If a module is dropped from RegisterAllModules.cpp, its sentinel disappears and this fails.
-    const std::vector<std::pair<std::string, std::string>> moduleSentinels = {
-        {"Log", "log"},     {"Io", "read_file_lines"}, {"Assets", "get_asset_path"}, {"Audio", "play_sound"},
-        {"Entity", "blam"}, {"Scene", "load_scene"},   {"Game", "fire_projectile"},
-    };
-    for (const auto& [module, global] : moduleSentinels)
+    std::cout << "[modules] each module installs at least one global\n";
+    // If a module's install body becomes empty (or was removed), its captured global list is empty
+    // and this fails. Catches "dropped from RegisterAllModules.cpp" without naming sentinels by hand.
+    Check(!LuaModuleRegistry::all().empty(), "module registry is non-empty");
+    for (const auto& m : LuaModuleRegistry::all())
     {
-        Check(IsFunction(lua, global), module + "Module installed (" + global + ")");
+        Check(!m.globals.empty(), m.name + "Module installed at least one global");
     }
 
     std::cout << "[primitives + systems]\n";
@@ -146,6 +159,13 @@ int main()
     const std::string smokeOutPath = "lua_api.smoke.lua";
 #endif
     Check(LuaApiManifest::Write(lua, preBinding, smokeOutPath), "manifest written");
+
+#ifdef LUA_API_COMPONENTS_OUTPUT
+    Check(LuaApiManifest::WriteComponentsJson(LUA_API_COMPONENTS_OUTPUT), "components.json written");
+#endif
+#ifdef LUA_API_MODULES_OUTPUT
+    Check(LuaApiManifest::WriteModulesJson(LUA_API_MODULES_OUTPUT), "modules.json written");
+#endif
 
     if (g_failures == 0)
     {


### PR DESCRIPTION
## Summary

Implements survey items **A2** and **A4**. Adds two machine-readable indexes alongside the existing `lua_api.smoke.lua`:

- **`components.json`** — every component registered with `LuaComponentRegistry`: `lua_key`, `usertype`, and the `registry.has_<key>` / `registry.get_<key>` accessor names. Agents grep this instead of crawling `src/Lua/Bindings/`.
- **`modules.json`** — every Lua free-function module registered with the new `LuaModuleRegistry`: module name, predicted binding-header path, and the list of globals that module installed into the live `sol::state`. Module install order is preserved (it matters for setup-ordering gotchas).

To populate `modules.json` without a hand-maintained name list, `src/Lua/Modules/RegisterAllModules.cpp` now exposes `kLuaModules` — a descriptor array of `{name, install}` pairs that captures the canonical install order in one place. `RegisterAllLuaModules` iterates it for production setup; `OctarineLuaApiTest` iterates the same list with per-module global snapshots to fill `LuaModuleRegistry`.

The previously hand-maintained `moduleSentinels` list in the test is gone in favor of asserting that each module installed at least one new global. Catches "module dropped from `kLuaModules`" without naming sentinels by hand.

CI drift gate (linux + editor-release leg) now diffs all three artifacts (`lua_api.smoke.lua`, `components.json`, `modules.json`); drift on any one fails the build and uploads the regenerated copies as an artifact for inspection.

## Test plan

- [x] Linux + editor-release ctest passes (`LuaApiSmokeTest` + `AssetPipelineTest`)
- [x] All three artifacts drift-checked on a fresh CI run ([run 26693010901](https://github.com/mblackman/Octarine-Engine/actions/runs/26693010901))
- [x] All 6 matrix legs green
- [ ] Intentional break test (post-merge): drop a `registerComponent<>()` or delete a `kLuaModules` entry, confirm the corresponding JSON drifts and CI fails
