### PR TITLE
Add Run Player toolbar action backed by PlayerLauncher

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,7 @@ if (OCTARINE_WITH_EDITOR)
     list(APPEND SRC_FILES src/Editor/EditorPersistence.cpp)
     list(APPEND SRC_FILES src/Editor/EditorLayoutPresets.cpp)
     list(APPEND SRC_FILES src/Editor/Inspectors/RegisterAllInspectors.cpp)
+    list(APPEND SRC_FILES src/Editor/PlayerLauncher.cpp)
 endif ()
 
 if (UNIX AND NOT APPLE AND NOT ANDROID)
@@ -151,12 +152,21 @@ endif ()
 
 # Create the engine target. On Android, SDLActivity dlopens libmain.so and jumps to SDL_main, so the
 # engine must be that shared lib (OUTPUT_NAME main → libmain.so). Everywhere else it is a plain
-# executable.
+# executable. The desktop non-editor build renames its OUTPUT to `OctarineEngine-player` so the
+# editor (also `OctarineEngine`) and the player can coexist in the same dev tree — the editor
+# resolves the player binary by that fixed name when handling the Run Player toolbar action.
 if (ANDROID)
     add_library(${PROJECT_NAME} SHARED ${SRC_FILES})
     set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME main)
 else ()
     add_executable(${PROJECT_NAME} ${SRC_FILES})
+    # Dev player presets (player-debug / player-profile / player-release): rename the binary so
+    # `OctarineEngine` (editor) and `OctarineEngine-player` coexist in the same tree. Shipping
+    # configs (ship-release / packaging) keep the canonical `OctarineEngine` name — downstream
+    # packaging owns the shipped artifact's filename.
+    if (NOT OCTARINE_WITH_EDITOR AND NOT OCTARINE_SHIPPED)
+        set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME OctarineEngine-player)
+    endif ()
 endif ()
 
 # Set target properties

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -28,7 +28,7 @@ config_dir=relwithdebinfo
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "$script_dir/.." && pwd)"
 build_dir="$repo_root/build/$preset"
-binary="$build_dir/bin/$config_dir/OctarineEngine"
+binary="$build_dir/bin/$config_dir/OctarineEngine-player"
 
 game_path="${OCT_BENCH_GAME:-$repo_root/../Octarine-Engine-Example}"
 if [[ ! -d "$game_path" ]]; then

--- a/src/Editor/EditorPersistence.h
+++ b/src/Editor/EditorPersistence.h
@@ -43,12 +43,13 @@ struct EditorPersistence {
   bool showSceneManagement = false;
   bool showEngineOptions = true;
   bool showEditorSettings = true;
+  bool showPlayerOutput = false;
 
   // Single source of truth for persisted window-visibility flags. Both the project-prefs
   // serializer (EditorPersistence.cpp) and the layout-preset serializer (EditorLayoutPresets.cpp)
   // iterate this table, so a new window = one entry here.
   using FlagRef = std::pair<const char*, bool EditorPersistence::*>;
-  static constexpr std::array<FlagRef, 8> kWindowFlags = {{
+  static constexpr std::array<FlagRef, 9> kWindowFlags = {{
       {"showProfiler", &EditorPersistence::showProfiler},
       {"showHierarchy", &EditorPersistence::showHierarchy},
       {"showAssetBrowser", &EditorPersistence::showAssetBrowser},
@@ -57,6 +58,7 @@ struct EditorPersistence {
       {"showSceneManagement", &EditorPersistence::showSceneManagement},
       {"showEngineOptions", &EditorPersistence::showEngineOptions},
       {"showEditorSettings", &EditorPersistence::showEditorSettings},
+      {"showPlayerOutput", &EditorPersistence::showPlayerOutput},
   }};
 
   void LoadGlobal();

--- a/src/Editor/PlayerLauncher.cpp
+++ b/src/Editor/PlayerLauncher.cpp
@@ -1,0 +1,241 @@
+#include "Editor/PlayerLauncher.h"
+
+#ifdef OCTARINE_WITH_EDITOR
+
+#include "General/Logger.h"
+
+#include <SDL3/SDL_filesystem.h>
+
+#include <system_error>
+#include <utility>
+
+namespace octarine::editor
+{
+    namespace
+    {
+#ifdef _WIN32
+        constexpr const char* kPlayerExeName = "OctarineEngine-player.exe";
+#else
+        constexpr const char* kPlayerExeName = "OctarineEngine-player";
+#endif
+
+        bool FileExists(const std::filesystem::path& p)
+        {
+            std::error_code ec;
+            return std::filesystem::exists(p, ec) && !std::filesystem::is_directory(p, ec);
+        }
+    } // namespace
+
+    std::optional<std::filesystem::path> PlayerLauncher::ResolvePlayerBinary(const std::filesystem::path& editor_dir)
+    {
+        // Probe order matches plan recommendation: prefer a side-by-side install layout, then
+        // fall back to sibling dev presets. The first existing candidate wins.
+        //
+        // Editor exe lives at `<build>/<editor-preset>/bin/<config>/OctarineEngine[.exe]`. Player
+        // exe (renamed via CMakeLists.txt OUTPUT_NAME) lives at the mirror path under a sibling
+        // `player-*` preset dir with the matching `<config>` subdir.
+
+        // (1) Same directory (installed layout, or dev manually copied next to the editor).
+        {
+            std::filesystem::path candidate = editor_dir / kPlayerExeName;
+            if (FileExists(candidate))
+            {
+                return candidate;
+            }
+        }
+
+        // Compute `<build>` and the config-name string (e.g. "debug", "release") from the editor
+        // exe layout. The structure can be wrong (installed dropped editor in some other place);
+        // we just skip the sibling-preset probes if it doesn't look like a dev tree.
+        std::filesystem::path config_dir = editor_dir;            // ".../bin/debug"
+        std::filesystem::path bin_dir = config_dir.parent_path(); // ".../bin"
+        std::filesystem::path preset_dir = bin_dir.parent_path(); // ".../editor-debug"
+        std::filesystem::path build_dir = preset_dir.parent_path(); // ".../build"
+
+        if (config_dir.empty() || bin_dir.filename() != "bin" || build_dir.empty())
+        {
+            return std::nullopt;
+        }
+
+        const std::string config_name = config_dir.filename().string();
+
+        // (2) Sibling player-* presets in the same build dir. Try a matching-config preset first,
+        // then the others as a fallback.
+        const std::string_view candidates[] = {
+            "player-debug",
+            "player-release",
+            "player-profile",
+        };
+        for (const auto preset : candidates)
+        {
+            std::filesystem::path candidate =
+                build_dir / preset / "bin" / config_name / kPlayerExeName;
+            if (FileExists(candidate))
+            {
+                return candidate;
+            }
+        }
+        // Cross-config fallback: the matching config dir may not exist (e.g. editor built Debug,
+        // player built Release). Try the canonical config names.
+        const std::string_view configs[] = {"debug", "release", "relwithdebinfo", "minsizerel"};
+        for (const auto preset : candidates)
+        {
+            for (const auto cfg : configs)
+            {
+                std::filesystem::path candidate =
+                    build_dir / preset / "bin" / cfg / kPlayerExeName;
+                if (FileExists(candidate))
+                {
+                    return candidate;
+                }
+            }
+        }
+        return std::nullopt;
+    }
+
+    bool PlayerLauncher::Run(const std::filesystem::path& project_dir)
+    {
+        if (status_ == PlayerStatus::Running)
+        {
+            return true;
+        }
+
+        last_exit_code_.reset();
+        stdout_partial_.clear();
+        stderr_partial_.clear();
+
+        std::filesystem::path editor_dir;
+        if (const char* base = SDL_GetBasePath())
+        {
+            editor_dir = std::filesystem::path(base);
+        }
+        else
+        {
+            editor_dir = std::filesystem::current_path();
+        }
+
+        auto resolved = ResolvePlayerBinary(editor_dir);
+        if (!resolved)
+        {
+            AppendLine(true,
+                       "[player] cannot find OctarineEngine-player[.exe] beside the editor or under "
+                       "a sibling `player-*` preset. Build it with: "
+                       "cmake --preset player-debug && cmake --build build/player-debug");
+            status_ = PlayerStatus::FailedToLaunch;
+            return false;
+        }
+        resolved_binary_ = *resolved;
+
+        octarine::process::SpawnOptions opts;
+        opts.argv.push_back(resolved_binary_.string());
+        opts.argv.push_back(project_dir.string());
+
+        auto p = octarine::process::Process::Spawn(opts);
+        if (!p)
+        {
+            AppendLine(true, "[player] failed to spawn " + resolved_binary_.string());
+            status_ = PlayerStatus::FailedToLaunch;
+            return false;
+        }
+
+        p->OnStdout([this](std::string_view sv) { SplatChunk(sv, /*is_stderr=*/false); });
+        p->OnStderr([this](std::string_view sv) { SplatChunk(sv, /*is_stderr=*/true); });
+
+        process_ = std::move(p);
+        status_ = PlayerStatus::Running;
+        AppendLine(false, "[player] launched " + resolved_binary_.string() + " " + project_dir.string());
+        Logger::Info("PlayerLauncher: spawned " + resolved_binary_.string() + " for " + project_dir.string());
+        return true;
+    }
+
+    void PlayerLauncher::Stop()
+    {
+        if (status_ != PlayerStatus::Running || !process_)
+        {
+            return;
+        }
+        process_->Kill();
+        AppendLine(false, "[player] stop requested");
+    }
+
+    void PlayerLauncher::Pump()
+    {
+        if (!process_)
+        {
+            return;
+        }
+        const bool still_running = process_->Pump();
+        if (!still_running && status_ == PlayerStatus::Running)
+        {
+            FlushPartialLines();
+            last_exit_code_ = process_->ExitCode();
+            status_ = PlayerStatus::Exited;
+            const std::string code = last_exit_code_ ? std::to_string(*last_exit_code_) : std::string("?");
+            AppendLine(false, "[player] exited with code " + code);
+            process_.reset();
+        }
+    }
+
+    void PlayerLauncher::SplatChunk(std::string_view chunk, bool is_stderr)
+    {
+        std::string& partial = is_stderr ? stderr_partial_ : stdout_partial_;
+        partial.append(chunk);
+        std::size_t start = 0;
+        while (true)
+        {
+            const std::size_t nl = partial.find('\n', start);
+            if (nl == std::string::npos)
+            {
+                break;
+            }
+            std::string line(partial, start, nl - start);
+            if (!line.empty() && line.back() == '\r')
+            {
+                line.pop_back();
+            }
+            AppendLine(is_stderr, std::move(line));
+            start = nl + 1;
+        }
+        partial.erase(0, start);
+    }
+
+    void PlayerLauncher::FlushPartialLines()
+    {
+        if (!stdout_partial_.empty())
+        {
+            AppendLine(false, std::move(stdout_partial_));
+            stdout_partial_.clear();
+        }
+        if (!stderr_partial_.empty())
+        {
+            AppendLine(true, std::move(stderr_partial_));
+            stderr_partial_.clear();
+        }
+    }
+
+    void PlayerLauncher::AppendLine(bool is_stderr, std::string text)
+    {
+        if (log_.size() >= kLogCap)
+        {
+            log_.pop_front();
+            ++dropped_;
+        }
+        log_.push_back(PlayerLogLine{is_stderr, std::move(text)});
+    }
+
+    PlayerLauncher::LogSnapshot PlayerLauncher::LogCopy() const
+    {
+        LogSnapshot snap;
+        snap.total_dropped = dropped_;
+        snap.lines.assign(log_.begin(), log_.end());
+        return snap;
+    }
+
+    void PlayerLauncher::ClearLog()
+    {
+        log_.clear();
+        dropped_ = 0;
+    }
+} // namespace octarine::editor
+
+#endif // OCTARINE_WITH_EDITOR

--- a/src/Editor/PlayerLauncher.h
+++ b/src/Editor/PlayerLauncher.h
@@ -1,0 +1,100 @@
+#pragma once
+
+#ifdef OCTARINE_WITH_EDITOR
+
+// PlayerLauncher — Stage 3 of ai/EditorBuildAndDeployPlan.md.
+//
+// Owns the editor's spawned player subprocess. The Run Player toolbar action goes through here,
+// the per-frame Pump() call drains captured stdout/stderr into a ring-capped log buffer that the
+// Player Output window reads, and Stop() sends a terminate to the child.
+//
+// Lifetime: stored as a Registry singleton on the engine's Registry. Game::Setup constructs it
+// inside the OCTARINE_WITH_EDITOR-gated section; the destructor inherited from
+// octarine::process::Process kills any still-running child at shutdown.
+
+#include "Process/Process.h"
+
+#include <cstddef>
+#include <deque>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace octarine::editor
+{
+    enum class PlayerStatus
+    {
+        Idle,
+        Running,
+        Exited,
+        FailedToLaunch,
+    };
+
+    struct PlayerLogLine
+    {
+        bool is_stderr = false;
+        std::string text;
+    };
+
+    class PlayerLauncher
+    {
+    public:
+        // Resolves the player binary, spawns it pointed at `project_dir`, and starts capturing
+        // its stdout/stderr. Returns false when the binary cannot be located or `posix_spawn` /
+        // `CreateProcess` fails — both cases also push an explanatory line into the log buffer
+        // and flip status to FailedToLaunch. A no-op (returning true) when a player is already
+        // Running; v1 supports one concurrent player.
+        bool Run(const std::filesystem::path& project_dir);
+
+        // Terminates the running player if any. No-op when not Running.
+        void Stop();
+
+        // Drains the subprocess's captured stdout/stderr through the Process wrapper, splits the
+        // chunks into lines, and updates `status_` / `last_exit_code_` when the child exits.
+        // Cheap to call every frame; designed to live on the editor's main render path.
+        void Pump();
+
+        PlayerStatus Status() const { return status_; }
+        std::optional<int> LastExitCode() const { return last_exit_code_; }
+        const std::filesystem::path& ResolvedBinary() const { return resolved_binary_; }
+
+        struct LogSnapshot
+        {
+            std::vector<PlayerLogLine> lines;
+            std::size_t total_dropped = 0; // lines dropped because the ring buffer was full
+        };
+        LogSnapshot LogCopy() const;
+        void ClearLog();
+
+        // Probes the dev-tree layout (editor next to its build preset, player in a sibling preset
+        // dir) for `OctarineEngine-player[.exe]`. Public for unit testing — pass a synthetic
+        // editor dir + filesystem layout to exercise the candidates without spawning anything.
+        static std::optional<std::filesystem::path> ResolvePlayerBinary(const std::filesystem::path& editor_dir);
+
+    private:
+        static constexpr std::size_t kLogCap = 4096;
+
+        std::optional<octarine::process::Process> process_;
+        PlayerStatus status_ = PlayerStatus::Idle;
+        std::optional<int> last_exit_code_;
+        std::filesystem::path resolved_binary_;
+
+        // Per-stream line splitter state: process chunks are not line-aligned, so we buffer the
+        // tail until a '\n' arrives (or the process exits, at which point we flush).
+        std::string stdout_partial_;
+        std::string stderr_partial_;
+
+        // No mutex — Process callbacks run synchronously inside Pump() on the calling thread,
+        // so every append happens on the editor's main render thread.
+        std::deque<PlayerLogLine> log_;
+        std::size_t dropped_ = 0;
+
+        void SplatChunk(std::string_view chunk, bool is_stderr);
+        void AppendLine(bool is_stderr, std::string text);
+        void FlushPartialLines();
+    };
+} // namespace octarine::editor
+
+#endif // OCTARINE_WITH_EDITOR

--- a/src/Game/Game.cpp
+++ b/src/Game/Game.cpp
@@ -80,6 +80,7 @@
 #ifdef OCTARINE_WITH_EDITOR
 #include "../Editor/EditorLayoutPresets.h"
 #include "../Editor/EditorPersistence.h"
+#include "../Editor/PlayerLauncher.h"
 #include "../Editor/Inspectors/RegisterAllInspectors.h"
 #endif
 
@@ -220,6 +221,7 @@ bool Game::Initialize(const std::string& assetPath)
     registry_->Set<EditorPersistence>(EditorPersistence());
     auto& editorPersistence = registry_->Get<EditorPersistence>();
     editorPersistence.LoadGlobal();
+    registry_->Set<octarine::editor::PlayerLauncher>(octarine::editor::PlayerLauncher());
     if (effectivePath.empty())
     {
         effectivePath = editorPersistence.lastProjectPath;

--- a/src/Systems/RenderDebugGUISystem.cpp
+++ b/src/Systems/RenderDebugGUISystem.cpp
@@ -34,6 +34,7 @@
 #include "../Editor/EditorPersistence.h"
 #include "../Editor/Inspectors/ComponentInspectorRegistry.h"
 #include "../Editor/Inspectors/InspectorWidgets.h"
+#include "../Editor/PlayerLauncher.h"
 
 namespace
 {
@@ -87,6 +88,8 @@ const float deltaTime) {
   const bool projectLoaded = gameConfig.HasLoadedConfig();
 #ifdef OCTARINE_WITH_EDITOR
 auto& editorPersistence = registry->Get<EditorPersistence>();
+auto& playerLauncher = registry->Get<octarine::editor::PlayerLauncher>();
+playerLauncher.Pump();
 const bool editorSession = gameConfig.IsEditorMode() || !projectLoaded;
 const bool showEditorUI = editorSession;
 #endif
@@ -198,6 +201,7 @@ static bool openSaveLayoutModal = false;
             ImGui::MenuItem("Performance Profiler", nullptr, &editorPersistence.showProfiler);
             ImGui::MenuItem("Engine Options", nullptr, &editorPersistence.showEngineOptions);
             ImGui::MenuItem("Editor Settings", nullptr, &editorPersistence.showEditorSettings);
+            ImGui::MenuItem("Player Output", nullptr, &editorPersistence.showPlayerOutput);
             ImGui::MenuItem("Game Debug Overlays", "Grave", &engineOptions.showDebugGUI);
             ImGui::Separator();
             ImGui::MenuItem("FPS Counter", nullptr, &engineOptions.showFpsCounter);
@@ -258,6 +262,32 @@ static bool openSaveLayoutModal = false;
                     editorPersistence.masterVolume = engineOptions.masterVolume;
                     editorPersistence.SaveGlobal(); // persist immediately
                 }
+
+                ImGui::SameLine();
+                // Run Player / Stop Player: spawns the standalone OctarineEngine-player process
+                // pointed at the currently-loaded project. Separate from the embedded Play button
+                // above, which only resumes the in-editor scene.
+                {
+                    const bool playerRunning =
+                        playerLauncher.Status() == octarine::editor::PlayerStatus::Running;
+                    const bool canRun = projectLoaded || !registry->Get<AssetManager>().GetBasePath().empty();
+                    ImGui::BeginDisabled(!playerRunning && !canRun);
+                    if (ImGui::Button(playerRunning ? "Stop Player" : "Run Player"))
+                    {
+                        if (playerRunning)
+                        {
+                            playerLauncher.Stop();
+                        }
+                        else
+                        {
+                            // Player Output panel auto-opens so the dev sees launch / spawn errors.
+                            editorPersistence.showPlayerOutput = true;
+                            const std::string projectDir = registry->Get<AssetManager>().GetBasePath();
+                            playerLauncher.Run(std::filesystem::path(projectDir));
+                        }
+                    }
+                    ImGui::EndDisabled();
+                }
                 ImGui::EndMenuBar();
             }
         }
@@ -305,6 +335,8 @@ static bool openSaveLayoutModal = false;
         EngineOptionsWindow(engineOptions, &editorPersistence.showEngineOptions);
     if (editorPersistence.showEditorSettings)
         EditorSettingsWindow(editorPersistence, &editorPersistence.showEditorSettings);
+    if (editorPersistence.showPlayerOutput)
+        PlayerOutputWindow(game, &editorPersistence.showPlayerOutput);
 
     if (engineOptions.showImGuiDemoWindow)
     {
@@ -884,6 +916,87 @@ void RenderDebugGUISystem::LuaConsoleWindow(sol::state& lua)
         ImGui::SetKeyboardFocusHere(-1);
         reclaimFocus = false;
     }
+
+    ImGui::End();
+}
+
+void RenderDebugGUISystem::PlayerOutputWindow(Game* game, bool* p_open)
+{
+    auto& launcher = game->GetRegistry()->Get<octarine::editor::PlayerLauncher>();
+
+    ImGui::SetNextWindowSize(ImVec2(560, 400), ImGuiCond_FirstUseEver);
+    if (!ImGui::Begin("Player Output", p_open, ImGuiWindowFlags_NoScrollbar))
+    {
+        ImGui::End();
+        return;
+    }
+
+    const auto status = launcher.Status();
+    const char* statusText = "Idle";
+    ImVec4 statusColor = ImVec4(0.7F, 0.7F, 0.7F, 1.0F);
+    switch (status)
+    {
+    case octarine::editor::PlayerStatus::Running:
+        statusText = "Running";
+        statusColor = ImVec4(0.4F, 1.0F, 0.4F, 1.0F);
+        break;
+    case octarine::editor::PlayerStatus::Exited:
+        statusText = "Exited";
+        statusColor = ImVec4(1.0F, 1.0F, 0.4F, 1.0F);
+        break;
+    case octarine::editor::PlayerStatus::FailedToLaunch:
+        statusText = "Failed to launch";
+        statusColor = ImVec4(1.0F, 0.4F, 0.4F, 1.0F);
+        break;
+    case octarine::editor::PlayerStatus::Idle:
+    default:
+        break;
+    }
+    ImGui::TextDisabled("Status:");
+    ImGui::SameLine();
+    ImGui::TextColored(statusColor, "%s", statusText);
+    if (const auto code = launcher.LastExitCode())
+    {
+        ImGui::SameLine();
+        ImGui::TextDisabled("(exit %d)", *code);
+    }
+    if (!launcher.ResolvedBinary().empty())
+    {
+        ImGui::TextDisabled("Binary: %s", launcher.ResolvedBinary().string().c_str());
+    }
+
+    if (ImGui::Button("Clear"))
+    {
+        launcher.ClearLog();
+    }
+    ImGui::SameLine();
+    static bool autoScroll = true;
+    ImGui::Checkbox("Auto-scroll", &autoScroll);
+
+    ImGui::Separator();
+
+    ImGui::BeginChild("PlayerOutputScroll", ImVec2(0, 0), false, ImGuiWindowFlags_HorizontalScrollbar);
+    const auto snap = launcher.LogCopy();
+    if (snap.total_dropped > 0)
+    {
+        ImGui::TextDisabled("[older %zu lines dropped]", snap.total_dropped);
+    }
+    for (const auto& line : snap.lines)
+    {
+        if (line.is_stderr)
+        {
+            ImGui::TextColored(ImVec4(1.0F, 0.5F, 0.5F, 1.0F), "%s", line.text.c_str());
+        }
+        else
+        {
+            ImGui::TextUnformatted(line.text.c_str());
+        }
+    }
+    if (autoScroll && ImGui::GetScrollY() >= ImGui::GetScrollMaxY())
+    {
+        ImGui::SetScrollHereY(1.0F);
+    }
+    ImGui::EndChild();
 
     ImGui::End();
 }

--- a/src/Systems/RenderDebugGUISystem.h
+++ b/src/Systems/RenderDebugGUISystem.h
@@ -114,6 +114,7 @@ class RenderDebugGUISystem {
   static void SceneWindow(Game* game, SDL_Texture* gameTexture, bool* p_open);
   static void AssetBrowserWindow(Registry* registry);
   static void LuaConsoleWindow(sol::state& lua);
+  static void PlayerOutputWindow(Game* game, bool* p_open);
 #endif
   static void FPSWindow(float deltaTime);
   static void EntityInfoWindow(const Registry* registry);


### PR DESCRIPTION
## Summary
Stage 3 of `ai/EditorBuildAndDeployPlan.md`. Editor's playback toolbar gains a **Run Player / Stop Player** button that spawns the standalone `OctarineEngine-player` subprocess at the currently-loaded project. Player stdout/stderr stream into a new **Player Output** ImGui window with auto-scroll, status indicator, and per-line stdout/stderr coloring. Windows menu gains a *Player Output* toggle; `EditorPersistence::showPlayerOutput` persists with the existing layout-preset machinery.

`PlayerLauncher` is a Registry singleton constructed in `Game::Setup` right after `EditorPersistence`. The launcher resolves the player binary by probing same-dir first, then sibling `player-*` preset `bin/<config>` dirs; missing binary emits a hint pointing at `cmake --build --preset player-debug`. `Pump()` runs every frame from `RenderDebugGUISystem::Render` to drain captured output and transition Running -> Exited.

Dev player presets (`player-debug` / `player-profile` / `player-release`) now emit `OctarineEngine-player` so the editor and player coexist in the same dev tree; `ship-release` and the packaging path keep the canonical `OctarineEngine` name so downstream packaging owns the shipped binary's filename.

## Test plan
- [x] Local Windows: `cmake --preset editor-debug -DOCTARINE_ENABLE_TESTS=ON`, build, `ctest` → all 4 tests green (LuaApiSmokeTest, AssetPipelineTest, ProcessTest, ProjectIniTest).
- [x] Local Windows: `cmake --preset player-debug && cmake --build build/player-debug` produces `OctarineEngine-player.exe`.
- [ ] CI: build + ctest legs pass on the Linux editor-release runner; non-editor build legs produce renamed player binary.
- [ ] Interactive: launch editor, hit Run Player, confirm player window appears and Player Output captures its stdout; hit Stop Player and confirm process terminates.