### PR TITLE
Add C++ project.ini reader for editor surfaces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,7 @@ set(SRC_FILES
         src/Lua/Modules/IoModuleLuaBinding.cpp
         src/Lua/Modules/LogModuleLuaBinding.cpp
         src/Lua/Modules/SceneModuleLuaBinding.cpp
+        src/Project/ProjectIni.cpp
         src/Renderer/Renderer.cpp
         src/Systems/AudioSystem.cpp
 )
@@ -512,6 +513,29 @@ if (OCTARINE_ENABLE_TESTS)
     endif ()
 
     add_test(NAME AssetPipelineTest COMMAND OctarineAssetPipelineTest)
+
+    # project.ini reader smoke test: standalone — no engine sources required. Validates parse +
+    # shipping-identity rules (mirrors cmake/OctarinePackage.cmake + android/app/build.gradle).
+    add_executable(OctarineProjectIniTest
+            src/Project/ProjectIni.cpp
+            tests/ProjectIniTest.cpp
+    )
+
+    set_target_properties(OctarineProjectIniTest PROPERTIES
+            CXX_STANDARD 20
+            CXX_STANDARD_REQUIRED ON
+            CXX_EXTENSIONS OFF
+    )
+
+    target_include_directories(OctarineProjectIniTest PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/src
+    )
+
+    if (MSVC)
+        target_compile_options(OctarineProjectIniTest PRIVATE /W4 /permissive- /MP /EHsc)
+    endif ()
+
+    add_test(NAME ProjectIniTest COMMAND OctarineProjectIniTest)
 
     message(STATUS "Octarine: Tests ENABLED")
 endif ()

--- a/src/Project/ProjectIni.cpp
+++ b/src/Project/ProjectIni.cpp
@@ -1,0 +1,148 @@
+#include "Project/ProjectIni.h"
+
+#include <cctype>
+#include <fstream>
+#include <regex>
+#include <sstream>
+
+namespace octarine::project
+{
+    namespace
+    {
+        // Mirrors the CMake regex in cmake/OctarinePackage.cmake and the Gradle check in
+        // android/app/build.gradle. Lowercase reverse-DNS, segments separated by '.'.
+        const std::regex& PackageIdRegex()
+        {
+            static const std::regex re(R"(^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)+$)");
+            return re;
+        }
+
+        std::string_view Trim(std::string_view s)
+        {
+            const auto is_ws = [](char c) { return c == ' ' || c == '\t' || c == '\r'; };
+            while (!s.empty() && is_ws(s.front()))
+            {
+                s.remove_prefix(1);
+            }
+            while (!s.empty() && is_ws(s.back()))
+            {
+                s.remove_suffix(1);
+            }
+            return s;
+        }
+
+        void Assign(ProjectIni& ini, const std::string& key, std::string value)
+        {
+            if (key == "name") ini.name = value;
+            else if (key == "package_id") ini.package_id = value;
+            else if (key == "version_name") ini.version_name = value;
+            else if (key == "version_code") ini.version_code = value;
+            else if (key == "vendor") ini.vendor = value;
+            else if (key == "description") ini.description = value;
+            else if (key == "orientation") ini.orientation = value;
+            else if (key == "fullscreen") ini.fullscreen = value;
+            else if (key == "permissions") ini.permissions = value;
+            else if (key == "category") ini.category = value;
+            else if (key == "icon") ini.icon = value;
+            ini.all[key] = std::move(value);
+        }
+    } // namespace
+
+    ProjectIni ProjectIni::Parse(std::string_view text, std::vector<std::string>* parse_warnings)
+    {
+        ProjectIni ini;
+        std::string line;
+        size_t pos = 0;
+        size_t line_no = 0;
+        while (pos <= text.size())
+        {
+            const size_t nl = text.find('\n', pos);
+            const size_t end = (nl == std::string_view::npos) ? text.size() : nl;
+            line.assign(text.data() + pos, end - pos);
+            pos = end + 1;
+            ++line_no;
+
+            std::string_view trimmed = Trim(line);
+            if (trimmed.empty() || trimmed.front() == '#')
+            {
+                if (nl == std::string_view::npos) break;
+                continue;
+            }
+
+            const auto eq = trimmed.find('=');
+            if (eq == std::string_view::npos)
+            {
+                if (parse_warnings)
+                {
+                    std::ostringstream w;
+                    w << "line " << line_no << ": malformed (no '='): " << trimmed;
+                    parse_warnings->push_back(w.str());
+                }
+                if (nl == std::string_view::npos) break;
+                continue;
+            }
+
+            std::string_view key_sv = Trim(trimmed.substr(0, eq));
+            std::string_view val_sv = Trim(trimmed.substr(eq + 1));
+
+            if (key_sv.empty())
+            {
+                if (parse_warnings)
+                {
+                    std::ostringstream w;
+                    w << "line " << line_no << ": empty key";
+                    parse_warnings->push_back(w.str());
+                }
+                if (nl == std::string_view::npos) break;
+                continue;
+            }
+
+            Assign(ini, std::string(key_sv), std::string(val_sv));
+
+            if (nl == std::string_view::npos) break;
+        }
+        return ini;
+    }
+
+    std::optional<ProjectIni> ProjectIni::Load(const std::filesystem::path& project_dir)
+    {
+        const std::filesystem::path path = project_dir / "project.ini";
+        std::error_code ec;
+        if (!std::filesystem::exists(path, ec))
+        {
+            return std::nullopt;
+        }
+        std::ifstream f(path, std::ios::binary);
+        if (!f)
+        {
+            return std::nullopt;
+        }
+        std::ostringstream ss;
+        ss << f.rdbuf();
+        ProjectIni ini = Parse(ss.str());
+        ini.source_path = path;
+        return ini;
+    }
+
+    std::vector<std::string> ProjectIni::ValidateForShipping() const
+    {
+        std::vector<std::string> errors;
+        if (name.empty())
+        {
+            errors.emplace_back("missing required key: name");
+        }
+        if (version_name.empty())
+        {
+            errors.emplace_back("missing required key: version_name");
+        }
+        if (package_id.empty())
+        {
+            errors.emplace_back("missing required key: package_id (Android bundle id)");
+        }
+        else if (!std::regex_match(package_id, PackageIdRegex()))
+        {
+            errors.push_back("package_id '" + package_id + "' must be reverse-DNS (e.g. com.studio.mygame)");
+        }
+        return errors;
+    }
+} // namespace octarine::project

--- a/src/Project/ProjectIni.h
+++ b/src/Project/ProjectIni.h
@@ -1,0 +1,58 @@
+#pragma once
+
+// C++ reader for the game project's `project.ini` — third corner alongside the CMake parser
+// (`cmake/OctarinePackage.cmake :: octarine_read_project_ini`) and the Gradle parser
+// (`android/app/build.gradle :: java.util.Properties`). Used by the editor to surface project
+// identity in panels and to validate before Export Build spawns a packaging script.
+//
+// Schema matches the other two parsers; validation mirrors the shipping-build identity rules
+// (required: name, version_name, package_id; package_id must be reverse-DNS).
+
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace octarine::project
+{
+    struct ProjectIni
+    {
+        // Required for shipping builds.
+        std::string name;
+        std::string package_id;
+        std::string version_name;
+
+        // Optional identity / packaging knobs.
+        std::string version_code;
+        std::string vendor;
+        std::string description;
+        std::string orientation;
+        std::string fullscreen;
+        std::string permissions;
+        std::string category;
+        std::string icon;
+
+        // Every parsed key (including the named ones above), preserved verbatim so callers can
+        // read keys the editor doesn't know about yet.
+        std::unordered_map<std::string, std::string> all;
+
+        // Source path the file was loaded from (empty for in-memory parses).
+        std::filesystem::path source_path;
+
+        // Loads + parses `<dir>/project.ini`. Returns nullopt if the file doesn't exist; an empty
+        // ProjectIni if the file exists but is empty.
+        static std::optional<ProjectIni> Load(const std::filesystem::path& project_dir);
+
+        // Parses raw INI text. Malformed lines produce an entry in `parse_warnings`. Comments
+        // (`#`) and blank lines are skipped.
+        static ProjectIni Parse(std::string_view text, std::vector<std::string>* parse_warnings = nullptr);
+
+        // Validates identity for a shipping build (mirrors the CMake/Gradle policy):
+        //   - name, version_name, package_id must be non-empty
+        //   - package_id must match `^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)+$`
+        // Returns the list of error messages; empty = valid. Caller decides whether to surface
+        // the errors as a warning (dev build) or a fatal (shipping/export build).
+        std::vector<std::string> ValidateForShipping() const;
+    };
+} // namespace octarine::project

--- a/tests/ProjectIniTest.cpp
+++ b/tests/ProjectIniTest.cpp
@@ -1,0 +1,125 @@
+// Unit checks for the project.ini reader. gtest-free; exit code = failed-check count.
+// Registered with ctest as ProjectIniTest. Mirrors the parsing tolerance + shipping-validation
+// rules of cmake/OctarinePackage.cmake and android/app/build.gradle.
+
+#include "Project/ProjectIni.h"
+
+#include <algorithm>
+#include <iostream>
+#include <string>
+
+using octarine::project::ProjectIni;
+
+namespace
+{
+    int g_failures = 0;
+
+    void Check(const bool cond, const std::string& what)
+    {
+        if (cond)
+        {
+            std::cout << "  ok   " << what << "\n";
+        }
+        else
+        {
+            std::cerr << "  FAIL " << what << "\n";
+            ++g_failures;
+        }
+    }
+
+    bool Contains(const std::vector<std::string>& v, const std::string& needle)
+    {
+        return std::any_of(v.begin(), v.end(),
+                           [&](const std::string& s) { return s.find(needle) != std::string::npos; });
+    }
+} // namespace
+
+int main()
+{
+    // Happy path: every known key parses + lands on the matching field.
+    {
+        const std::string body =
+            "# top comment\n"
+            "name = Octarine Example\n"
+            "package_id = com.octarine.example\n"
+            "version_name = 1.2.3\n"
+            "version_code = 42\n"
+            "vendor=Mateo\n"
+            "description = A small example\n"
+            "orientation = landscape\n"
+            "fullscreen = true\n"
+            "permissions = internet,recording\n"
+            "category = game\n"
+            "icon = assets/icon.png\n"
+            "\n"
+            "# trailing comment\n";
+
+        std::vector<std::string> warns;
+        const ProjectIni ini = ProjectIni::Parse(body, &warns);
+        Check(warns.empty(), "no parse warnings on well-formed file");
+        Check(ini.name == "Octarine Example", "name parsed");
+        Check(ini.package_id == "com.octarine.example", "package_id parsed");
+        Check(ini.version_name == "1.2.3", "version_name parsed");
+        Check(ini.version_code == "42", "version_code parsed");
+        Check(ini.vendor == "Mateo", "vendor parsed (no spaces around =)");
+        Check(ini.description == "A small example", "description parsed");
+        Check(ini.orientation == "landscape", "orientation parsed");
+        Check(ini.fullscreen == "true", "fullscreen parsed");
+        Check(ini.permissions == "internet,recording", "permissions parsed");
+        Check(ini.category == "game", "category parsed");
+        Check(ini.icon == "assets/icon.png", "icon parsed");
+
+        Check(ini.ValidateForShipping().empty(), "valid project passes ValidateForShipping");
+    }
+
+    // Unknown keys preserved in `all` map but don't fall on a typed field.
+    {
+        const ProjectIni ini = ProjectIni::Parse("future_key = experimental\nname = X\n");
+        auto it = ini.all.find("future_key");
+        Check(it != ini.all.end() && it->second == "experimental", "unknown keys retained in `all`");
+    }
+
+    // Malformed line surfaces in warnings but doesn't break the parse.
+    {
+        std::vector<std::string> warns;
+        const ProjectIni ini = ProjectIni::Parse("not an assignment\nname = OK\n", &warns);
+        Check(ini.name == "OK", "subsequent lines parse after a malformed line");
+        Check(!warns.empty() && Contains(warns, "malformed"), "malformed line surfaces in warnings");
+    }
+
+    // Validation: missing required keys.
+    {
+        const ProjectIni ini;
+        const auto errs = ini.ValidateForShipping();
+        Check(Contains(errs, "name"), "missing name reported");
+        Check(Contains(errs, "version_name"), "missing version_name reported");
+        Check(Contains(errs, "package_id"), "missing package_id reported");
+    }
+
+    // Validation: package_id must be reverse-DNS.
+    {
+        ProjectIni ini;
+        ini.name = "X";
+        ini.version_name = "1.0";
+        ini.package_id = "not-a-valid-id";
+        const auto errs = ini.ValidateForShipping();
+        Check(Contains(errs, "reverse-DNS"), "non-reverse-DNS package_id rejected");
+    }
+    {
+        ProjectIni ini;
+        ini.name = "X";
+        ini.version_name = "1.0";
+        ini.package_id = "com.studio.MyGame"; // uppercase rejected by the CMake/Gradle regex too
+        const auto errs = ini.ValidateForShipping();
+        Check(!errs.empty(), "uppercase in package_id rejected (matches CMake/Gradle regex)");
+    }
+    {
+        ProjectIni ini;
+        ini.name = "X";
+        ini.version_name = "1.0";
+        ini.package_id = "com.studio.mygame";
+        Check(ini.ValidateForShipping().empty(), "valid reverse-DNS package_id accepted");
+    }
+
+    return g_failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- New `src/Project/ProjectIni.{h,cpp}`: third corner alongside the CMake parser (`octarine_read_project_ini`) and the Gradle parser (`java.util.Properties` in `android/app/build.gradle`). Same flat `key=value` schema; same shipping-build identity validation rules (required `name`/`version_name`/`package_id` with reverse-DNS regex on `package_id`).
- Stage 2 of `ai/EditorBuildAndDeployPlan.md`. Editor uses it to surface project identity in panels and to fail fast before Export Build spawns a packaging script.
- Standalone `OctarineProjectIniTest` registered with ctest covers parsing tolerance (comments, malformed lines, unknown keys preserved) and validation positives + negatives.

## Test plan
- [x] Local: `cmake --preset editor-debug -DOCTARINE_ENABLE_TESTS=ON`, build, `ctest -R ProjectIniTest` → green.
- [x] Local: full `OctarineEngine` target still builds with `ProjectIni.cpp` added to `SRC_FILES`.
- [ ] CI: build + ctest legs pass on the Linux editor-release runner.