### PR TITLE
Drop ai/ plan references and fix doc accuracy bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ New here? Start with [`docs/QUICKSTART.md`](docs/QUICKSTART.md) — the shortest
 
 Octarine Engine itself is MIT-licensed (see [`LICENSE`](LICENSE)). Every shipped package
 (desktop ZIP/TGZ/DMG, Android AAB) ships a build-time-aggregated
-`THIRD_PARTY_LICENSES.txt` covering every linked dependency. The aggregator and shipping
-contract live in [`ai/LicenseShippingPlan.md`](ai/LicenseShippingPlan.md).
+`THIRD_PARTY_LICENSES.txt` covering every linked dependency. Aggregation lives in
+[`cmake/octarine-licenses.cmake`](cmake/octarine-licenses.cmake).
 
 Portions of this software are copyright © The FreeType Project (www.freetype.org). All rights
 reserved. FreeType is used under the terms of the FreeType License (FTL); see the bundled
@@ -74,6 +74,10 @@ cmake --build --preset player-profile
 ```
 
 The compiled binaries will be located in `build/[preset-name]/bin/`.
+
+For producing shippable artifacts (Windows ZIP/NSIS, Linux TGZ, macOS DMG, Android APK/AAB)
+see [`docs/device-builds.md`](docs/device-builds.md). Shipping config is the `ship-release`
+preset (and `ship-mac-universal` for universal macOS).
 
 ### Running the Engine
 

--- a/docs/device-builds.md
+++ b/docs/device-builds.md
@@ -2,7 +2,7 @@
 
 End-to-end reference for producing shippable artifacts on every platform Octarine
 targets: Windows, Linux, macOS (per-arch and universal), and Android (APK + AAB).
-(iOS work is parked on `defer/ios` — see `ai/iOSDeferralPlan.md`.)
+(iOS work is parked on the `defer/ios` branch.)
 
 This document covers:
 
@@ -264,9 +264,9 @@ so non-tag pushes, PRs, and pre-account state skip without failing the leg.
 Both `macos` and `macos-universal` legs notarize.
 
 Migrating to **App Store Connect API key** auth (`AuthKey_*.p8` — no
-annual rotation) is queued as Stage 9 of `ai/ShippingV1Plan.md`. Notarytool
-accepts either `--apple-id`/`--password` or `--key`/`--key-id`/`--issuer`,
-so the swap is one script edit when the key is generated.
+annual rotation) is a queued follow-up. Notarytool accepts either
+`--apple-id`/`--password` or `--key`/`--key-id`/`--issuer`, so the swap is
+one script edit when the key is generated.
 
 ### NSIS installer (Windows, opt-in)
 
@@ -492,9 +492,8 @@ traits from `__cpp_noexcept_function_type` and breaks differently.
 iOS build target (`ship-ios-*` presets, `_octarine_setup_ios_bundle`,
 `scripts/build-ios-ipa.sh`, `os_log` sink, `.github/workflows/ios*.yml`,
 the `Settings.bundle` license pointer) is parked on the `defer/ios` branch
-pending an Apple Developer account. Reattachment recipe in
-`ai/iOSDeferralPlan.md`; snapshot tag `ios-snapshot-2026-05-29` points at
-the last known-good commit.
+pending an Apple Developer account. Snapshot tag `ios-snapshot-2026-05-29`
+points at the last known-good commit.
 
 ---
 
@@ -705,7 +704,7 @@ Tag push fires two workflows:
   when the keystore secrets aren't wired).
 
 Drop the shipping artifacts into Steam / Play Store once distribution
-automation lands (see `ai/DeviceShippingPlan.md` § Stage 6).
+automation lands.
 
 ---
 
@@ -722,8 +721,3 @@ automation lands (see `ai/DeviceShippingPlan.md` § Stage 6).
 | Manifest load gate               | `AssetCatalog::Build` (`allowManifest` parameter)     |
 | `project.ini` parsers            | `OctarinePackage.cmake` `octarine_read_project_ini`, `build.gradle` `identityProp` |
 | Logger sink selection            | `src/General/Logger.cpp` (`android_logger` / stdout)  |
-
-For the historical plan and the rationale behind each stage, see
-`ai/AssetPipelineAndDeviceBuildsPlan.md` (closed) and
-`ai/DeviceShippingPlan.md` (active — distribution work picking up where
-the asset pipeline left off).

--- a/docs/lua-scripting.md
+++ b/docs/lua-scripting.md
@@ -2,7 +2,7 @@
 
 Octarine Engine is designed to be driven by Lua scripts. This guide explains how to structure your game project and use the engine's Lua API.
 
-For a complete working example, refer to the `Octarine-Engine-Example-main/` directory in the repository.
+For a complete working example, refer to the sibling `Octarine-Engine-Example/` directory.
 
 ---
 
@@ -151,20 +151,21 @@ Polling, action map, and callbacks. Action bindings + callbacks are cleared on `
 
 ## 6. ImGui Integration
 
-The engine exposes ImGui to Lua, allowing you to create debug tools and UI directly in script:
+The engine exposes ImGui to Lua, allowing you to create debug tools and UI directly in script.
+Wire it via the `script` component's `on_debug_gui` callback:
 
 ```lua
-function on_debug_gui(self, entity)
-    if ImGui.Begin("Tools") then
-        if ImGui.Button("Spawn Enemy") then
-            -- Logic to spawn an enemy
+script = {
+    on_debug_gui = function(self, entity)
+        if ImGui.Begin("Tools") then
+            if ImGui.Button("Spawn Enemy") then
+                -- Logic to spawn an enemy
+            end
         end
+        ImGui.End()
     end
-    ImGui.End()
-end
+}
 ```
-
-To use this, add the `on_debug_gui` function to a `script` component.
 
 ---
 
@@ -174,4 +175,4 @@ The engine looks for specific functions in your scripts:
 
 - `on_update(self, entity, delta_time)`: Called every frame.
 - `on_debug_gui(self, entity)`: Called during the ImGui rendering pass.
-- `on_click(self, entity)`: Called if the entity has a `button` component and is clicked.
+- `on_click(self, entity)`: Called if the entity has a `ui_button` component and is clicked.


### PR DESCRIPTION
## Summary

- Strip all `ai/*Plan.md` references from tracked docs. The `ai/` directory is local-only design-plan scratch (gitignored), so tracked docs should not point at it.
- Replace `ai/LicenseShippingPlan.md` pointer with the real aggregator at `cmake/octarine-licenses.cmake`. Drop four more `ai/` references in `docs/device-builds.md` (iOS deferral, ShippingV1 stage 9, DeviceShipping stage 6, AssetPipelineAndDeviceBuilds historical pointer) — inline what was load-bearing, drop the rest.
- Fix three correctness bugs in `docs/lua-scripting.md`:
  - Example dir name: `Octarine-Engine-Example-main/` → `Octarine-Engine-Example/` (real sibling dir name).
  - ImGui example: was a top-level `function on_debug_gui(...)` then narrated as a `script` component callback. Moved into a `script = { on_debug_gui = ... }` block.
  - `on_click` was documented against a `button` component; real component is `ui_button`.
- `README.md`: add a shipping pointer to `docs/device-builds.md` so dev-only build instructions are not misread as shipping guidance.

## Test plan

- [x] git grep -E 'ai/' -- '*.md' returns no tracked-doc hits.
- [x] All replaced links resolve to files that exist on main.
- [ ] Spot-check rendered Markdown on the PR diff.