### PR TITLE
Add in-app Android Acknowledgements activity for third-party licenses

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -59,14 +59,10 @@
     <uses-permission android:name="android.permission.INTERNET" />
     -->
 
-    <!-- Create a Java class extending SDLActivity and place it in a
-         directory under app/src/main/java matching the package, e.g. app/src/main/java/com/gamemaker/game/MyGame.java
-
-         then replace "SDLActivity" with the name of your class (e.g. "MyGame")
-         in the XML below.
-
-         An example Java class can be found in README-android.md
-    -->
+    <!-- com.octarine.host.MainActivity is a thin subclass of org.libsdl.app.SDLActivity that
+         adds the Acknowledgements options-menu entry (see java/com/octarine/host/MainActivity.java
+         and LicensesActivity.java). Downstream projects can drop their own subclass in alongside
+         and swap the activity name below. -->
     <!-- Theme + orientation come from project.ini via manifestPlaceholders (see
          android/app/build.gradle): `appTheme` defaults to AppTheme (fullscreen) and switches to
          AppTheme.Windowed when project.ini sets fullscreen=false; `screenOrientation` defaults to
@@ -82,7 +78,7 @@
         <meta-data android:name="SDL_ENV.SDL_ANDROID_TRAP_BACK_BUTTON" android:value="0"/>
          -->
 
-        <activity android:name="SDLActivity"
+        <activity android:name="com.octarine.host.MainActivity"
             android:label="@string/app_name"
             android:alwaysRetainTaskState="true"
             android:launchMode="singleInstance"
@@ -108,6 +104,15 @@
             </intent-filter>
             -->
         </activity>
+
+        <!-- In-app license viewer. Renders the bundled THIRD_PARTY_LICENSES.txt asset.
+             exported=false: launched only via MainActivity's options menu (Acknowledgements
+             entry), never from outside the app. Uses Theme.Material.Light for a normal
+             title-bar-and-back-arrow UI instead of inheriting the fullscreen game theme. -->
+        <activity android:name="com.octarine.host.LicensesActivity"
+            android:label="Acknowledgements"
+            android:exported="false"
+            android:theme="@android:style/Theme.Material.Light" />
     </application>
 
 </manifest>

--- a/android/app/src/main/java/com/octarine/host/LicensesActivity.java
+++ b/android/app/src/main/java/com/octarine/host/LicensesActivity.java
@@ -1,0 +1,58 @@
+package com.octarine.host;
+
+import android.app.Activity;
+import android.graphics.Typeface;
+import android.os.Bundle;
+import android.view.ViewGroup;
+import android.widget.ScrollView;
+import android.widget.TextView;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+
+// Renders THIRD_PARTY_LICENSES.txt (bundled under the APK's assets/ by app/build.gradle's
+// licenseAssetsDir wiring) inside a scrollable, selectable TextView. No layout XML — building
+// the view tree programmatically keeps this self-contained and avoids a new res/layout file.
+public class LicensesActivity extends Activity {
+    private static final String LICENSES_ASSET = "THIRD_PARTY_LICENSES.txt";
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setTitle("Acknowledgements");
+
+        TextView text = new TextView(this);
+        text.setTextIsSelectable(true);
+        text.setTypeface(Typeface.MONOSPACE);
+        int pad = (int) (16 * getResources().getDisplayMetrics().density);
+        text.setPadding(pad, pad, pad, pad);
+        text.setText(loadAsset());
+
+        ScrollView scroll = new ScrollView(this);
+        scroll.addView(text, new ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT));
+
+        setContentView(scroll, new ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT));
+    }
+
+    private CharSequence loadAsset() {
+        StringBuilder out = new StringBuilder();
+        try (InputStream in = getAssets().open(LICENSES_ASSET);
+             BufferedReader r = new BufferedReader(
+                     new InputStreamReader(in, StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = r.readLine()) != null) {
+                out.append(line).append('\n');
+            }
+        } catch (IOException e) {
+            return "Failed to load " + LICENSES_ASSET + ": " + e.getMessage();
+        }
+        return out;
+    }
+}

--- a/android/app/src/main/java/com/octarine/host/MainActivity.java
+++ b/android/app/src/main/java/com/octarine/host/MainActivity.java
@@ -1,0 +1,31 @@
+package com.octarine.host;
+
+import android.content.Intent;
+import android.view.Menu;
+import android.view.MenuItem;
+
+import org.libsdl.app.SDLActivity;
+
+// Thin host activity. Inherits all SDL lifecycle / surface / input handling from SDLActivity;
+// the only thing it adds is an Acknowledgements entry on the platform options menu that hands
+// off to LicensesActivity. Keeping this as a subclass (not a fork) lets us track upstream SDL
+// without merge churn.
+public class MainActivity extends SDLActivity {
+    private static final int MENU_LICENSES = 1;
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        super.onCreateOptionsMenu(menu);
+        menu.add(Menu.NONE, MENU_LICENSES, Menu.NONE, "Acknowledgements");
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (item.getItemId() == MENU_LICENSES) {
+            startActivity(new Intent(this, LicensesActivity.class));
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+}


### PR DESCRIPTION
## Summary
- New `com.octarine.host.MainActivity` (Java) — thin `SDLActivity` subclass that adds an "Acknowledgements" entry to the options menu and launches `LicensesActivity` on selection.
- New `com.octarine.host.LicensesActivity` — reads bundled `THIRD_PARTY_LICENSES.txt` from `getAssets()`, renders into a selectable monospace `TextView` inside a `ScrollView`. Uses `Theme.Material.Light` for normal title-bar UX.
- `AndroidManifest.xml` now launches `com.octarine.host.MainActivity` instead of bare `SDLActivity`; new `<activity>` entry registers `LicensesActivity` (`exported=false`).
- Closes Stage 8 of `ai/ShippingV1Plan.md`. The legal text already shipped under `base/assets/` — this gives users a way to read it without cracking the AAB.

## Deferred (out of scope per plan)
- Lua-side `game.open_acknowledgements()` module function — would let game scripts surface the screen from their own settings UI. Today the activity is reachable via `openOptionsMenu()` / `KEYCODE_MENU`. Followup if Lua surface justifies the JNI plumbing.

## R8 / keep-rules
Both new activities are referenced by `AndroidManifest.xml` `android:name=` — R8 default rules auto-keep manifest-referenced classes. Existing `-keep` on `org.libsdl.app.SDLActivity` continues to cover the parent class.

## Test plan
- [ ] `android.yml` AAB build green
- [ ] `android-emulator.yml` boot/launch smoke green
- [ ] Manually open menu on a built APK → "Acknowledgements" → scroll through FreeType + SDL3 + ImGui + spdlog + lua + sol2 + glm text
- [ ] `aapt2 dump xmltree app-release.aab base/AndroidManifest.xml` shows both `MainActivity` and `LicensesActivity` entries, only `MainActivity` has the `LAUNCHER` intent filter
- [ ] Inspect AAB: exactly one `base/assets/THIRD_PARTY_LICENSES.txt`