### PR TITLE
Add OCPK asset bundle (Stage 14 B4): bake-time pack + runtime open

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,7 @@ set(SRC_FILES
         src/Main.cpp
         src/AssetManager/AssetManager.cpp
         src/AssetManager/AssetCatalog.cpp
+        src/AssetManager/AssetPak.cpp
         src/AssetManager/SceneAssetScanner.cpp
         src/ECS/Registry.cpp
         src/Game/Game.cpp

--- a/src/AssetManager/AssetManager.cpp
+++ b/src/AssetManager/AssetManager.cpp
@@ -11,8 +11,23 @@
 
 #include "../Game/GameConfig.h"
 #include "../General/Logger.h"
+#include "AssetManager/AssetPak.h"
 
 AssetManager::~AssetManager() { ClearAssets(); }
+
+SDL_IOStream *AssetManager::OpenAssetIO(const std::string &fullPath) const {
+  if (asset_pak_ != nullptr && asset_pak_->IsOpen() && !base_path_.empty()) {
+    std::error_code ec;
+    const std::filesystem::path rel =
+        std::filesystem::relative(std::filesystem::path(fullPath), std::filesystem::path(base_path_), ec);
+    if (!ec && !rel.empty()) {
+      if (SDL_IOStream *io = asset_pak_->OpenIO(rel.generic_string()); io != nullptr) {
+        return io;
+      }
+    }
+  }
+  return SDL_IOFromFile(fullPath.c_str(), "rb");
+}
 void AssetManager::LoadGameConfig(const GameConfig &config) {
   base_path_ = config.GetAssetPath();
   if (config.GetDefaultScaleMode().has_value()) {
@@ -168,8 +183,9 @@ int AssetManager::Validate(const std::vector<AssetReference> &refs) const {
 void AssetManager::AddTexture(SDL_Renderer *renderer, const std::string &assetId, const std::string &path) {
   const std::string fullPath = GetFullPath(path);
 
-  // Route through SDL IO so the same path resolves on desktop, an APK asset root, or a .app bundle.
-  SDL_IOStream *io = SDL_IOFromFile(fullPath.c_str(), "rb");
+  // Route through OpenAssetIO so the same path resolves on desktop, an APK asset root, a .app
+  // bundle, or — for shipped builds — the OCPK asset bundle.
+  SDL_IOStream *io = OpenAssetIO(fullPath);
   if (!io) {
     Logger::Error("Failed to open texture file " + fullPath + ": " + std::string(SDL_GetError()));
     return;
@@ -209,7 +225,7 @@ SDL_Texture *AssetManager::GetTexture(const std::string &assetId) const {
 
 void AssetManager::AddFont(const std::string &assetId, const std::string &path, const float fontSize) {
   const std::string fullPath = GetFullPath(path);
-  SDL_IOStream *io = SDL_IOFromFile(fullPath.c_str(), "rb");
+  SDL_IOStream *io = OpenAssetIO(fullPath);
   if (!io) {
     Logger::Error("Failed to open font file " + assetId + " from " + fullPath + ": " + std::string(SDL_GetError()));
     return;
@@ -238,7 +254,7 @@ void AssetManager::AddAudioClip(MIX_Mixer *mixer, const std::string &assetId, co
   }
 
   const std::string fullPath = GetFullPath(path);
-  SDL_IOStream *io = SDL_IOFromFile(fullPath.c_str(), "rb");
+  SDL_IOStream *io = OpenAssetIO(fullPath);
   if (!io) {
     Logger::Error("Failed to open audio file " + assetId + " from " + fullPath + ": " + std::string(SDL_GetError()));
     return;

--- a/src/AssetManager/AssetManager.h
+++ b/src/AssetManager/AssetManager.h
@@ -13,6 +13,7 @@
 #include "AssetManager/AssetCatalog.h"
 #include "AssetManager/AssetReference.h"
 
+class AssetPak;
 class GameConfig;
 
 class AssetManager {
@@ -31,6 +32,10 @@ class AssetManager {
   // Bumped whenever a texture is added or replaced. Sprite renderers compare against
   // their cached generation to know when to re-resolve a stale SDL_Texture* pointer.
   std::uint64_t texture_generation_{0};
+  // Optional shipped-bundle archive (Stage 14 / B4). When set, AssetManager prefers reading each
+  // asset's bytes from the pak over the loose file at `fullPath`. Non-owning — the Registry owns
+  // the AssetPak instance.
+  const AssetPak* asset_pak_{nullptr};
 
  public:
   AssetManager() = default;
@@ -81,6 +86,13 @@ class AssetManager {
   [[nodiscard]] AssetCatalog& GetCatalog() { return catalog_; }
   [[nodiscard]] const AssetCatalog& GetCatalog() const { return catalog_; }
 
+  // Wire in an opened AssetPak (typically by Game::Setup on shipped builds, after probing for an
+  // asset_bundle.pak beside the project). Asset load sites prefer the pak when set; absent it,
+  // they fall through to SDL_IOFromFile on the loose tree. Pointer is non-owning; the Registry
+  // owns the AssetPak instance.
+  void SetAssetPak(const AssetPak* pak) { asset_pak_ = pak; }
+  [[nodiscard]] const AssetPak* GetAssetPak() const { return asset_pak_; }
+
   // Current acquire count for an id (0 if untracked). Test/diagnostic aid.
   [[nodiscard]] int RefCount(const std::string& assetId) const;
 
@@ -89,6 +101,11 @@ class AssetManager {
   [[nodiscard]] const std::map<std::string, MIX_Audio*>& GetAudioClips() const { return audio_clips_; }
 
  private:
+  // Open a read-only SDL_IOStream over `fullPath`. Tries the wired AssetPak first (lookup by
+  // project-relative key) and falls back to SDL_IOFromFile for dev builds + bootstrap projects
+  // where no pak has been baked yet.
+  [[nodiscard]] SDL_IOStream* OpenAssetIO(const std::string& fullPath) const;
+
   // Perform the actual SDL/MIX load for a catalog entry (no refcount bookkeeping). Returns whether
   // the handle is resident afterwards.
   bool LoadFromCatalog(const CatalogEntry& entry, const std::string& assetId, SDL_Renderer* renderer,

--- a/src/AssetManager/AssetPak.cpp
+++ b/src/AssetManager/AssetPak.cpp
@@ -1,0 +1,228 @@
+#include "AssetManager/AssetPak.h"
+
+#include <algorithm>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <vector>
+
+#include <SDL3/SDL.h>
+
+#include "AssetManager/AssetCatalog.h"
+#include "General/Logger.h"
+
+namespace {
+constexpr char kMagic[4] = {'O', 'C', 'P', 'K'};
+constexpr std::uint32_t kVersion = 1;
+
+// Header is fixed-size; declared inline to keep the wire format adjacent to the I/O routines that
+// produce + consume it. `reserved` is padding to a clean 32-byte header (8B magic+ver, 8B toc_off,
+// 4B toc_count, 4B reserved).
+#pragma pack(push, 1)
+struct PakHeader {
+    char magic[4];
+    std::uint32_t version;
+    std::uint64_t tocOffset;
+    std::uint32_t tocCount;
+    std::uint32_t reserved;
+};
+#pragma pack(pop)
+static_assert(sizeof(PakHeader) == 24, "PakHeader must be exactly 24 bytes on disk");
+
+// Re-root `fullPath` against `basePath` and normalize to forward slashes. Mirrors the path form
+// AssetCatalog::WriteManifest emits, so the pak key + manifest `file` field are interchangeable.
+std::string MakeRelPath(const std::string& fullPath, const std::string& basePath) {
+    namespace fs = std::filesystem;
+    std::error_code ec;
+    fs::path rel = fs::relative(fs::path(fullPath), fs::path(basePath), ec);
+    if (ec || rel.empty()) {
+        rel = fs::path(fullPath);
+    }
+    std::string s = rel.generic_string();
+    // Defensive: relative() can yield `..` on a non-prefixed input. Keep as-is — pack/unpack still
+    // round-trip, the bake just lands a non-portable key (which the runtime can still look up).
+    return s;
+}
+}  // namespace
+
+AssetPak::~AssetPak() {
+    if (data_ != nullptr) {
+        SDL_free(data_);
+        data_ = nullptr;
+    }
+}
+
+bool AssetPak::Pack(const AssetCatalog& catalog, const std::string& outPath,
+                    const std::string& basePath) {
+    std::ofstream out(outPath, std::ios::binary | std::ios::trunc);
+    if (!out) {
+        Logger::Error("AssetPak::Pack: failed to open " + outPath + " for writing");
+        return false;
+    }
+
+    // Reserve space for the header — patched in once tocOffset is known.
+    PakHeader header{};
+    std::memcpy(header.magic, kMagic, 4);
+    header.version = kVersion;
+    out.write(reinterpret_cast<const char*>(&header), sizeof(header));
+
+    struct StagedEntry {
+        std::string relPath;
+        std::uint64_t offset;
+        std::uint64_t size;
+    };
+    std::vector<StagedEntry> staged;
+    staged.reserve(catalog.Size());
+
+    // Stream each asset's bytes into the output. Buffer per-entry rather than slurping every asset
+    // into RAM — a project with a few hundred MB of assets shouldn't need that much during bake.
+    constexpr std::size_t kCopyChunk = 64 * 1024;
+    std::vector<char> buf(kCopyChunk);
+
+    for (const auto& [id, entry] : catalog.Entries()) {
+        std::ifstream in(entry.fullPath, std::ios::binary);
+        if (!in) {
+            Logger::Error("AssetPak::Pack: failed to read " + entry.fullPath);
+            out.close();
+            std::error_code ec;
+            std::filesystem::remove(outPath, ec);
+            return false;
+        }
+        const std::uint64_t offset = static_cast<std::uint64_t>(out.tellp());
+        std::uint64_t size = 0;
+        while (in) {
+            in.read(buf.data(), static_cast<std::streamsize>(buf.size()));
+            const std::streamsize got = in.gcount();
+            if (got > 0) {
+                out.write(buf.data(), got);
+                size += static_cast<std::uint64_t>(got);
+            }
+        }
+        staged.push_back({MakeRelPath(entry.fullPath, basePath), offset, size});
+    }
+
+    // TOC.
+    const std::uint64_t tocOffset = static_cast<std::uint64_t>(out.tellp());
+    for (const auto& s : staged) {
+        out.write(reinterpret_cast<const char*>(&s.offset), sizeof(s.offset));
+        out.write(reinterpret_cast<const char*>(&s.size), sizeof(s.size));
+        const std::uint16_t pathLen = static_cast<std::uint16_t>(s.relPath.size());
+        out.write(reinterpret_cast<const char*>(&pathLen), sizeof(pathLen));
+        out.write(s.relPath.data(), pathLen);
+    }
+
+    // Patch header w/ TOC info.
+    header.tocOffset = tocOffset;
+    header.tocCount = static_cast<std::uint32_t>(staged.size());
+    out.seekp(0, std::ios::beg);
+    out.write(reinterpret_cast<const char*>(&header), sizeof(header));
+    out.close();
+
+    if (!out) {
+        Logger::Error("AssetPak::Pack: write error finalizing " + outPath);
+        std::error_code ec;
+        std::filesystem::remove(outPath, ec);
+        return false;
+    }
+    Logger::Info("AssetPak::Pack: wrote " + std::to_string(staged.size()) + " entries to " + outPath);
+    return true;
+}
+
+bool AssetPak::Open(const std::string& pakPath) {
+    if (data_ != nullptr) {
+        SDL_free(data_);
+        data_ = nullptr;
+        data_size_ = 0;
+        entries_.clear();
+    }
+
+    // SDL_LoadFile resolves through SDL_IOFromFile, so this works inside an Android APK + a
+    // desktop loose dir without callers needing to know which they're on.
+    std::size_t sz = 0;
+    void* buf = SDL_LoadFile(pakPath.c_str(), &sz);
+    if (buf == nullptr) {
+        Logger::Warn("AssetPak::Open: SDL_LoadFile failed for " + pakPath + ": " +
+                     std::string(SDL_GetError()));
+        return false;
+    }
+    if (sz < sizeof(PakHeader)) {
+        Logger::Error("AssetPak::Open: " + pakPath + " is shorter than the pak header");
+        SDL_free(buf);
+        return false;
+    }
+    PakHeader header{};
+    std::memcpy(&header, buf, sizeof(header));
+    if (std::memcmp(header.magic, kMagic, 4) != 0) {
+        Logger::Error("AssetPak::Open: " + pakPath + " has wrong magic (not an OCPK file)");
+        SDL_free(buf);
+        return false;
+    }
+    if (header.version != kVersion) {
+        Logger::Error("AssetPak::Open: " + pakPath + " is OCPK v" + std::to_string(header.version) +
+                      "; engine expects v" + std::to_string(kVersion));
+        SDL_free(buf);
+        return false;
+    }
+    if (header.tocOffset > sz) {
+        Logger::Error("AssetPak::Open: " + pakPath + " TOC offset past end of file");
+        SDL_free(buf);
+        return false;
+    }
+
+    const auto* tocCursor = static_cast<const std::uint8_t*>(buf) + header.tocOffset;
+    const auto* tocEnd = static_cast<const std::uint8_t*>(buf) + sz;
+    entries_.clear();
+    for (std::uint32_t i = 0; i < header.tocCount; ++i) {
+        if (tocCursor + sizeof(std::uint64_t) * 2 + sizeof(std::uint16_t) > tocEnd) {
+            Logger::Error("AssetPak::Open: truncated TOC in " + pakPath);
+            SDL_free(buf);
+            entries_.clear();
+            return false;
+        }
+        Entry e{};
+        std::memcpy(&e.offset, tocCursor, sizeof(e.offset));
+        tocCursor += sizeof(e.offset);
+        std::memcpy(&e.size, tocCursor, sizeof(e.size));
+        tocCursor += sizeof(e.size);
+        std::uint16_t pathLen = 0;
+        std::memcpy(&pathLen, tocCursor, sizeof(pathLen));
+        tocCursor += sizeof(pathLen);
+        if (tocCursor + pathLen > tocEnd) {
+            Logger::Error("AssetPak::Open: TOC path overruns file in " + pakPath);
+            SDL_free(buf);
+            entries_.clear();
+            return false;
+        }
+        std::string relPath(reinterpret_cast<const char*>(tocCursor), pathLen);
+        tocCursor += pathLen;
+        if (e.offset + e.size > header.tocOffset) {
+            Logger::Error("AssetPak::Open: entry '" + relPath + "' overlaps TOC region");
+            SDL_free(buf);
+            entries_.clear();
+            return false;
+        }
+        entries_.emplace(std::move(relPath), e);
+    }
+
+    data_ = buf;
+    data_size_ = sz;
+    Logger::Info("AssetPak::Open: loaded " + std::to_string(entries_.size()) + " entries from " +
+                 pakPath);
+    return true;
+}
+
+bool AssetPak::Contains(const std::string& relPath) const {
+    return entries_.find(relPath) != entries_.end();
+}
+
+SDL_IOStream* AssetPak::OpenIO(const std::string& relPath) const {
+    if (data_ == nullptr) {
+        return nullptr;
+    }
+    const auto it = entries_.find(relPath);
+    if (it == entries_.end()) {
+        return nullptr;
+    }
+    const auto* slice = static_cast<const std::uint8_t*>(data_) + it->second.offset;
+    return SDL_IOFromConstMem(slice, it->second.size);
+}

--- a/src/AssetManager/AssetPak.h
+++ b/src/AssetManager/AssetPak.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <string>
+#include <vector>
+
+#include <SDL3/SDL_iostream.h>
+
+class AssetCatalog;
+
+// One-file archive of every baked asset, opened as a single SDL_LoadFile blob at startup. Each
+// entry is referenced by its project-relative path (forward slashes), matching the `file` field
+// AssetCatalog::WriteManifest serializes — so a lookup driven from `fullPath - basePath` resolves
+// cleanly to the same key the manifest uses.
+//
+// Format ("OCPK" v1, little-endian):
+//   [16] magic="OCPK" | u32 version=1 | u64 toc_off | u32 toc_count | u32 reserved
+//   [data...]   raw blob bytes concatenated in TOC order
+//   [TOC...]    repeated `toc_count` times:
+//                 u64 offset (from file start)
+//                 u64 size
+//                 u16 path_len
+//                 char path[path_len]   (no trailing NUL)
+//
+// Whole-file load: the pak gets read into memory once via SDL_LoadFile and each Open() returns an
+// SDL_IOFromConstMem slice over the cached buffer. Memory cost ≈ total baked asset bytes — fine
+// for indie shipping budgets; if a project ever needs lazy reads, swap the impl to a custom
+// SDL_IOStreamInterface backed by pread() and the lookup map stays unchanged.
+class AssetPak {
+public:
+    AssetPak() = default;
+    AssetPak(const AssetPak&) = delete;
+    AssetPak& operator=(const AssetPak&) = delete;
+    AssetPak(AssetPak&&) = default;
+    AssetPak& operator=(AssetPak&&) = default;
+    ~AssetPak();
+
+    // Pack every entry in `catalog` into a single .pak at `outPath`. Each entry's `fullPath` is
+    // read and stored under its project-relative form (`fullPath` re-rooted against `basePath`,
+    // forward-slashed). Returns false on any I/O failure; partially-written paks are removed.
+    static bool Pack(const AssetCatalog& catalog, const std::string& outPath,
+                     const std::string& basePath);
+
+    // Open a pak file from disk into memory. Returns true on success. The instance owns the
+    // backing buffer until destruction.
+    bool Open(const std::string& pakPath);
+
+    // True when Open() succeeded.
+    [[nodiscard]] bool IsOpen() const { return data_ != nullptr; }
+
+    // True when `relPath` (project-relative, forward slashes) is a stored entry.
+    [[nodiscard]] bool Contains(const std::string& relPath) const;
+
+    // Open a read-only SDL_IOStream over the pak entry at `relPath`. Returns nullptr if the
+    // entry is absent — caller falls back to SDL_IOFromFile. The returned stream is backed by
+    // the pak's owned buffer; the caller closes it as usual.
+    [[nodiscard]] SDL_IOStream* OpenIO(const std::string& relPath) const;
+
+    [[nodiscard]] std::size_t Size() const { return entries_.size(); }
+
+private:
+    struct Entry {
+        std::uint64_t offset;
+        std::uint64_t size;
+    };
+
+    void* data_{nullptr};
+    std::size_t data_size_{0};
+    std::map<std::string, Entry> entries_;
+};

--- a/src/Game/Game.cpp
+++ b/src/Game/Game.cpp
@@ -13,6 +13,7 @@
 #include "../Events/KeyInputEvent.h"
 #include "../General/Logger.h"
 #include "AssetManager/AssetCatalog.h"
+#include "AssetManager/AssetPak.h"
 #include "AssetManager/SceneAssetScanner.h"
 #include "../Renderer/RenderQueue.h"
 #include "../Renderer/Renderer.h"
@@ -559,6 +560,20 @@ bool Game::RunBakeValidation(const std::string& assetPath)
             manifestPath);
     }
 
+    // Pack every cataloged asset into a single asset_bundle.pak alongside the manifest. Shipped
+    // builds (OCTARINE_SHIPPED) open this in place of the loose asset tree; dev builds ignore it
+    // and read the original files. Manifest write is the source-of-truth gate — if that failed,
+    // skip the pak so a stale archive doesn't ship.
+    if (wrote)
+    {
+        const std::string pakPath = (std::filesystem::path(assetPath) / "asset_bundle.pak").string();
+        if (!AssetPak::Pack(assetManager.GetCatalog(), pakPath, assetPath))
+        {
+            Logger::Error("Bake: AssetPak::Pack failed for " + pakPath);
+            return false;
+        }
+    }
+
     if (bake_validation_failures_ > 0)
     {
         Logger::Error("Bake: " + std::to_string(bake_validation_failures_) +
@@ -696,6 +711,21 @@ void Game::Setup()
 #endif
         assetManager.GetCatalog().Build(assetManager.GetBasePath(), lua, gameConfig, allowManifest);
         assetManager.GetCatalog().DumpToLog();
+
+        // Shipped builds (and a dev build with --use-manifest) probe for an asset_bundle.pak
+        // beside the manifest. When present, AssetManager reads every asset out of it instead of
+        // the loose tree — same code paths, different SDL_IOStream source. Absence is fine:
+        // dev/bootstrap projects haven't baked one yet.
+        if (allowManifest)
+        {
+            const std::string pakPath = (std::filesystem::path(assetManager.GetBasePath()) /
+                                         "asset_bundle.pak").string();
+            auto& pak = registry_->Set<AssetPak>(AssetPak());
+            if (pak.Open(pakPath))
+            {
+                assetManager.SetAssetPak(&pak);
+            }
+        }
 
         // Expose the global `assets` table (id -> id, raises on typo) so scripts can reference
         // ids safely before LoadGame runs the startup script.

--- a/tests/AssetPipelineTest.cpp
+++ b/tests/AssetPipelineTest.cpp
@@ -7,16 +7,22 @@
 
 #include <sol/sol.hpp>
 
+#include <cstring>
 #include <filesystem>
+#include <fstream>
 #include <iostream>
 #include <optional>
+#include <set>
 #include <string>
+#include <vector>
 
 #include "AssetManager/AssetCatalog.h"
 #include "AssetManager/AssetManager.h"
 #include "AssetManager/AssetMetadata.h"
+#include "AssetManager/AssetPak.h"
 #include "AssetManager/AssetReference.h"
 #include "AssetManager/SceneAssetScanner.h"
+#include <SDL3/SDL.h>
 
 namespace
 {
@@ -238,6 +244,76 @@ int main()
         Check(!bad.valid(), "assets.<unknown> raises instead of returning nil");
     }
 #endif
+
+    std::cout << "[pak] round-trip pack/open via fixture catalog\n";
+    {
+        // SDL needed for SDL_LoadFile / SDL_IOFromConstMem during Open/OpenIO.
+        SDL_Init(0);
+
+        sol::state lua;
+        lua.open_libraries(sol::lib::base, sol::lib::table);
+
+        AssetCatalog catalog;
+        catalog.Build(ASSET_TEST_FIXTURE_DIR, lua, std::optional<ScaleMode>(ScaleMode::Nearest));
+        Check(catalog.Size() > 0, "pak round-trip: fixture catalog has entries");
+
+        const std::filesystem::path tmpDir =
+            std::filesystem::temp_directory_path() / "octarine_asset_pak_test";
+        std::error_code ec;
+        std::filesystem::create_directories(tmpDir, ec);
+        const std::string pakPath = (tmpDir / "asset_bundle.pak").string();
+
+        const bool packed = AssetPak::Pack(catalog, pakPath, ASSET_TEST_FIXTURE_DIR);
+        Check(packed, "AssetPak::Pack succeeds");
+
+        AssetPak pak;
+        Check(pak.Open(pakPath), "AssetPak::Open succeeds on freshly packed file");
+        // The pak dedupes by source file: a font that appears in the catalog at multiple sizes
+        // shares one underlying file + one pak entry. Compare against unique fullPath count, not
+        // raw catalog.Size().
+        std::set<std::string> uniqueFullPaths;
+        for (const auto& [id, entry] : catalog.Entries()) {
+            uniqueFullPaths.insert(entry.fullPath);
+        }
+        Check(pak.Size() == uniqueFullPaths.size(), "pak entry count matches unique source-file count");
+
+        // Byte-compare every entry: read original file off disk, fetch the pak slice via OpenIO,
+        // confirm length + contents match. Proves the offset/size TOC + memory-mapped slice
+        // serve the same bytes the loose tree would have.
+        int compared = 0;
+        int mismatch = 0;
+        for (const auto& [id, entry] : catalog.Entries())
+        {
+            const std::filesystem::path rel = std::filesystem::relative(
+                std::filesystem::path(entry.fullPath),
+                std::filesystem::path(ASSET_TEST_FIXTURE_DIR));
+            const std::string relStr = rel.generic_string();
+
+            std::ifstream src(entry.fullPath, std::ios::binary);
+            const std::vector<char> srcBytes((std::istreambuf_iterator<char>(src)),
+                                              std::istreambuf_iterator<char>());
+
+            SDL_IOStream* io = pak.OpenIO(relStr);
+            if (io == nullptr)
+            {
+                ++mismatch;
+                continue;
+            }
+            std::vector<char> pakBytes(srcBytes.size());
+            const size_t got = SDL_ReadIO(io, pakBytes.data(), pakBytes.size());
+            SDL_CloseIO(io);
+            if (got != srcBytes.size() || std::memcmp(pakBytes.data(), srcBytes.data(), got) != 0)
+            {
+                ++mismatch;
+            }
+            ++compared;
+        }
+        Check(compared == static_cast<int>(catalog.Size()), "every catalog entry resolves through the pak");
+        Check(mismatch == 0, "every pak entry's bytes match the source file exactly");
+
+        std::filesystem::remove_all(tmpDir, ec);
+        SDL_Quit();
+    }
 
     if (g_failures == 0)
     {


### PR DESCRIPTION
## Summary
- Closes Stage 14 / track B4 of `ai/ShippingV1Plan.md`. Shipped builds now read every cataloged asset out of a single `asset_bundle.pak` archive instead of the loose tree.
- New `AssetPak` (`src/AssetManager/AssetPak.{h,cpp}`) — minimal `OCPK` v1 format (24-byte header, concat'd blobs, TOC of `offset/size/path`). Whole-file load via `SDL_LoadFile`; per-asset `SDL_IOFromConstMem` slices.
- `Game::Bake` emits `asset_bundle.pak` right after `WriteManifest` (manifest write is the gate — failed bake never ships a partial pak).
- `Game::Setup` probes for the pak under the `OCTARINE_SHIPPED` / `--use-manifest` branch and stashes the opened `AssetPak` in the Registry; hands a non-owning pointer to `AssetManager` via `SetAssetPak`.
- `AssetManager::OpenAssetIO` becomes the single chokepoint for the three SDL load sites (texture / font / audio): pak first, `SDL_IOFromFile` fallback.
- `OctarineAssetPipelineTest` extended with a pak round-trip: pack the fixture catalog, reopen, byte-compare every entry's pak slice against the source on disk.

Dev/bootstrap paths unchanged: when no pak is wired in, every load site falls through to `SDL_IOFromFile` exactly as before.

## Verified locally
- `cmake --build build/editor-debug --target OctarineAssetPipelineTest`
- `./build/editor-debug/bin/debug/OctarineAssetPipelineTest.exe` → `Asset pipeline test: PASS` (all `[pak]` checks green, including byte-exact slice comparison for every fixture asset).

## Test plan
- [ ] Linux editor-release CI runs `OctarineAssetPipelineTest` — pak round-trip green
- [ ] Bake smoke (Stage 7) against `Octarine-Engine-Example` emits `asset_bundle.pak` alongside `asset_manifest.lua`
- [ ] Android AAB build: pak rides as a single `assets/asset_bundle.pak`, app boots, scenes load
- [ ] macOS package leg: shipped `.app` carries `asset_bundle.pak`, Gatekeeper-clean