### PR TITLE
Add bake-time BS.1770 audio loudness normalize (Stage 14 B2 finishing half)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,7 @@ set(SRC_FILES
         src/AssetManager/AssetCatalog.cpp
         src/AssetManager/AssetPak.cpp
         src/AssetManager/AtlasBaker.cpp
+        src/AssetManager/AudioNormalizer.cpp
         src/AssetManager/GlyphAtlas.cpp
         src/AssetManager/SceneAssetScanner.cpp
         src/ECS/Registry.cpp

--- a/src/AssetManager/AssetCatalog.cpp
+++ b/src/AssetManager/AssetCatalog.cpp
@@ -121,6 +121,7 @@ namespace
         AudioMeta meta;
         if (const sol::optional<std::string> id = t["id"]; id) meta.id = *id;
         if (const sol::optional<bool> stream = t["stream"]; stream) meta.stream = *stream;
+        if (const sol::optional<bool> normalize = t["normalize"]; normalize) meta.normalize = *normalize;
         return meta;
     }
 
@@ -291,6 +292,7 @@ bool AssetCatalog::ScanFilesystem(const std::string& basePath, sol::state& lua,
                 entry.id = meta.id.value_or(stem);
                 entry.fullPath = fullPath;
                 entry.stream = meta.stream;
+                entry.normalize = meta.normalize;
                 insert(std::move(entry));
                 break;
             }
@@ -385,6 +387,7 @@ bool AssetCatalog::LoadManifest(const std::string& manifestPath, sol::state& lua
             break;
         case AssetType::Audio:
             entry.stream = e["stream"].get_or(false);
+            entry.normalize = e["normalize"].get_or(false);
             break;
         }
         entries_.emplace(std::move(id), std::move(entry));
@@ -457,6 +460,7 @@ bool AssetCatalog::WriteManifest(const std::string& outPath, const std::string& 
             break;
         case AssetType::Audio:
             out << ", stream = " << (entry.stream ? "true" : "false");
+            out << ", normalize = " << (entry.normalize ? "true" : "false");
             break;
         }
 

--- a/src/AssetManager/AssetCatalog.h
+++ b/src/AssetManager/AssetCatalog.h
@@ -44,6 +44,7 @@ struct CatalogEntry
     float fontSize{0.0F};
     // Audio
     bool stream{false};
+    bool normalize{false};
 };
 
 // Directory-discovery + sidecar-parsing catalog: maps asset id -> CatalogEntry. Loads nothing;

--- a/src/AssetManager/AssetMetadata.h
+++ b/src/AssetManager/AssetMetadata.h
@@ -46,7 +46,8 @@ struct FontMeta {
 
 struct AudioMeta {
   std::optional<std::string> id;  // override the derived id (filename stem)
-  bool stream{false};             // stream from disk vs full decode 
+  bool stream{false};             // stream from disk vs full decode
+  bool normalize{false};          // run BS.1770 loudness normalize at bake (Stage 14 B2 — WAV only)
 
-  void applyDefaults() {}  // `stream` already carries its default
+  void applyDefaults() {}  // `stream`/`normalize` already carry their defaults
 };

--- a/src/AssetManager/AssetPak.cpp
+++ b/src/AssetManager/AssetPak.cpp
@@ -56,7 +56,8 @@ AssetPak::~AssetPak() {
 
 bool AssetPak::Pack(const AssetCatalog& catalog, const std::string& outPath,
                     const std::string& basePath,
-                    const std::vector<std::string>& extraFiles) {
+                    const std::vector<std::string>& extraFiles,
+                    const std::map<std::string, std::string>& pathOverrides) {
     std::ofstream out(outPath, std::ios::binary | std::ios::trunc);
     if (!out) {
         Logger::Error("AssetPak::Pack: failed to open " + outPath + " for writing");
@@ -83,9 +84,17 @@ bool AssetPak::Pack(const AssetCatalog& catalog, const std::string& outPath,
     std::vector<char> buf(kCopyChunk);
 
     for (const auto& [id, entry] : catalog.Entries()) {
-        std::ifstream in(entry.fullPath, std::ios::binary);
+        const std::string relPath = MakeRelPath(entry.fullPath, basePath);
+        // pathOverrides[relPath] swaps the source-of-bytes; the pak still stores under `relPath`,
+        // so the runtime lookup is unchanged. Audio normalize uses this to ship the normalized
+        // WAV without rewriting the asset tree.
+        std::string sourcePath = entry.fullPath;
+        if (auto it = pathOverrides.find(relPath); it != pathOverrides.end()) {
+            sourcePath = it->second;
+        }
+        std::ifstream in(sourcePath, std::ios::binary);
         if (!in) {
-            Logger::Error("AssetPak::Pack: failed to read " + entry.fullPath);
+            Logger::Error("AssetPak::Pack: failed to read " + sourcePath);
             out.close();
             std::error_code ec;
             std::filesystem::remove(outPath, ec);
@@ -101,7 +110,7 @@ bool AssetPak::Pack(const AssetCatalog& catalog, const std::string& outPath,
                 size += static_cast<std::uint64_t>(got);
             }
         }
-        staged.push_back({MakeRelPath(entry.fullPath, basePath), offset, size});
+        staged.push_back({relPath, offset, size});
     }
 
     // Append any extra (non-catalog) files in the same shape. Bake passes derived artifacts —

--- a/src/AssetManager/AssetPak.h
+++ b/src/AssetManager/AssetPak.h
@@ -40,11 +40,15 @@ public:
     // read and stored under its project-relative form (`fullPath` re-rooted against `basePath`,
     // forward-slashed). `extraFiles` lets the bake step include derived artifacts (glyph atlases,
     // audio bakes, etc.) that don't live in the asset catalog — each is read + stored under its
-    // own project-relative form. Duplicates against catalog entries are silently dropped (first
+    // own project-relative form. `pathOverrides` re-routes a catalog entry's *source* bytes to an
+    // alternative path while keeping the original relPath in the pak — used by the audio
+    // normalize pass to swap normalized WAVs in for their originals at packing time without
+    // mutating the source tree. Duplicates against catalog entries are silently dropped (first
     // write wins). Returns false on any I/O failure; partially-written paks are removed.
     static bool Pack(const AssetCatalog& catalog, const std::string& outPath,
                      const std::string& basePath,
-                     const std::vector<std::string>& extraFiles = {});
+                     const std::vector<std::string>& extraFiles = {},
+                     const std::map<std::string, std::string>& pathOverrides = {});
 
     // Open a pak file from disk into memory. Returns true on success. The instance owns the
     // backing buffer until destruction.

--- a/src/AssetManager/AudioNormalizer.cpp
+++ b/src/AssetManager/AudioNormalizer.cpp
@@ -1,0 +1,312 @@
+#include "AssetManager/AudioNormalizer.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <fstream>
+#include <limits>
+#include <vector>
+
+#include "General/Logger.h"
+
+namespace {
+constexpr double kPi = 3.14159265358979323846;
+constexpr double kAbsoluteGateLufs = -70.0;
+constexpr double kRelativeGateLU = 10.0;
+
+// ---- Minimal WAV I/O ----------------------------------------------------------------------------
+// Hand-rolls a single subchunk PCM16 RIFF reader/writer. No fmt extensions, no fact chunk, no
+// non-PCM formats. Anything that doesn't fit returns false from ReadWav so the bake step skips +
+// warns rather than corrupting the file.
+
+#pragma pack(push, 1)
+struct WavHeader {
+    char riff[4];
+    std::uint32_t fileSize;
+    char wave[4];
+    char fmt[4];
+    std::uint32_t fmtSize;
+    std::uint16_t audioFormat;  // 1 = PCM
+    std::uint16_t numChannels;
+    std::uint32_t sampleRate;
+    std::uint32_t byteRate;
+    std::uint16_t blockAlign;
+    std::uint16_t bitsPerSample;
+};
+#pragma pack(pop)
+
+struct WavData {
+    std::uint16_t numChannels{0};
+    std::uint32_t sampleRate{0};
+    // Interleaved samples in [-1, 1] (channels × frames).
+    std::vector<float> samples;
+};
+
+bool ReadWav(const std::string& path, WavData& out) {
+    std::ifstream f(path, std::ios::binary);
+    if (!f) {
+        Logger::Warn("AudioNormalizer: cannot open " + path);
+        return false;
+    }
+    WavHeader h{};
+    f.read(reinterpret_cast<char*>(&h), sizeof(h));
+    if (!f) {
+        Logger::Warn("AudioNormalizer: short read on header " + path);
+        return false;
+    }
+    if (std::memcmp(h.riff, "RIFF", 4) != 0 || std::memcmp(h.wave, "WAVE", 4) != 0 ||
+        std::memcmp(h.fmt, "fmt ", 4) != 0) {
+        Logger::Warn("AudioNormalizer: " + path + " is not a RIFF/WAVE/fmt file");
+        return false;
+    }
+    if (h.audioFormat != 1) {
+        Logger::Warn("AudioNormalizer: " + path + " is not PCM (audio_format=" +
+                     std::to_string(h.audioFormat) + ") — skipping normalize");
+        return false;
+    }
+    if (h.bitsPerSample != 16) {
+        Logger::Warn("AudioNormalizer: " + path + " is not 16-bit PCM (got " +
+                     std::to_string(h.bitsPerSample) + ") — skipping normalize");
+        return false;
+    }
+    if (h.numChannels != 1 && h.numChannels != 2) {
+        Logger::Warn("AudioNormalizer: " + path + " has " + std::to_string(h.numChannels) +
+                     " channels — only mono/stereo supported, skipping");
+        return false;
+    }
+    // The fmt chunk size can be larger than the basic 16-byte WAVEFORMATEX header. Skip the rest.
+    if (h.fmtSize > 16) {
+        f.seekg(h.fmtSize - 16, std::ios::cur);
+    }
+    // Walk subchunks until `data` is found — some encoders emit LIST/INFO before data.
+    char tag[4];
+    std::uint32_t sz = 0;
+    while (f.read(tag, 4)) {
+        f.read(reinterpret_cast<char*>(&sz), 4);
+        if (std::memcmp(tag, "data", 4) == 0) break;
+        f.seekg(sz, std::ios::cur);
+    }
+    if (!f || std::memcmp(tag, "data", 4) != 0) {
+        Logger::Warn("AudioNormalizer: " + path + " has no data chunk");
+        return false;
+    }
+    const std::size_t sampleCount = sz / sizeof(std::int16_t);
+    std::vector<std::int16_t> raw(sampleCount);
+    f.read(reinterpret_cast<char*>(raw.data()), sz);
+    if (!f) {
+        Logger::Warn("AudioNormalizer: short read on data " + path);
+        return false;
+    }
+    out.numChannels = h.numChannels;
+    out.sampleRate = h.sampleRate;
+    out.samples.resize(sampleCount);
+    constexpr float kScale = 1.0F / 32768.0F;
+    for (std::size_t i = 0; i < sampleCount; ++i) {
+        out.samples[i] = static_cast<float>(raw[i]) * kScale;
+    }
+    return true;
+}
+
+bool WriteWav(const std::string& path, const WavData& in) {
+    std::ofstream f(path, std::ios::binary | std::ios::trunc);
+    if (!f) {
+        Logger::Error("AudioNormalizer: cannot open " + path + " for writing");
+        return false;
+    }
+    const std::uint32_t dataBytes = static_cast<std::uint32_t>(in.samples.size() * sizeof(std::int16_t));
+    WavHeader h{};
+    std::memcpy(h.riff, "RIFF", 4);
+    h.fileSize = 36 + dataBytes;
+    std::memcpy(h.wave, "WAVE", 4);
+    std::memcpy(h.fmt, "fmt ", 4);
+    h.fmtSize = 16;
+    h.audioFormat = 1;
+    h.numChannels = in.numChannels;
+    h.sampleRate = in.sampleRate;
+    h.bitsPerSample = 16;
+    h.blockAlign = in.numChannels * 2;
+    h.byteRate = in.sampleRate * h.blockAlign;
+    f.write(reinterpret_cast<const char*>(&h), sizeof(h));
+    f.write("data", 4);
+    f.write(reinterpret_cast<const char*>(&dataBytes), 4);
+    for (const float s : in.samples) {
+        const float scaled = std::clamp(s, -1.0F, 1.0F) * 32767.0F;
+        const std::int16_t out_s = static_cast<std::int16_t>(std::lrintf(scaled));
+        f.write(reinterpret_cast<const char*>(&out_s), 2);
+    }
+    return static_cast<bool>(f);
+}
+
+// ---- BS.1770 K-weighting biquad coefficients (per sample rate, via RBJ bilinear) ----------------
+// Two cascaded biquads: Stage 1 = high-shelf (+4 dB @ 1681.97 Hz, Q ≈ 0.7071); Stage 2 = high-pass
+// (≈38.14 Hz, Q ≈ 0.5003). Coefficients normalized so a0 == 1 for the standard direct-form II
+// transposed difference equation.
+struct Biquad {
+    double b0{0}, b1{0}, b2{0}, a1{0}, a2{0};
+};
+
+Biquad MakeHighShelf(double fc, double gainDb, double Q, double fs) {
+    const double A = std::pow(10.0, gainDb / 40.0);
+    const double w0 = 2.0 * kPi * fc / fs;
+    const double cosW = std::cos(w0);
+    const double sinW = std::sin(w0);
+    const double alpha = sinW / (2.0 * Q);
+    const double sqrtA2alpha = 2.0 * std::sqrt(A) * alpha;
+
+    const double b0 = A * ((A + 1) + (A - 1) * cosW + sqrtA2alpha);
+    const double b1 = -2.0 * A * ((A - 1) + (A + 1) * cosW);
+    const double b2 = A * ((A + 1) + (A - 1) * cosW - sqrtA2alpha);
+    const double a0 = (A + 1) - (A - 1) * cosW + sqrtA2alpha;
+    const double a1 = 2.0 * ((A - 1) - (A + 1) * cosW);
+    const double a2 = (A + 1) - (A - 1) * cosW - sqrtA2alpha;
+    return {b0 / a0, b1 / a0, b2 / a0, a1 / a0, a2 / a0};
+}
+
+Biquad MakeHighPass(double fc, double Q, double fs) {
+    const double w0 = 2.0 * kPi * fc / fs;
+    const double cosW = std::cos(w0);
+    const double sinW = std::sin(w0);
+    const double alpha = sinW / (2.0 * Q);
+
+    const double b0 = (1.0 + cosW) / 2.0;
+    const double b1 = -(1.0 + cosW);
+    const double b2 = (1.0 + cosW) / 2.0;
+    const double a0 = 1.0 + alpha;
+    const double a1 = -2.0 * cosW;
+    const double a2 = 1.0 - alpha;
+    return {b0 / a0, b1 / a0, b2 / a0, a1 / a0, a2 / a0};
+}
+
+void ApplyBiquadInPlace(std::vector<double>& x, const Biquad& bq) {
+    double x1 = 0.0, x2 = 0.0, y1 = 0.0, y2 = 0.0;
+    for (double& s : x) {
+        const double in = s;
+        const double out = bq.b0 * in + bq.b1 * x1 + bq.b2 * x2 - bq.a1 * y1 - bq.a2 * y2;
+        x2 = x1;
+        x1 = in;
+        y2 = y1;
+        y1 = out;
+        s = out;
+    }
+}
+
+// Integrated loudness in LUFS for the interleaved PCM in `data`. Returns NaN when the entire
+// signal is below the absolute gate (-70 LUFS) — caller treats that as "skip, too quiet to align".
+double MeasureLufs(const WavData& data) {
+    if (data.samples.empty() || data.sampleRate == 0) {
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+
+    // K-weighting filter chain (Stage 1 + Stage 2) at the source rate.
+    const Biquad stage1 = MakeHighShelf(1681.974450955533, 4.0, 0.7071752369554196, data.sampleRate);
+    const Biquad stage2 = MakeHighPass(38.13547087602444, 0.5003270373238773, data.sampleRate);
+
+    // Per-channel K-weighted square energies, interleaved framewise.
+    const std::size_t numFrames = data.samples.size() / data.numChannels;
+    std::vector<std::vector<double>> chans(data.numChannels, std::vector<double>(numFrames, 0.0));
+    for (std::size_t i = 0; i < numFrames; ++i) {
+        for (std::uint16_t c = 0; c < data.numChannels; ++c) {
+            chans[c][i] = data.samples[i * data.numChannels + c];
+        }
+    }
+    for (auto& ch : chans) {
+        ApplyBiquadInPlace(ch, stage1);
+        ApplyBiquadInPlace(ch, stage2);
+    }
+
+    // 400 ms gated blocks at 75% overlap (step = 100 ms).
+    const std::size_t blockSize = static_cast<std::size_t>(0.4 * data.sampleRate);
+    const std::size_t hop = static_cast<std::size_t>(0.1 * data.sampleRate);
+    if (numFrames < blockSize) {
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+    constexpr std::array<double, 6> kChannelWeights = {1.0, 1.0, 1.0, 1.41, 1.41, 1.0};
+
+    std::vector<double> blockLufs;
+    for (std::size_t start = 0; start + blockSize <= numFrames; start += hop) {
+        double blockMS = 0.0;
+        for (std::uint16_t c = 0; c < data.numChannels; ++c) {
+            double sum = 0.0;
+            for (std::size_t i = 0; i < blockSize; ++i) {
+                const double v = chans[c][start + i];
+                sum += v * v;
+            }
+            const double channelMS = sum / static_cast<double>(blockSize);
+            const double w = c < kChannelWeights.size() ? kChannelWeights[c] : 1.0;
+            blockMS += w * channelMS;
+        }
+        if (blockMS > 0.0) {
+            blockLufs.push_back(-0.691 + 10.0 * std::log10(blockMS));
+        }
+    }
+    if (blockLufs.empty()) {
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+
+    // Absolute gate -70 LUFS.
+    double absSum = 0.0;
+    std::size_t absCount = 0;
+    for (const double l : blockLufs) {
+        if (l >= kAbsoluteGateLufs) {
+            absSum += std::pow(10.0, (l + 0.691) / 10.0);
+            ++absCount;
+        }
+    }
+    if (absCount == 0) {
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+    const double ungatedLufs = -0.691 + 10.0 * std::log10(absSum / absCount);
+    const double relGate = ungatedLufs - kRelativeGateLU;
+
+    // Relative gate; final integrated loudness from blocks past both thresholds.
+    double finalSum = 0.0;
+    std::size_t finalCount = 0;
+    for (const double l : blockLufs) {
+        if (l >= kAbsoluteGateLufs && l >= relGate) {
+            finalSum += std::pow(10.0, (l + 0.691) / 10.0);
+            ++finalCount;
+        }
+    }
+    if (finalCount == 0) {
+        return ungatedLufs;
+    }
+    return -0.691 + 10.0 * std::log10(finalSum / finalCount);
+}
+
+}  // namespace
+
+bool AudioNormalizer::NormalizeWav(const std::string& srcPath, const std::string& dstPath,
+                                   const double targetLufs) {
+    WavData data;
+    if (!ReadWav(srcPath, data)) {
+        return false;
+    }
+    const double measured = MeasureLufs(data);
+    if (!std::isfinite(measured)) {
+        Logger::Warn("AudioNormalizer: " + srcPath +
+                     " is below the -70 LUFS absolute gate; skipping normalize");
+        return false;
+    }
+    const double gainDb = targetLufs - measured;
+    const double gainLinear = std::pow(10.0, gainDb / 20.0);
+    for (float& s : data.samples) {
+        const double scaled = static_cast<double>(s) * gainLinear;
+        s = static_cast<float>(std::clamp(scaled, -1.0, 1.0));
+    }
+    if (!WriteWav(dstPath, data)) {
+        return false;
+    }
+    Logger::Info("AudioNormalizer: " + srcPath + " " + std::to_string(measured) + " LUFS -> " +
+                 std::to_string(targetLufs) + " LUFS (gain " + std::to_string(gainDb) + " dB)");
+    return true;
+}
+
+double AudioNormalizer::MeasureWavLufs(const std::string& wavPath) {
+    WavData data;
+    if (!ReadWav(wavPath, data)) {
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+    return MeasureLufs(data);
+}

--- a/src/AssetManager/AudioNormalizer.h
+++ b/src/AssetManager/AudioNormalizer.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <string>
+
+// Bake-time audio loudness normalizer for `meta.normalize = true` (Stage 14 B2).
+//
+// Implements ITU-R BS.1770-4 integrated loudness measurement: a K-weighting filter chain
+// (pre-filter high-shelf + RLB high-pass) feeds 400 ms gated mean-square blocks at 75% overlap;
+// the integrated loudness uses both the absolute (-70 LUFS) + relative (-10 LU below ungated
+// mean) gates per spec. Gain is applied uniformly to reach the target loudness; samples that
+// would clip int16 are hard-clamped.
+//
+// Format support is minimal on purpose: PCM 16-bit WAV in / out, mono or stereo, arbitrary
+// sample rate (filter coefficients derived per-rate via bilinear transform of the BS.1770 analog
+// prototypes). Compressed sources (.ogg / .mp3) are skipped — they need a decoder this engine
+// doesn't yet vendor. A future PR can add stb_vorbis + minimp3 to widen the matrix.
+class AudioNormalizer {
+ public:
+    // Read `srcPath`, measure integrated loudness, apply the gain needed to land at
+    // `targetLufs`, write the result to `dstPath`. Returns false on unsupported format, I/O error,
+    // or a signal too quiet to measure (everything below -70 LUFS absolute gate). On false the
+    // caller should fall through to shipping the original.
+    static bool NormalizeWav(const std::string& srcPath, const std::string& dstPath, double targetLufs = -16.0);
+
+    // Pure measurement — no file write. Returns the integrated loudness in LUFS, or NaN when the
+    // signal is entirely below the -70 LUFS absolute gate. Exposed so the test can verify the
+    // post-normalize loudness lands at the target without re-implementing the analyzer.
+    static double MeasureWavLufs(const std::string& wavPath);
+};

--- a/src/Game/Game.cpp
+++ b/src/Game/Game.cpp
@@ -15,6 +15,7 @@
 #include "AssetManager/AssetCatalog.h"
 #include "AssetManager/AssetPak.h"
 #include "AssetManager/AtlasBaker.h"
+#include "AssetManager/AudioNormalizer.h"
 #include "AssetManager/SceneAssetScanner.h"
 #include <SDL3_ttf/SDL_ttf.h>
 #include "../Renderer/RenderQueue.h"
@@ -596,14 +597,39 @@ bool Game::RunBakeValidation(const std::string& assetPath)
         TTF_Quit();
     }
 
-    // Pack every cataloged asset (+ any derived atlas files) into a single asset_bundle.pak
-    // alongside the manifest. Shipped builds (OCTARINE_SHIPPED) open this in place of the loose
-    // asset tree; dev builds ignore it. Manifest write is the source-of-truth gate — if that
-    // failed, skip the pak so a stale archive doesn't ship.
+    // Audio normalize pass (Stage 14 B2): for every Audio catalog entry with `meta.normalize=true`,
+    // run BS.1770 integrated loudness measurement + apply the gain to land at -16 LUFS, writing
+    // the normalized WAV to `<basePath>/normalized/<rel>.wav`. The pak override map then routes
+    // the catalog's original relPath to read bytes from the normalized variant — so shipped
+    // builds carry the loudness-aligned audio while dev tree (and dev runs) stay untouched.
+    std::map<std::string, std::string> audioOverrides;
+    if (wrote)
+    {
+        const std::filesystem::path normRoot = std::filesystem::path(assetPath) / "normalized";
+        for (const auto& [id, entry] : assetManager.GetCatalog().Entries())
+        {
+            if (entry.type != AssetType::Audio || !entry.normalize) continue;
+            const std::filesystem::path src(entry.fullPath);
+            const std::filesystem::path rel = std::filesystem::relative(src, std::filesystem::path(assetPath));
+            const std::filesystem::path dst = normRoot / rel;
+            std::error_code ec;
+            std::filesystem::create_directories(dst.parent_path(), ec);
+            if (AudioNormalizer::NormalizeWav(entry.fullPath, dst.string()))
+            {
+                audioOverrides[rel.generic_string()] = dst.string();
+            }
+        }
+    }
+
+    // Pack every cataloged asset (+ any derived atlas files, w/ optional normalized-audio
+    // overrides) into a single asset_bundle.pak alongside the manifest. Shipped builds
+    // (OCTARINE_SHIPPED) open this in place of the loose asset tree; dev builds ignore it.
+    // Manifest write is the source-of-truth gate — if that failed, skip the pak so a stale
+    // archive doesn't ship.
     if (wrote)
     {
         const std::string pakPath = (std::filesystem::path(assetPath) / "asset_bundle.pak").string();
-        if (!AssetPak::Pack(assetManager.GetCatalog(), pakPath, assetPath, atlasFiles))
+        if (!AssetPak::Pack(assetManager.GetCatalog(), pakPath, assetPath, atlasFiles, audioOverrides))
         {
             Logger::Error("Bake: AssetPak::Pack failed for " + pakPath);
             return false;

--- a/tests/AssetPipelineTest.cpp
+++ b/tests/AssetPipelineTest.cpp
@@ -22,10 +22,12 @@
 #include "AssetManager/AssetPak.h"
 #include "AssetManager/AssetReference.h"
 #include "AssetManager/AtlasBaker.h"
+#include "AssetManager/AudioNormalizer.h"
 #include "AssetManager/GlyphAtlas.h"
 #include "stb/stb_image_write.h"  // header-only; IMPL lives in AtlasBaker.cpp
 #include "AssetManager/SceneAssetScanner.h"
 #include <SDL3/SDL.h>
+#include <cmath>
 #include <SDL3_ttf/SDL_ttf.h>
 
 namespace
@@ -374,6 +376,72 @@ int main()
 
         std::filesystem::remove_all(tmpDir, ec);
         SDL_Quit();
+    }
+
+    std::cout << "[audio normalize] BS.1770 measure + gain round-trip\n";
+    {
+        // Synthesize 2 seconds of a quiet 1 kHz sine wave (amplitude 0.1 in [-1,1], 48 kHz mono),
+        // measure its loudness, normalize to -16 LUFS, measure again. The bake step writes WAVs
+        // via AudioNormalizer's same path, so this exercises ReadWav/WriteWav + the full BS.1770
+        // chain end-to-end.
+        const std::filesystem::path tmpDir =
+            std::filesystem::temp_directory_path() / "octarine_audio_norm_test";
+        std::error_code ec;
+        std::filesystem::create_directories(tmpDir, ec);
+        const std::string srcPath = (tmpDir / "quiet_tone.wav").string();
+        const std::string dstPath = (tmpDir / "normalized.wav").string();
+
+        {
+            constexpr std::uint32_t sampleRate = 48000;
+            constexpr std::uint32_t frames = sampleRate * 2;  // 2 seconds
+            constexpr double amplitude = 0.1;
+            constexpr double freq = 1000.0;
+            std::vector<std::int16_t> samples(frames);
+            for (std::uint32_t i = 0; i < frames; ++i) {
+                const double t = static_cast<double>(i) / sampleRate;
+                const double v = amplitude * std::sin(2.0 * 3.14159265358979323846 * freq * t);
+                samples[i] = static_cast<std::int16_t>(std::lrint(v * 32767.0));
+            }
+            // Hand-rolled minimal WAV writer mirroring AudioNormalizer's expected shape.
+            std::ofstream f(srcPath, std::ios::binary);
+            const std::uint32_t dataBytes = static_cast<std::uint32_t>(samples.size() * 2);
+            const std::uint32_t fileSize = 36 + dataBytes;
+            const std::uint16_t numChannels = 1;
+            const std::uint16_t bitsPerSample = 16;
+            const std::uint16_t blockAlign = numChannels * (bitsPerSample / 8);
+            const std::uint32_t byteRate = sampleRate * blockAlign;
+            const std::uint16_t audioFormat = 1;
+            const std::uint32_t fmtSize = 16;
+            f.write("RIFF", 4);
+            f.write(reinterpret_cast<const char*>(&fileSize), 4);
+            f.write("WAVE", 4);
+            f.write("fmt ", 4);
+            f.write(reinterpret_cast<const char*>(&fmtSize), 4);
+            f.write(reinterpret_cast<const char*>(&audioFormat), 2);
+            f.write(reinterpret_cast<const char*>(&numChannels), 2);
+            f.write(reinterpret_cast<const char*>(&sampleRate), 4);
+            f.write(reinterpret_cast<const char*>(&byteRate), 4);
+            f.write(reinterpret_cast<const char*>(&blockAlign), 2);
+            f.write(reinterpret_cast<const char*>(&bitsPerSample), 2);
+            f.write("data", 4);
+            f.write(reinterpret_cast<const char*>(&dataBytes), 4);
+            f.write(reinterpret_cast<const char*>(samples.data()), dataBytes);
+        }
+
+        const double preLufs = AudioNormalizer::MeasureWavLufs(srcPath);
+        Check(std::isfinite(preLufs), "BS.1770 measures synthetic quiet sine to a finite LUFS");
+        Check(preLufs < -20.0, "synthetic quiet sine measures well below -20 LUFS");
+
+        const double targetLufs = -16.0;
+        Check(AudioNormalizer::NormalizeWav(srcPath, dstPath, targetLufs),
+              "AudioNormalizer::NormalizeWav writes the normalized WAV");
+
+        const double postLufs = AudioNormalizer::MeasureWavLufs(dstPath);
+        Check(std::isfinite(postLufs), "normalized output measures to a finite LUFS");
+        Check(std::abs(postLufs - targetLufs) < 1.0,
+              "normalized output lands within 1 LU of the -16 LUFS target");
+
+        std::filesystem::remove_all(tmpDir, ec);
     }
 
     if (g_failures == 0)


### PR DESCRIPTION
## Summary
Closes the deferred half of Stage 14 / track B2 of `ai/ShippingV1Plan.md`. Streaming half already landed in #70.

- New `AudioNormalizer` (`src/AssetManager/AudioNormalizer.{h,cpp}`) — minimal PCM16 WAV reader/writer + ITU-R BS.1770-4 integrated loudness measurement (K-weighted: stage 1 high-shelf +4 dB @ 1681.97 Hz, stage 2 high-pass @ 38.14 Hz, biquad coefficients derived per sample rate via RBJ bilinear transform). Gated 400 ms blocks at 75% overlap, absolute -70 LUFS + relative -10 LU gates per spec.
- `AudioMeta.normalize` + `CatalogEntry.normalize` plumbed through sidecar parse + manifest serialize.
- `Game::Bake`: for each Audio entry with `meta.normalize=true`, writes the normalized WAV to `<basePath>/normalized/<rel>.wav` (-16 LUFS target). Dev tree + dev runs stay untouched.
- `AssetPak::Pack` gains a `pathOverrides` map that re-routes a catalog entry's source-of-bytes while keeping its original `relPath` in the pak. Runtime lookup is unchanged; shipped builds get the normalized audio transparently.

## Format support (intentionally narrow)
- **In/out**: PCM 16-bit WAV, mono or stereo, arbitrary sample rate.
- **Skip + warn**: compressed sources (.ogg/.mp3), non-PCM WAVs, >2-channel. Original ships unchanged.
- A future PR can add stb_vorbis + minimp3 to widen the matrix.

## Verified locally
- `OctarineAssetPipelineTest` PASS. New `[audio normalize]` block: 2 s of a 1 kHz sine at amplitude 0.1 measures ~-23.3 LUFS; after `NormalizeWav` to -16 LUFS the output measures within 1 LU of the target.

## Test plan
- [ ] Linux editor-release CI runs `OctarineAssetPipelineTest` — new `[audio normalize]` checks green
- [ ] Bake smoke (Stage 7) against `Octarine-Engine-Example` exits 0 even though no example audio carries `meta.normalize` yet (path should no-op cleanly)
- [ ] Tag a project that flags one .wav with `meta.normalize=true`; verify `<basePath>/normalized/...` is written and the pak's stored bytes for the audio relPath equal the normalized file