### PR TITLE
Plumb meta.stream into SDL_mixer predecode toggle (Stage 14 B2)

### DIFF
--- a/src/AssetManager/AssetManager.cpp
+++ b/src/AssetManager/AssetManager.cpp
@@ -101,7 +101,7 @@ bool AssetManager::LoadFromCatalog(const CatalogEntry &entry, const std::string 
         Logger::Info("AssetManager::Acquire: audio disabled, skipping clip: " + assetId);
         return false;
       }
-      AddAudioClip(mixer, assetId, entry.fullPath);
+      AddAudioClip(mixer, assetId, entry.fullPath, entry.stream);
       return audio_clips_.contains(assetId);
   }
   return false;
@@ -247,7 +247,8 @@ void AssetManager::AddFont(const std::string &assetId, const std::string &path, 
   Logger::Info("Added font: " + assetId + " from path: " + fullPath);
 }
 
-void AssetManager::AddAudioClip(MIX_Mixer *mixer, const std::string &assetId, const std::string &path) {
+void AssetManager::AddAudioClip(MIX_Mixer *mixer, const std::string &assetId, const std::string &path,
+                                const bool stream) {
   if (!mixer) {
     Logger::Error("AddAudioClip called with null mixer for: " + assetId);
     return;
@@ -259,7 +260,10 @@ void AssetManager::AddAudioClip(MIX_Mixer *mixer, const std::string &assetId, co
     Logger::Error("Failed to open audio file " + assetId + " from " + fullPath + ": " + std::string(SDL_GetError()));
     return;
   }
-  MIX_Audio *clip = MIX_LoadAudio_IO(mixer, io, true, true);  // predecode + closes the stream
+  // predecode=true is the default for short SFX — full PCM in RAM at load time, lowest play-call
+  // latency. predecode=false (meta.stream=true on the source) keeps the file compressed and
+  // decodes on demand; pays back as flat memory for long-form music + ambient beds.
+  MIX_Audio *clip = MIX_LoadAudio_IO(mixer, io, !stream, true);  // closes the stream regardless
   if (!clip) {
     Logger::Error("Failed to load audio clip " + assetId + " from " + fullPath + ": " + std::string(SDL_GetError()));
     return;

--- a/src/AssetManager/AssetManager.h
+++ b/src/AssetManager/AssetManager.h
@@ -77,7 +77,11 @@ class AssetManager {
   [[nodiscard]] SDL_Texture* GetTexture(const std::string& assetId) const;
   void AddFont(const std::string& assetId, const std::string& path, float fontSize);
   [[nodiscard]] TTF_Font* GetFont(const std::string& assetId) const;
-  void AddAudioClip(MIX_Mixer* mixer, const std::string& assetId, const std::string& path);
+  // `stream` plumbs the catalog's `meta.stream` flag into SDL_mixer's predecode toggle: false for
+  // SFX (eager decode = predictable play latency), true for long music + ambient beds (lazy decode
+  // = decode-as-played, keeps the loading footprint flat at the cost of a touch more per-play cost).
+  void AddAudioClip(MIX_Mixer* mixer, const std::string& assetId, const std::string& path,
+                    bool stream = false);
   [[nodiscard]] MIX_Audio* GetAudioClip(const std::string& assetId) const;
   [[nodiscard]] std::string GetFullPath(const std::string& relativePath) const;
   void SetDefaultScaleMode(const std::string& scaleMode);

--- a/tests/AssetPipelineTest.cpp
+++ b/tests/AssetPipelineTest.cpp
@@ -101,8 +101,9 @@ int main()
         const bool ok = catalog.Build(ASSET_TEST_FIXTURE_DIR, lua, std::optional<ScaleMode>(ScaleMode::Nearest));
         Check(ok, "catalog build reports no id collisions");
 
-        // 3 textures (hero, boss, branding) + 3 fonts (main-16, title-12, title-24) + 1 audio (jump).
-        Check(catalog.Size() == 7, "catalog discovered 7 entries");
+        // 3 textures (hero, boss, branding) + 3 fonts (main-16, title-12, title-24) + 2 audio
+        // (jump default-decode, music meta.stream=true).
+        Check(catalog.Size() == 8, "catalog discovered 8 entries");
 
         const CatalogEntry* hero = catalog.Find("hero");
         Check(hero != nullptr && hero->type == AssetType::Texture, "hero is a texture");
@@ -120,6 +121,10 @@ int main()
         const CatalogEntry* jump = catalog.Find("jump");
         Check(jump != nullptr && jump->type == AssetType::Audio, "jump.wav is audio");
         Check(jump != nullptr && !jump->stream, "jump defaults to non-streaming");
+
+        const CatalogEntry* music = catalog.Find("music");
+        Check(music != nullptr && music->type == AssetType::Audio, "music.wav is audio");
+        Check(music != nullptr && music->stream, "music.wav meta.stream=true propagates to catalog");
     }
 
     std::cout << "[manifest] baked manifest matches the directory scan\n";

--- a/tests/fixtures/assets/sounds/music.wav
+++ b/tests/fixtures/assets/sounds/music.wav
@@ -1,0 +1,1 @@
+RIFF dummy

--- a/tests/fixtures/assets/sounds/music.wav.meta
+++ b/tests/fixtures/assets/sounds/music.wav.meta
@@ -1,0 +1,4 @@
+-- Sidecar for music.wav: long-form audio, decode lazily via SDL_mixer streaming.
+return {
+  stream = true,
+}


### PR DESCRIPTION
## Summary
- `MIX_LoadAudio_IO(mixer, io, predecode, closeio)` now flips its `predecode` argument from each catalog entry's `stream` flag. Short SFX (default) keep the full PCM in RAM at load time; long music + ambient beds tagged `meta.stream = true` decode on demand.
- The plumbing was already in the meta -> catalog -> manifest pipeline (`AudioMeta.stream`, `CatalogEntry.stream`, manifest serialization, AssetCatalog::WriteManifest); only the consumer (`AssetManager::AddAudioClip`) was hardcoded.
- Closes Stage 14 / track B2 (streaming half) of `ai/ShippingV1Plan.md`.

## Out of scope (deliberate)
- `meta.normalize` (loudness normalize at bake) — needs an ffmpeg host dep. Re-introducing the PATH/skip-warn anti-pattern just removed in Stage 10 is the wrong default; deferring until a vendored loudness path or a vcpkg ffmpeg port is in hand.

## Verified locally
- New fixture `tests/fixtures/assets/sounds/music.wav` + `music.wav.meta` (`stream = true`).
- `OctarineAssetPipelineTest` adds two checks: `music.wav is audio`, `music.wav meta.stream=true propagates to catalog`. Existing `jump defaults to non-streaming` still green.

## Test plan
- [ ] Linux editor-release CI runs `OctarineAssetPipelineTest` — `music` checks green