### PR TITLE
Add octarine-new scaffolder for bash and PowerShell

### DIFF
--- a/scripts/octarine-new.ps1
+++ b/scripts/octarine-new.ps1
@@ -1,0 +1,125 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Scaffold a new Octarine project (project.ini + config.ini + game.lua + asset dirs).
+
+.DESCRIPTION
+    Mirrors scripts/octarine-new.sh. Drop-in for Windows-native dev environments where
+    bash isn't on PATH. Produces a directory the engine can run directly
+    (OctarineEngine <dir>) and that 'cmake --preset ship-release' can package.
+
+.EXAMPLE
+    .\scripts\octarine-new.ps1 -Name "My Game" -PackageId com.studio.mygame -Dir C:\src\mygame
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$Name,
+    [Parameter(Mandatory = $true)][string]$PackageId,
+    [Parameter(Mandatory = $true)][string]$Dir,
+    [string]$VersionName = "0.1.0",
+    [int]$VersionCode = 1
+)
+
+$ErrorActionPreference = "Stop"
+
+if ($PackageId -notmatch '^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)+$') {
+    throw "-PackageId must be reverse-DNS (e.g. com.studio.mygame): got '$PackageId'"
+}
+
+if (Test-Path $Dir) {
+    $item = Get-Item -LiteralPath $Dir
+    if (-not $item.PSIsContainer) {
+        throw "-Dir exists and is a file, not a directory: $Dir"
+    }
+    if ((Get-ChildItem -LiteralPath $Dir -Force | Measure-Object).Count -gt 0) {
+        throw "-Dir already exists and is not empty: $Dir"
+    }
+} else {
+    New-Item -ItemType Directory -Path $Dir | Out-Null
+}
+
+New-Item -ItemType Directory -Force -Path (Join-Path $Dir "assets") | Out-Null
+New-Item -ItemType Directory -Force -Path (Join-Path $Dir "THIRD_PARTY_LICENSES.d") | Out-Null
+
+$projectIni = @"
+# Game identity for packaging. Read by desktop CPack, Android Gradle, iOS Info.plist (later).
+# Single source of truth across every platform. Flat key=value, no sections.
+
+name         = $Name
+package_id   = $PackageId
+version_name = $VersionName
+version_code = $VersionCode
+"@
+
+$configIni = @"
+# Engine runtime config. Loaded at startup before game.lua.
+Title=$Name
+LogLevel=info
+StartupScript=game.lua
+DefaultScalingMode=nearest
+DefaultWindowWidth=1280
+DefaultWindowHeight=720
+"@
+
+$gameLua = @"
+-- $Name — entry point loaded via config.ini StartupScript.
+log("Hello from $Name!")
+"@
+
+$licensesReadme = @'
+Drop additional third-party attribution files (one .txt per dependency) into this
+directory. Packaged builds append them to the engine's shipped THIRD_PARTY_LICENSES.txt.
+'@
+
+$gitignore = @'
+# Engine-generated runtime/editor state
+imgui.ini
+editor_prefs.ini
+preferences.ini
+*_prefs.ini
+
+# Asset bake outputs + caches
+asset_manifest.lua
+*.meta.cache
+
+# Local build dirs
+build/
+.cache/
+'@
+
+$readme = @"
+# $Name
+
+Built with the Octarine engine.
+
+## Run (dev)
+
+``````sh
+OctarineEngine $Dir
+``````
+
+## Package a release
+
+``````sh
+cmake --preset ship-release -DOCTARINE_PACKAGE_PROJECT=$Dir
+cmake --build --preset ship-release --target package
+``````
+
+Output bundles land under ``build/ship-release/``.
+"@
+
+# Windows PowerShell 5.1's `Set-Content -Encoding utf8` writes a BOM, which the engine's
+# INI parser and Lua's loader both reject. Use the .NET API w/ a no-BOM UTF8 encoder.
+$utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+function Write-Text([string]$Path, [string]$Content) {
+    [System.IO.File]::WriteAllText($Path, $Content, $utf8NoBom)
+}
+
+Write-Text (Join-Path $Dir "project.ini")                       $projectIni
+Write-Text (Join-Path $Dir "config.ini")                        $configIni
+Write-Text (Join-Path $Dir "game.lua")                          $gameLua
+Write-Text (Join-Path $Dir "THIRD_PARTY_LICENSES.d/README.txt") $licensesReadme
+Write-Text (Join-Path $Dir ".gitignore")                        $gitignore
+Write-Text (Join-Path $Dir "README.md")                         $readme
+
+Write-Output "Scaffolded '$Name' at $Dir"

--- a/scripts/octarine-new.sh
+++ b/scripts/octarine-new.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Scaffold a new Octarine project: project.ini + config.ini + game.lua + asset dirs.
+# Usage:
+#   octarine-new.sh --name "My Game" --package-id com.studio.mygame --dir /path/to/out
+#
+# After scaffolding, build a packaged release with:
+#   cmake --preset ship-release -DOCTARINE_PACKAGE_PROJECT=<dir>
+#   cmake --build --preset ship-release --target package
+#
+# Or run from a debug build:
+#   ./build/editor-debug/bin/debug/OctarineEngine <dir>
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: octarine-new.sh --name <display-name> --package-id <reverse-dns> --dir <output-dir>
+
+Required:
+  --name        Human-readable game title (e.g. "My Game")
+  --package-id  Reverse-DNS bundle identifier (e.g. com.studio.mygame)
+  --dir         Output directory (must not already exist or must be empty)
+
+Optional:
+  --version-name   semver string (default: 0.1.0)
+  --version-code   integer build code (default: 1)
+  -h, --help       show this message
+EOF
+}
+
+name=""
+package_id=""
+dir=""
+version_name="0.1.0"
+version_code="1"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --name) name="$2"; shift 2 ;;
+    --package-id) package_id="$2"; shift 2 ;;
+    --dir) dir="$2"; shift 2 ;;
+    --version-name) version_name="$2"; shift 2 ;;
+    --version-code) version_code="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+[[ -z "$name" ]]       && { echo "--name required" >&2; exit 2; }
+[[ -z "$package_id" ]] && { echo "--package-id required" >&2; exit 2; }
+[[ -z "$dir" ]]        && { echo "--dir required" >&2; exit 2; }
+
+if [[ ! "$package_id" =~ ^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)+$ ]]; then
+  echo "--package-id must be reverse-DNS (e.g. com.studio.mygame): got '$package_id'" >&2
+  exit 2
+fi
+
+if [[ -e "$dir" ]]; then
+  if [[ -d "$dir" ]] && [[ -z "$(ls -A "$dir")" ]]; then
+    :
+  else
+    echo "--dir already exists and is not empty: $dir" >&2
+    exit 1
+  fi
+fi
+
+mkdir -p "$dir/assets" "$dir/THIRD_PARTY_LICENSES.d"
+
+cat > "$dir/project.ini" <<EOF
+# Game identity for packaging. Read by desktop CPack, Android Gradle, iOS Info.plist (later).
+# Single source of truth across every platform. Flat key=value, no sections.
+
+name         = ${name}
+package_id   = ${package_id}
+version_name = ${version_name}
+version_code = ${version_code}
+EOF
+
+cat > "$dir/config.ini" <<EOF
+# Engine runtime config. Loaded at startup before game.lua.
+Title=${name}
+LogLevel=info
+StartupScript=game.lua
+DefaultScalingMode=nearest
+DefaultWindowWidth=1280
+DefaultWindowHeight=720
+EOF
+
+# shellcheck disable=SC2016
+cat > "$dir/game.lua" <<EOF
+-- ${name} — entry point loaded via config.ini StartupScript.
+log("Hello from ${name}!")
+EOF
+
+cat > "$dir/THIRD_PARTY_LICENSES.d/README.txt" <<'EOF'
+Drop additional third-party attribution files (one .txt per dependency) into this
+directory. Packaged builds append them to the engine's shipped THIRD_PARTY_LICENSES.txt.
+EOF
+
+cat > "$dir/.gitignore" <<'EOF'
+# Engine-generated runtime/editor state
+imgui.ini
+editor_prefs.ini
+preferences.ini
+*_prefs.ini
+
+# Asset bake outputs + caches
+asset_manifest.lua
+*.meta.cache
+
+# Local build dirs
+build/
+.cache/
+EOF
+
+cat > "$dir/README.md" <<EOF
+# ${name}
+
+Built with the Octarine engine.
+
+## Run (dev)
+
+\`\`\`sh
+OctarineEngine $(pwd)/$(basename "$dir")
+\`\`\`
+
+## Package a release
+
+\`\`\`sh
+cmake --preset ship-release -DOCTARINE_PACKAGE_PROJECT=\$(pwd)
+cmake --build --preset ship-release --target package
+\`\`\`
+
+Output bundles land under \`build/ship-release/\`.
+EOF
+
+echo "Scaffolded '${name}' at ${dir}"


### PR DESCRIPTION
## Summary
- New `scripts/octarine-new.sh` + `scripts/octarine-new.ps1` scaffold a buildable Octarine project in one command (closes Stage 5 of `ai/ShippingV1Plan.md`).
- Emits `project.ini`, `config.ini` (incl. required `Title=`), `game.lua` with a hello-world log, `assets/`, `THIRD_PARTY_LICENSES.d/`, `.gitignore`, `README.md`.
- Validates `--package-id` as reverse-DNS and refuses to clobber a non-empty `--dir`.
- PowerShell variant writes UTF-8 **without BOM** via `[System.IO.File]::WriteAllText` — `Set-Content -Encoding utf8` on Windows PowerShell 5.1 prepends a BOM that the engine's INI parser and Lua loader both reject.

## Test plan
- [x] `scripts/octarine-new.sh --name "Sh Game" --package-id com.acme.shgame --dir /tmp/...` + `OctarineEngine <dir>` boots, Lua logs `Hello from Sh Game!`
- [x] `scripts/octarine-new.ps1 -Name "PS Game" -PackageId com.acme.psgame -Dir C:\Temp\...` + `OctarineEngine <dir>` boots, Lua logs `Hello from PS Game!`
- [x] Bad `--package-id` (`bad-id`) rejected w/ exit 2
- [x] Non-empty existing `--dir` rejected w/ exit 1
- [x] Output `config.ini` first byte is `#` (35), not a BOM