### PR TITLE
Extract Android multi-ABI native fan-out into octarine-native plugin

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,5 +1,8 @@
 plugins {
     id 'com.android.application'
+    // Repo-local plugin: multi-ABI native fan-out via buildSrc/. No-op when octarineNative.abis
+    // is empty (single-ABI dev path stays on AGP's externalNativeBuild).
+    id 'octarine-native'
 }
 
 // --- Octarine host app ---------------------------------------------------------------------------
@@ -253,9 +256,11 @@ android {
     }
 
     sourceSets.main {
-        // Multi-ABI mode: per-ABI libmain.so lands under build/octarineJni/<abi>/. AGP packages
-        // every <abi>/ subdir into the APK's lib/<abi>/.
-        jniLibs.srcDirs = multiAbi ? ['libs', nativeBuildRoot] : ['libs']
+        // Single-ABI dev mode: AGP's externalNativeBuild puts libmain.so where AGP wants it.
+        // Multi-ABI: the octarine-native plugin (buildSrc/) registers each ABI's stage task and
+        // calls `variant.sources.jniLibs.addGeneratedSourceDirectory(...)`, so no static srcDir
+        // entry is needed here.
+        jniLibs.srcDirs = ['libs']
         assets.srcDirs = [stagedAssetsDir, licenseAssetsDir]
         // Generated mipmap-*/values-v31 ride beside the committed res tree; AAPT2 merges them so
         // ic_launcher.png and the splash AppTheme override land in the APK with no manual placement.
@@ -374,74 +379,33 @@ tasks.register('generateOctarineIcons', Exec) {
     }
 }
 
-// Multi-ABI native build orchestration. Single-ABI dev path stays on AGP's externalNativeBuild
-// (see the `if (!multiAbi)` blocks above) — these tasks only register when -Poctarine.abis is
-// passed. For each ABI we fan-out three tasks: configure (cmake), build (cmake --build), stage
-// (copy libmain.so into jniLibs srcDir). The aggregator `octarineNativeAll` depends on every
-// stage task, and preBuild pulls it in so `assembleDebug` / `bundleRelease` see the .so files.
-//
-// vcpkg's android workflow needs ANDROID_NDK_HOME — propagated via the `environment` block on
-// each Exec so cmake sees the same NDK android.toolchain.cmake AGP would have used.
+// Multi-ABI native build orchestration lives in the octarine-native plugin (buildSrc/). It reads
+// the values below, fans out per-ABI cmake configure/build/stage tasks, and wires the .so outputs
+// into each variant's jniLibs via androidComponents.onVariants — no preBuild.dependsOn glue.
+// Single-ABI mode keeps the externalNativeBuild path above (faster IDE inner loop).
 if (multiAbi) {
     def ndkHome = System.getenv('ANDROID_NDK_HOME') ?: System.getenv('ANDROID_NDK_ROOT')
     if (ndkHome == null) {
         ndkHome = "${android.sdkDirectory}/ndk/${appNdk}"
     }
-    def ndkToolchain = "${ndkHome}/build/cmake/android.toolchain.cmake"
-    def stageTaskNames = []
-
-    abiList.each { iterAbi ->
-        def triplet = tripletForAbi.getOrDefault(iterAbi, 'arm64-android')
-        def configureDir = "${nativeBuildRoot}/.build/${iterAbi}"
-        def stageOutDir  = "${nativeBuildRoot}/${iterAbi}"
-        def configureTask = "octarineNative_${iterAbi}_configure"
-        def buildTask     = "octarineNative_${iterAbi}_build"
-        def stageTask     = "octarineNative_${iterAbi}_stage"
-
-        tasks.register(configureTask, Exec) {
-            description = "CMake configure for Android ABI ${iterAbi} (triplet ${triplet})."
-            doFirst {
-                file(configureDir).mkdirs()
-                file(stageOutDir).mkdirs()
-            }
-            workingDir configureDir
-            environment 'ANDROID_NDK_HOME', ndkHome
-            commandLine 'cmake',
-                    "${repoRoot}",
-                    '-G', 'Ninja',
-                    "-DANDROID_ABI=${iterAbi}",
-                    "-DANDROID_PLATFORM=android-${appMinSdk}",
-                    '-DANDROID_STL=c++_shared',
-                    "-DCMAKE_TOOLCHAIN_FILE=${vcpkgRoot}/scripts/buildsystems/vcpkg.cmake",
-                    "-DVCPKG_CHAINLOAD_TOOLCHAIN_FILE=${ndkToolchain}",
-                    "-DVCPKG_TARGET_TRIPLET=${triplet}",
-                    '-DVCPKG_MANIFEST_MODE=ON',
-                    "-DVCPKG_OVERLAY_PORTS=${rootDir}/vcpkg-overlay-ports",
-                    '-DCMAKE_BUILD_TYPE=Release'
-        }
-
-        tasks.register(buildTask, Exec) {
-            description = "CMake build for Android ABI ${iterAbi}."
-            dependsOn configureTask
-            workingDir configureDir
-            commandLine 'cmake', '--build', '.', '--target', 'OctarineEngine', '--parallel'
-        }
-
-        tasks.register(stageTask, Copy) {
-            description = "Stage libmain.so for Android ABI ${iterAbi} into jniLibs."
-            dependsOn buildTask
-            from("${configureDir}") {
-                include 'libmain.so'
-            }
-            into stageOutDir
-        }
-
-        stageTaskNames += stageTask
-    }
-
-    tasks.register('octarineNativeAll') {
-        description = 'Build libmain.so for every ABI in -Poctarine.abis.'
-        dependsOn stageTaskNames
+    // Bind locals first — every name below also appears on the extension, and Groovy's
+    // OWNER_FIRST resolution inside the `octarineNative { ... }` closure would otherwise route
+    // every RHS through the extension property instead of the script-local def.
+    def _abiList     = abiList
+    def _vcpkgRoot   = vcpkgRoot.toString()
+    def _ndkHome     = ndkHome
+    def _repoRoot    = repoRoot.toString()
+    def _overlay     = "${rootDir}/vcpkg-overlay-ports".toString()
+    def _minSdk      = appMinSdk
+    def _tripletMap  = tripletForAbi
+    octarineNative { ext ->
+        ext.abis.set(_abiList)
+        ext.vcpkgRoot.set(_vcpkgRoot)
+        ext.ndkHome.set(_ndkHome)
+        ext.repoRoot.set(_repoRoot)
+        ext.vcpkgOverlayPorts.set(_overlay)
+        ext.minSdk.set(_minSdk)
+        ext.tripletForAbi.set(_tripletMap)
     }
 }
 
@@ -496,10 +460,10 @@ tasks.register('generateOctarineLicenses', Exec) {
 
 tasks.configureEach { task ->
     if (task.name == 'preBuild') {
+        // Asset / icon / license generators stay on the preBuild edge — their outputs land in
+        // sourceSet srcDirs that AGP reads at merge time. Multi-ABI native libs use AGP's variant
+        // jniLibs.addGeneratedSourceDirectory wiring from the octarine-native plugin instead.
         task.dependsOn 'stageOctarineAssets', 'generateOctarineIcons', 'generateOctarineLicenses'
-        if (multiAbi) {
-            task.dependsOn 'octarineNativeAll'
-        }
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,8 +1,11 @@
 // Root build file. Modern layout: repositories + the AGP version live in settings.gradle
 // (pluginManagement / dependencyResolutionManagement). Plugins are declared here `apply false` and
 // applied per-module.
+// AGP is pulled in by buildSrc/build.gradle.kts (the octarine-native plugin's compile classpath
+// needs it), so declaring a version here would collide with "already on the classpath" — apply
+// without version + `apply false` and let app/build.gradle pull it in.
 plugins {
-    id 'com.android.application' version '8.7.3' apply false
+    id 'com.android.application' apply false
 }
 
 tasks.register('clean', Delete) {

--- a/android/buildSrc/build.gradle.kts
+++ b/android/buildSrc/build.gradle.kts
@@ -1,0 +1,28 @@
+// buildSrc holds the repo-local Octarine gradle plugin (octarine-native). kotlin-dsl gives the
+// plugin access to Kotlin + the AGP Variant API without a separate composite build. Gradle
+// auto-applies whatever this directory builds before evaluating any other build script in the
+// android/ project.
+
+plugins {
+    `kotlin-dsl`
+}
+
+repositories {
+    google()
+    mavenCentral()
+    gradlePluginPortal()
+}
+
+// Pinned to the same AGP version the app applies (android/build.gradle). Bump in lockstep.
+dependencies {
+    implementation("com.android.tools.build:gradle:8.7.3")
+}
+
+gradlePlugin {
+    plugins {
+        create("octarineNative") {
+            id = "octarine-native"
+            implementationClass = "OctarineNativePlugin"
+        }
+    }
+}

--- a/android/buildSrc/settings.gradle.kts
+++ b/android/buildSrc/settings.gradle.kts
@@ -1,0 +1,10 @@
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+rootProject.name = "buildSrc"

--- a/android/buildSrc/src/main/kotlin/OctarineNativeExtension.kt
+++ b/android/buildSrc/src/main/kotlin/OctarineNativeExtension.kt
@@ -1,0 +1,23 @@
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property
+
+/**
+ * Plugin-facing configuration for octarine-native. Kept minimal — every value is something the
+ * caller already had to compute (vcpkgRoot, ndkHome, repoRoot) or is intrinsic to the engine
+ * (overlay ports dir, minSdk, abi→triplet mapping).
+ *
+ * `abis` is the multi-ABI fan-out trigger: when empty (default), the plugin is a no-op and the
+ * app build's `if (!multiAbi) externalNativeBuild { ... }` path handles single-ABI native compile.
+ * Pass `-Poctarine.abis=arm64-v8a,x86_64` upstream and the build script forwards the resolved list
+ * into this property.
+ */
+interface OctarineNativeExtension {
+    val abis: ListProperty<String>
+    val vcpkgRoot: Property<String>
+    val ndkHome: Property<String>
+    val repoRoot: Property<String>
+    val vcpkgOverlayPorts: Property<String>
+    val minSdk: Property<Int>
+    val tripletForAbi: MapProperty<String, String>
+}

--- a/android/buildSrc/src/main/kotlin/OctarineNativePlugin.kt
+++ b/android/buildSrc/src/main/kotlin/OctarineNativePlugin.kt
@@ -1,0 +1,120 @@
+import com.android.build.api.variant.ApplicationAndroidComponentsExtension
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.tasks.Exec
+import org.gradle.kotlin.dsl.create
+import org.gradle.kotlin.dsl.getByType
+import org.gradle.kotlin.dsl.register
+import java.io.File
+
+/**
+ * Multi-ABI native build orchestration for the Android host app. Replaces the bespoke
+ * `octarineNative_<abi>_{configure,build,stage}` task fan-out that used to live inline in
+ * `android/app/build.gradle` with a `Plugin<Project>` + a typed stage task, and uses AGP's
+ * `androidComponents.onVariants` to wire the .so outputs into each variant's jniLibs rather than
+ * the previous `tasks.configureEach { if (task.name == 'preBuild') task.dependsOn ... }` shim.
+ *
+ * Single-ABI mode (no `octarineNative { abis = [...] }` configured): the plugin is a no-op and
+ * AGP's externalNativeBuild path drives the native compile (faster IDE inner loop).
+ *
+ * Multi-ABI mode: for every ABI in `extension.abis`, three tasks are registered:
+ *   octarineNative_<abi>_configure   — cmake configure into build/octarineJni/.build/<abi>
+ *   octarineNative_<abi>_build       — cmake --build (produces libmain.so)
+ *   octarineNative_<abi>_stage       — copy libmain.so to build/octarineJni/<abi>/<abi>/libmain.so
+ * The stage task's outputDirectory is attached per variant via
+ * `variant.sources.jniLibs.addGeneratedSourceDirectory(...)` — AGP then derives the dependency
+ * edge automatically and packages the .so at `lib/<abi>/libmain.so` in the APK/AAB.
+ */
+class OctarineNativePlugin : Plugin<Project> {
+    override fun apply(project: Project) {
+        val ext = project.extensions.create<OctarineNativeExtension>("octarineNative")
+        ext.minSdk.convention(28)
+        ext.tripletForAbi.convention(
+            mapOf(
+                "arm64-v8a" to "arm64-android",
+                "x86_64" to "x64-android",
+                "armeabi-v7a" to "arm-android",
+                "x86" to "x86-android",
+            )
+        )
+
+        val androidComponents = project.extensions.getByType<ApplicationAndroidComponentsExtension>()
+
+        // onVariants fires once per build variant (debug + release). The per-ABI Exec/stage
+        // tasks are content-identical across variants, so register them lazily on first sight and
+        // reuse the existing TaskProvider for the second variant.
+        androidComponents.onVariants { variant ->
+            val abis = ext.abis.get()
+            if (abis.isEmpty()) return@onVariants
+
+            abis.forEach { abi ->
+                val triplet = ext.tripletForAbi.get()[abi] ?: "arm64-android"
+                val stageTask = registerAbiTasks(project, ext, abi, triplet)
+                variant.sources.jniLibs?.addGeneratedSourceDirectory(
+                    stageTask,
+                    OctarineStageNativeTask::outputDirectory,
+                )
+            }
+        }
+    }
+
+    private fun registerAbiTasks(
+        project: Project,
+        ext: OctarineNativeExtension,
+        abiName: String,
+        triplet: String,
+    ): org.gradle.api.tasks.TaskProvider<OctarineStageNativeTask> {
+        val nativeRoot = project.layout.buildDirectory.dir("octarineJni").get().asFile
+        val configureDir = File(nativeRoot, ".build/$abiName")
+        val stageDir = File(nativeRoot, ".staged/$abiName")
+
+        val configureTaskName = "octarineNative_${abiName}_configure"
+        val buildTaskName = "octarineNative_${abiName}_build"
+        val stageTaskName = "octarineNative_${abiName}_stage"
+
+        // Bail out early if this ABI's tasks are already registered (second variant pass).
+        project.tasks.findByName(stageTaskName)?.let {
+            @Suppress("UNCHECKED_CAST")
+            return project.tasks.named(stageTaskName) as org.gradle.api.tasks.TaskProvider<OctarineStageNativeTask>
+        }
+
+        val configureTask = project.tasks.register<Exec>(configureTaskName) {
+            description = "CMake configure for Android ABI $abiName (triplet $triplet)."
+            doFirst {
+                configureDir.mkdirs()
+            }
+            workingDir = configureDir
+            environment("ANDROID_NDK_HOME", ext.ndkHome.get())
+            val ndkToolchain = File(ext.ndkHome.get(), "build/cmake/android.toolchain.cmake")
+            commandLine(
+                "cmake",
+                ext.repoRoot.get(),
+                "-G", "Ninja",
+                "-DANDROID_ABI=$abiName",
+                "-DANDROID_PLATFORM=android-${ext.minSdk.get()}",
+                "-DANDROID_STL=c++_shared",
+                "-DCMAKE_TOOLCHAIN_FILE=${ext.vcpkgRoot.get()}/scripts/buildsystems/vcpkg.cmake",
+                "-DVCPKG_CHAINLOAD_TOOLCHAIN_FILE=$ndkToolchain",
+                "-DVCPKG_TARGET_TRIPLET=$triplet",
+                "-DVCPKG_MANIFEST_MODE=ON",
+                "-DVCPKG_OVERLAY_PORTS=${ext.vcpkgOverlayPorts.get()}",
+                "-DCMAKE_BUILD_TYPE=Release",
+            )
+        }
+
+        val buildTask = project.tasks.register<Exec>(buildTaskName) {
+            description = "CMake build of libmain.so for Android ABI $abiName."
+            dependsOn(configureTask)
+            workingDir = configureDir
+            commandLine("cmake", "--build", ".", "--target", "OctarineEngine", "--parallel")
+        }
+
+        return project.tasks.register<OctarineStageNativeTask>(stageTaskName) {
+            description = "Stage libmain.so for Android ABI $abiName into a jniLibs-shaped directory."
+            dependsOn(buildTask)
+            abi.set(abiName)
+            libmain.set(project.layout.file(project.provider { File(configureDir, "libmain.so") }))
+            outputDirectory.set(stageDir)
+        }
+    }
+}

--- a/android/buildSrc/src/main/kotlin/OctarineStageNativeTask.kt
+++ b/android/buildSrc/src/main/kotlin/OctarineStageNativeTask.kt
@@ -1,0 +1,36 @@
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+
+/**
+ * Stages a freshly-built libmain.so for one Android ABI into an AGP-shaped jniLibs source
+ * directory: `<outputDirectory>/<abi>/libmain.so`. The output directory is exposed back to AGP
+ * via `variant.sources.jniLibs.addGeneratedSourceDirectory(stageTask, OctarineStageNativeTask::outputDirectory)`,
+ * which wires the dependency edge (assembleX depends on stage) and the packaging step (the .so
+ * lands at lib/<abi>/libmain.so inside the APK/AAB) without any preBuild.dependsOn glue.
+ */
+abstract class OctarineStageNativeTask : DefaultTask() {
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val libmain: RegularFileProperty
+
+    @get:Input
+    abstract val abi: Property<String>
+
+    @get:OutputDirectory
+    abstract val outputDirectory: DirectoryProperty
+
+    @TaskAction
+    fun stage() {
+        val abiDir = outputDirectory.get().asFile.resolve(abi.get())
+        abiDir.mkdirs()
+        libmain.get().asFile.copyTo(abiDir.resolve("libmain.so"), overwrite = true)
+    }
+}


### PR DESCRIPTION
## Summary
- Moves the bespoke `octarineNative_<abi>_{configure,build,stage}` task fan-out + `octarineNativeAll` aggregator out of inline `android/app/build.gradle` and into a proper Gradle plugin under `android/buildSrc/` (kotlin-dsl). Applied via `id 'octarine-native'`.
- Plugin uses AGP's `androidComponents.onVariants` API: per ABI, it registers the configure/build/stage tasks, then `variant.sources.jniLibs.addGeneratedSourceDirectory(stageTask, OctarineStageNativeTask::outputDirectory)` — AGP derives the dependency edge + `lib/<abi>/libmain.so` packaging automatically. Drops the static `jniLibs.srcDirs = multiAbi ? [...] : ['libs']` swap and the `tasks.configureEach { preBuild.dependsOn 'octarineNativeAll' }` shim.
- Single-ABI dev path (no `-Poctarine.abis`) unchanged: plugin no-ops when the `abis` ListProperty is empty, externalNativeBuild still owns the native compile (faster IDE inner loop).
- Closes Stage 12 of `ai/ShippingV1Plan.md`.

## Validated locally via `gradlew --dry-run`
- `bundleRelease -Poctarine.abis=arm64-v8a,x86_64` task graph includes both ABIs' configure/build/stage + `mergeReleaseJniLibFolders` + `packageReleaseBundle`.
- `assembleDebug` (single-ABI) runs `configureCMakeDebug[arm64-v8a]`; no `octarineNative_*` tasks fire.

## Test plan
- [ ] `android.yml` `android (arm64-v8a)` (Build APK, single-ABI) — should still use externalNativeBuild path, plugin no-op
- [ ] `android.yml` `Build AAB (release bundle, multi-ABI)` — should fan out both ABIs via plugin tasks, produce identical-shape AAB to main
- [ ] `android.yml` `Verify AAB carries every ABI` — both `base/lib/arm64-v8a/libmain.so` + `base/lib/x86_64/libmain.so` present
- [ ] `android.yml` `Verify AAB ships project icon (not SDL template)` — still green (untouched code)
- [ ] `android (minify probe)` leg