### PR TITLE
Drop ai/ plan references from tracked sources

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -99,8 +99,7 @@ jobs:
 
       # Decode the release keystore on demand. Secrets are not available to fork PRs (so HAS_KEYSTORE
       # stays empty there), in which case bundleRelease falls back to the debug key — still a useful
-      # build-passes signal. Pinned secret names mirror the Stage 1 contract in
-      # ai/DeviceShippingPlan.md.
+      # build-passes signal.
       - name: Decode release keystore
         id: keystore
         if: env.OCTARINE_ANDROID_KEYSTORE != ''

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -55,7 +55,7 @@ jobs:
           # supports per-arch port builds + auto-lipo, or (b) we vendor a `multi_arch` overlay
           # that builds each port per-arch + lipo'es the final outputs. Until then, the
           # ship-mac-universal preset stays in tree for local opt-in builds; CI just doesn't
-          # exercise it. See ai/ShippingV1Plan.md note + ai/DeviceShippingPlan.md stage 5.
+          # exercise it.
 
     steps:
       - name: Checkout engine
@@ -129,7 +129,7 @@ jobs:
       # pre-account state skip cleanly). Bootstrap an ephemeral keychain, import the Developer
       # ID Application cert, then hand off to scripts/octarine-macos-notarize.sh which mounts
       # the cpack-produced .dmg, signs the .app, submits to notarytool, staples, and rebuilds
-      # the .dmg as the shipping artifact. See ai/ShippingV1Plan.md Stage 4.
+      # the .dmg as the shipping artifact.
       - name: Bootstrap macOS signing keychain
         if: |
           startsWith(matrix.platform, 'macos')

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,8 +61,7 @@ if (ANDROID)
     set(OCTARINE_SHIPPED ON CACHE BOOL "Forced ON on Android (manifest-load, no FS scan)" FORCE)
 endif ()
 
-# iOS build target is parked on the defer/ios branch pending an Apple Developer account; see
-# ai/iOSDeferralPlan.md.
+# iOS build target is parked on the defer/ios branch pending an Apple Developer account.
 
 if (OCTARINE_WITH_EDITOR)
     set(OCTARINE_WITH_IMGUI ON CACHE BOOL "Forced ON by Editor" FORCE)

--- a/cmake/OctarinePackage.cmake
+++ b/cmake/OctarinePackage.cmake
@@ -136,7 +136,7 @@ function(_octarine_validate_identity PROJECT_DIR PKG_NAME PKG_ID PKG_VER SHIPPED
 endfunction()
 
 # iOS bundle helper, orientation/permission Info.plist mappers, and Settings.bundle wiring are
-# parked on the defer/ios branch pending an Apple Developer account; see ai/iOSDeferralPlan.md.
+# parked on the defer/ios branch pending an Apple Developer account.
 
 # Generate per-OS icon files (.ico/.icns/.png) under ${OUT_DIR}/desktop. Sets ${ICO_VAR},
 # ${ICNS_VAR}, ${PNG_VAR} in the caller's scope to the conventional output paths (callers test

--- a/scripts/octarine-icons.cmake
+++ b/scripts/octarine-icons.cmake
@@ -35,7 +35,7 @@
 #     values-v31/octarine_splash.xml           (overrides AppTheme w/ splash attrs on API 31+)
 #   desktop/
 #     (iOS Assets.xcassets/AppIcon.appiconset + LaunchScreen.storyboard emitter is parked on
-#     defer/ios pending an Apple Developer account; see ai/iOSDeferralPlan.md.)
+#     defer/ios pending an Apple Developer account.)
 #     octarine_icon.ico                        (Windows; multi-resolution embed)
 #     octarine_icon.icns                       (macOS; magick writes the .icns directly)
 #     octarine_icon.png                        (Linux; 256×256 PNG for .desktop)

--- a/src/AssetManager/AtlasBaker.h
+++ b/src/AssetManager/AtlasBaker.h
@@ -23,6 +23,6 @@ class AtlasBaker {
 
   // Default ASCII printable set (codepoints 32..126). Suitable for most western UIs; projects with
   // accented Latin or non-Latin scripts will eventually want an explicit list via meta.glyphs (not
-  // yet plumbed — see Stage 14 B3 in ai/ShippingV1Plan.md).
+  // yet plumbed).
   static std::vector<std::uint32_t> DefaultAsciiPrintable();
 };

--- a/src/Editor/PlayerLauncher.h
+++ b/src/Editor/PlayerLauncher.h
@@ -2,7 +2,7 @@
 
 #ifdef OCTARINE_WITH_EDITOR
 
-// PlayerLauncher — Stage 3 of ai/EditorBuildAndDeployPlan.md.
+// PlayerLauncher.
 //
 // Owns the editor's spawned player subprocess. The Run Player toolbar action goes through here,
 // the per-frame Pump() call drains captured stdout/stderr into a ring-capped log buffer that the

--- a/src/General/Logger.cpp
+++ b/src/General/Logger.cpp
@@ -11,8 +11,7 @@
 #include <spdlog/sinks/stdout_color_sinks.h>
 #endif
 
-// iOS os_log sink is parked on the defer/ios branch pending an Apple Developer account; see
-// ai/iOSDeferralPlan.md.
+// iOS os_log sink is parked on the defer/ios branch pending an Apple Developer account.
 
 std::shared_ptr<spdlog::logger> Logger::lua_logger_;
 std::vector<std::string> Logger::history_;


### PR DESCRIPTION
## Summary

Tracked code, config, and workflow comments should not point at the local-only `ai/` design-plan directory (gitignored, agent scratchpad). Follow-up to #80, which scrubbed `docs/`. Strips the `see ai/X.md` tails from 9 comment blocks across:

- `CMakeLists.txt`
- `cmake/OctarinePackage.cmake`
- `scripts/octarine-icons.cmake`
- `.github/workflows/android.yml`
- `.github/workflows/package.yml`
- `src/AssetManager/AtlasBaker.h`
- `src/Editor/PlayerLauncher.h`
- `src/General/Logger.cpp`

Comment-only changes; no behavior change.

After merge, `git grep ai/` returns zero hits in tracked files.

## Test plan

- [x] `git grep -nE '\bai/'` returns no hits on the branch.
- [ ] CI passes (comment-only edits; should be a no-op).