### PR TITLE
Add 2D spatial audio (Sound plan Phase 3)

### DIFF
--- a/components.json
+++ b/components.json
@@ -8,6 +8,12 @@
       "get_accessor": "registry.get_animation"
     },
     {
+      "lua_key": "audio_listener",
+      "usertype": "audio_listener_component",
+      "has_accessor": "registry.has_audio_listener",
+      "get_accessor": "registry.get_audio_listener"
+    },
+    {
       "lua_key": "audio_source",
       "usertype": "audio_source_component",
       "has_accessor": "registry.has_audio_source",

--- a/lua_api.smoke.lua
+++ b/lua_api.smoke.lua
@@ -592,6 +592,10 @@ function acquire_scene_assets(...) end
 animation_component = {}
 
 
+---@class audio_listener_component
+audio_listener_component = {}
+
+
 ---@class audio_source_component
 audio_source_component = {}
 
@@ -715,6 +719,8 @@ registry = {}
 
 function registry.get_animation(...) end
 
+function registry.get_audio_listener(...) end
+
 function registry.get_audio_source(...) end
 
 function registry.get_box_collider(...) end
@@ -748,6 +754,8 @@ function registry.get_text_label(...) end
 function registry.get_ui_button(...) end
 
 function registry.has_animation(...) end
+
+function registry.has_audio_listener(...) end
 
 function registry.has_audio_source(...) end
 

--- a/src/Components/AudioListenerComponent.h
+++ b/src/Components/AudioListenerComponent.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <glm/glm.hpp>
+
+#include "ECS/Entity.h"
+
+struct AudioListenerComponent {
+  float maxDistance = 1000.0f;
+  float rolloff = 1.0f;
+
+  AudioListenerComponent() = default;
+  explicit AudioListenerComponent(float t_maxDistance, float t_rolloff = 1.0f)
+      : maxDistance(t_maxDistance), rolloff(t_rolloff) {}
+};
+
+// Singleton cache populated each frame by UpdateListenerTransformSystem and read by
+// SpatialAudioSystem. Decouples spatial-audio math from the listener-entity query so the
+// per-emitter callback can short-circuit without re-iterating archetypes. `valid` flips to
+// false when no listener entity exists; emitters skip spatial logic in that case.
+struct AudioListenerCache {
+  Entity entity{};
+  glm::vec2 position{0.0f, 0.0f};
+  glm::vec2 forward{0.0f, 1.0f};
+  glm::vec2 right{1.0f, 0.0f};
+  float maxDistance = 1000.0f;
+  float rolloff = 1.0f;
+  bool valid = false;
+};

--- a/src/Components/AudioSinkComponent.h
+++ b/src/Components/AudioSinkComponent.h
@@ -9,6 +9,16 @@ struct AudioSinkComponent {
   std::uint32_t generation = 0;
   bool finished = false;
 
+  // Cached state for SpatialAudioSystem + DopplerSystem so they only call MIX_Set* when
+  // the computed value changed. Initial sentinels (lastGain < 0, lastPan outside [-1, 1],
+  // lastRatio < 0) force the first frame to apply regardless. `stereoApplied` separately
+  // tracks whether MIX_SetTrackStereo has a non-null override currently set; flipping a
+  // source from spatial→non-spatial calls MIX_SetTrackStereo(nullptr) once and clears it.
+  float lastGain = -1.0f;
+  float lastPan = 2.0f;
+  float lastRatio = -1.0f;
+  bool stereoApplied = false;
+
   AudioSinkComponent() = default;
   AudioSinkComponent(MIX_Track* t_track, std::uint32_t t_generation) : track(t_track), generation(t_generation) {}
 };

--- a/src/Components/AudioSourceComponent.h
+++ b/src/Components/AudioSourceComponent.h
@@ -10,12 +10,23 @@ struct AudioSourceComponent {
   bool playOnSpawn = true;
   bool despawnOnFinish = false;
 
+  // Phase 3 spatial: when `spatial` is true, SpatialAudioSystem mutates the track's gain +
+  // stereo pan each frame from the listener/emitter geometry. Non-spatial sources keep the
+  // raw `volume` from AudioSystem and ignore the spatial system.
+  bool spatial = false;
+  float minDistance = 50.0f;
+  float maxDistance = 1000.0f;
+
   explicit AudioSourceComponent(std::string t_clipId = "", float t_volume = 1.0f, float t_pitch = 1.0f,
-                                bool t_loop = false, bool t_playOnSpawn = true, bool t_despawnOnFinish = false)
+                                bool t_loop = false, bool t_playOnSpawn = true, bool t_despawnOnFinish = false,
+                                bool t_spatial = false, float t_minDistance = 50.0f, float t_maxDistance = 1000.0f)
       : clipId(std::move(t_clipId)),
         volume(t_volume),
         pitch(t_pitch),
         loop(t_loop),
         playOnSpawn(t_playOnSpawn),
-        despawnOnFinish(t_despawnOnFinish) {}
+        despawnOnFinish(t_despawnOnFinish),
+        spatial(t_spatial),
+        minDistance(t_minDistance),
+        maxDistance(t_maxDistance) {}
 };

--- a/src/Game/Game.cpp
+++ b/src/Game/Game.cpp
@@ -45,6 +45,7 @@
 #include "Lua/LuaApiManifest.h"
 #include "Lua/LuaEntityLoader.h"
 #include "Lua/Modules/RegisterAllModules.h"
+#include "Components/AudioListenerComponent.h"
 #include "Systems/AnimationSystem.h"
 #include "Systems/AudioSystem.h"
 #include "Systems/CameraFollowSystem.h"
@@ -61,8 +62,10 @@
 #include "Systems/RenderSpriteSystem.h"
 #include "Systems/RenderTextSystem.h"
 #include "Systems/ScriptSystem.h"
+#include "Systems/SpatialAudioSystem.h"
 #include "Systems/TransformSystem.h"
 #include "Systems/UIButtonSystem.h"
+#include "Systems/UpdateListenerTransformSystem.h"
 #include "Systems/VelocityIntegrationSystem.h"
 
 #ifdef OCTARINE_WITH_IMGUI
@@ -735,6 +738,14 @@ void Game::Setup()
 
     // Collision reads transform.globalPosition / globalScale — must run after TransformSystem.
     registry_->RegisterBulkSystem(CollisionSystem());
+
+    // Spatial audio: snapshot the listener entity (UpdateListenerTransformSystem) then mutate
+    // gain + stereo pan on live spatial tracks (SpatialAudioSystem). Both must run AFTER
+    // TransformSystem so emitter + listener globals are this-frame values; AudioSystem (above)
+    // is the one that creates the AudioSinkComponent's MIX_Track that these mutate.
+    registry_->Set<AudioListenerCache>(AudioListenerCache{});
+    registry_->RegisterBulkSystem<GlobalTransformComponent>(UpdateListenerTransformSystem());
+    registry_->RegisterSystem<GlobalTransformComponent, AudioSourceComponent, AudioSinkComponent>(SpatialAudioSystem());
 
     // Camera follows after gameplay-driven transform updates
     registry_->RegisterSystem<PositionComponent, CameraFollowComponent>(CameraFollowSystem());

--- a/src/Lua/Bindings/AudioListenerComponentLuaBinding.h
+++ b/src/Lua/Bindings/AudioListenerComponentLuaBinding.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <sol/sol.hpp>
+
+#include "Components/AudioListenerComponent.h"
+#include "Lua/Bindings/LuaBinding.h"
+
+template <>
+struct LuaBinding<AudioListenerComponent>
+{
+    static constexpr const char* kLuaKey = "audio_listener";
+    static constexpr const char* kUsertypeName = "audio_listener_component";
+
+    static AudioListenerComponent fromLua(const sol::object& data)
+    {
+        using namespace LuaComponentHelpers;
+        if (!data.is<sol::table>()) return {};
+        const auto t = data.as<sol::table>();
+        const float maxDistance = SafeGetOptionalValue<float>(t, "max_distance", 1000.0f);
+        const float rolloff = SafeGetOptionalValue<float>(t, "rolloff", 1.0f);
+        return AudioListenerComponent(maxDistance, rolloff);
+    }
+
+    static void bindUsertype(sol::state& lua)
+    {
+        lua.new_usertype<AudioListenerComponent>(kUsertypeName,
+                                                 "max_distance", &AudioListenerComponent::maxDistance,
+                                                 "rolloff", &AudioListenerComponent::rolloff);
+    }
+};

--- a/src/Lua/Bindings/AudioSourceComponentLuaBinding.h
+++ b/src/Lua/Bindings/AudioSourceComponentLuaBinding.h
@@ -21,7 +21,11 @@ struct LuaBinding<AudioSourceComponent>
         const bool loop = SafeGetOptionalValue<bool>(t, "loop", false);
         const bool playOnSpawn = SafeGetOptionalValue<bool>(t, "play_on_spawn", true);
         const bool despawnOnFinish = SafeGetOptionalValue<bool>(t, "despawn_on_finish", false);
-        return AudioSourceComponent(clipId, volume, pitch, loop, playOnSpawn, despawnOnFinish);
+        const bool spatial = SafeGetOptionalValue<bool>(t, "spatial", false);
+        const float minDistance = SafeGetOptionalValue<float>(t, "min_distance", 50.0f);
+        const float maxDistance = SafeGetOptionalValue<float>(t, "max_distance", 1000.0f);
+        return AudioSourceComponent(clipId, volume, pitch, loop, playOnSpawn, despawnOnFinish, spatial, minDistance,
+                                    maxDistance);
     }
 
     static void bindUsertype(sol::state& lua)
@@ -32,6 +36,9 @@ struct LuaBinding<AudioSourceComponent>
                                                "pitch", &AudioSourceComponent::pitch,
                                                "loop", &AudioSourceComponent::loop,
                                                "play_on_spawn", &AudioSourceComponent::playOnSpawn,
-                                               "despawn_on_finish", &AudioSourceComponent::despawnOnFinish);
+                                               "despawn_on_finish", &AudioSourceComponent::despawnOnFinish,
+                                               "spatial", &AudioSourceComponent::spatial,
+                                               "min_distance", &AudioSourceComponent::minDistance,
+                                               "max_distance", &AudioSourceComponent::maxDistance);
     }
 };

--- a/src/Lua/Bindings/RegisterAllBindings.cpp
+++ b/src/Lua/Bindings/RegisterAllBindings.cpp
@@ -1,6 +1,7 @@
 #include "Lua/Bindings/RegisterAllBindings.h"
 
 #include "Lua/Bindings/AnimationComponentLuaBinding.h"
+#include "Lua/Bindings/AudioListenerComponentLuaBinding.h"
 #include "Lua/Bindings/AudioSourceComponentLuaBinding.h"
 #include "Lua/Bindings/BoxColliderComponentLuaBinding.h"
 #include "Lua/Bindings/CameraFollowComponentLuaBinding.h"
@@ -33,6 +34,7 @@ void RegisterAllLuaBindings()
     LuaComponentRegistry::registerComponent<UIButtonComponent>();
     LuaComponentRegistry::registerComponent<TextLabelComponent>();
     LuaComponentRegistry::registerComponent<AudioSourceComponent>();
+    LuaComponentRegistry::registerComponent<AudioListenerComponent>();
     LuaComponentRegistry::registerComponent<NameComponent>();
     LuaComponentRegistry::registerComponent<ScaleComponent>();
     LuaComponentRegistry::registerComponent<PositionComponent>();

--- a/src/Systems/SpatialAudioSystem.h
+++ b/src/Systems/SpatialAudioSystem.h
@@ -18,20 +18,34 @@
 // — register both AFTER TransformSystem so emitter/listener positions are this-frame
 // globals. Non-spatial sources are skipped entirely; their gain stays at whatever
 // AudioSystem set from `source.volume`.
+//
+// Cache pointer is hoisted to a member so the per-emitter callback does not hit
+// Registry::Get<AudioListenerCache>() (typeid-keyed map lookup) on every call. The
+// AudioListenerCache singleton is Set once during Game::Setup and never reseated, so
+// the pointer is stable for the registry's lifetime.
 class SpatialAudioSystem {
  public:
   void operator()(const ContextFacade& ctx, const GlobalTransformComponent& transform, AudioSourceComponent& source,
                   AudioSinkComponent& sink) {
     if (sink.finished || !sink.track) return;
 
-    auto* registry = ctx.GetRegistry();
-    const auto& cache = registry->Get<AudioListenerCache>();
+    if (!cache_) cache_ = &ctx.GetRegistry()->Get<AudioListenerCache>();
+    const auto& cache = *cache_;
 
     if (!source.spatial || !cache.valid) {
-      // Source isn't (or no longer is) spatial: clear any prior stereo override and let
-      // the gain reflect raw source.volume so toggling `spatial` at runtime resets cleanly.
-      MIX_SetTrackStereo(sink.track, nullptr);
-      MIX_SetTrackGain(sink.track, std::max(0.0f, source.volume));
+      // Source isn't (or no longer is) spatial: clear any prior stereo override once on
+      // the transition and let the gain reflect raw source.volume. Subsequent frames
+      // skip both calls when nothing changed.
+      if (sink.stereoApplied) {
+        MIX_SetTrackStereo(sink.track, nullptr);
+        sink.stereoApplied = false;
+        sink.lastPan = 2.0f;
+      }
+      const float gain = std::max(0.0f, source.volume);
+      if (gain != sink.lastGain) {
+        MIX_SetTrackGain(sink.track, gain);
+        sink.lastGain = gain;
+      }
       return;
     }
 
@@ -54,7 +68,10 @@ class SpatialAudioSystem {
     }
 
     const float gain = baseVolume * std::clamp(attenuation, 0.0f, 1.0f);
-    MIX_SetTrackGain(sink.track, gain);
+    if (gain != sink.lastGain) {
+      MIX_SetTrackGain(sink.track, gain);
+      sink.lastGain = gain;
+    }
 
     // Pan: project the listener→emitter vector onto the listener's right axis. Center
     // (distance ≈ 0) → equal L/R. Past `maxDist`, gain is already zero so the pan stays
@@ -66,9 +83,16 @@ class SpatialAudioSystem {
       pan = std::clamp(rightDot / distance, -1.0f, 1.0f);
     }
 
-    MIX_StereoGains gains{};
-    gains.left = std::clamp(1.0f - pan, 0.0f, 1.0f);
-    gains.right = std::clamp(1.0f + pan, 0.0f, 1.0f);
-    MIX_SetTrackStereo(sink.track, &gains);
+    if (!sink.stereoApplied || pan != sink.lastPan) {
+      MIX_StereoGains gains{};
+      gains.left = std::clamp(1.0f - pan, 0.0f, 1.0f);
+      gains.right = std::clamp(1.0f + pan, 0.0f, 1.0f);
+      MIX_SetTrackStereo(sink.track, &gains);
+      sink.stereoApplied = true;
+      sink.lastPan = pan;
+    }
   }
+
+ private:
+  const AudioListenerCache* cache_ = nullptr;
 };

--- a/src/Systems/SpatialAudioSystem.h
+++ b/src/Systems/SpatialAudioSystem.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <SDL3_mixer/SDL_mixer.h>
+
+#include <algorithm>
+#include <cmath>
+#include <glm/glm.hpp>
+
+#include "../Components/AudioListenerComponent.h"
+#include "../Components/AudioSinkComponent.h"
+#include "../Components/AudioSourceComponent.h"
+#include "../Components/GlobalTransformComponent.h"
+#include "../ECS/Iterable.h"
+#include "../ECS/Registry.h"
+
+// Per-emitter system: applies distance attenuation + stereo pan to spatial sources each
+// frame. Reads the AudioListenerCache singleton populated by UpdateListenerTransformSystem
+// — register both AFTER TransformSystem so emitter/listener positions are this-frame
+// globals. Non-spatial sources are skipped entirely; their gain stays at whatever
+// AudioSystem set from `source.volume`.
+class SpatialAudioSystem {
+ public:
+  void operator()(const ContextFacade& ctx, const GlobalTransformComponent& transform, AudioSourceComponent& source,
+                  AudioSinkComponent& sink) {
+    if (sink.finished || !sink.track) return;
+
+    auto* registry = ctx.GetRegistry();
+    const auto& cache = registry->Get<AudioListenerCache>();
+
+    if (!source.spatial || !cache.valid) {
+      // Source isn't (or no longer is) spatial: clear any prior stereo override and let
+      // the gain reflect raw source.volume so toggling `spatial` at runtime resets cleanly.
+      MIX_SetTrackStereo(sink.track, nullptr);
+      MIX_SetTrackGain(sink.track, std::max(0.0f, source.volume));
+      return;
+    }
+
+    const glm::vec2 rel = transform.position - cache.position;
+    const float distance = glm::length(rel);
+
+    const float baseVolume = std::max(0.0f, source.volume);
+    const float minDist = std::max(0.0f, source.minDistance);
+    const float maxDist = std::max(minDist + 1e-3f, source.maxDistance);
+    const float rolloff = std::max(0.0f, cache.rolloff);
+
+    float attenuation;
+    if (distance <= minDist) {
+      attenuation = 1.0f;
+    } else if (distance >= maxDist) {
+      attenuation = 0.0f;
+    } else {
+      const float t = (distance - minDist) / (maxDist - minDist);
+      attenuation = 1.0f / (1.0f + rolloff * t);
+    }
+
+    const float gain = baseVolume * std::clamp(attenuation, 0.0f, 1.0f);
+    MIX_SetTrackGain(sink.track, gain);
+
+    // Pan: project the listener→emitter vector onto the listener's right axis. Center
+    // (distance ≈ 0) → equal L/R. Past `maxDist`, gain is already zero so the pan stays
+    // applied but inaudible — no extra check needed.
+    constexpr float kEpsilon = 1e-4f;
+    float pan = 0.0f;
+    if (distance > kEpsilon) {
+      const float rightDot = glm::dot(rel, cache.right);
+      pan = std::clamp(rightDot / distance, -1.0f, 1.0f);
+    }
+
+    MIX_StereoGains gains{};
+    gains.left = std::clamp(1.0f - pan, 0.0f, 1.0f);
+    gains.right = std::clamp(1.0f + pan, 0.0f, 1.0f);
+    MIX_SetTrackStereo(sink.track, &gains);
+  }
+};

--- a/src/Systems/UpdateListenerTransformSystem.h
+++ b/src/Systems/UpdateListenerTransformSystem.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <glm/glm.hpp>
+
+#include "../Components/AudioListenerComponent.h"
+#include "../Components/GlobalTransformComponent.h"
+#include "../ECS/Iterable.h"
+#include "../ECS/Query.h"
+#include "../ECS/Registry.h"
+#include "../General/Logger.h"
+
+// Bulk system: snapshots the (first) AudioListenerComponent entity each frame into the
+// AudioListenerCache singleton on the Registry. Runs after TransformSystem so the cached
+// position reflects this frame's resolved global transform. SpatialAudioSystem reads the
+// cache once per emitter — no second archetype walk for the listener.
+class UpdateListenerTransformSystem {
+ public:
+  void operator()(const ContextFacade& ctx, const Iterable& /*iter*/) {
+    auto* registry = ctx.GetRegistry();
+    auto& cache = registry->Get<AudioListenerCache>();
+    cache.valid = false;
+    cache.entity = Entity{};
+
+    if (!query_) {
+      query_ = registry->CreateQuery<GlobalTransformComponent, AudioListenerComponent>();
+    }
+    query_->Update();
+
+    bool found = false;
+    int listenerCount = 0;
+    query_->ForEach([&](const Entity entity, const GlobalTransformComponent& transform,
+                        const AudioListenerComponent& listener) {
+      ++listenerCount;
+      if (found) return;
+      cache.entity = entity;
+      cache.position = transform.position;
+      // 2D top-down basis. When camera rotation lands later, derive forward/right from
+      // the camera's world rotation here so the spatial math stays decoupled from any
+      // listener-entity rotation (the "Listener Dilemma" decoupling).
+      cache.forward = glm::vec2(0.0f, 1.0f);
+      cache.right = glm::vec2(1.0f, 0.0f);
+      cache.maxDistance = listener.maxDistance;
+      cache.rolloff = listener.rolloff;
+      cache.valid = true;
+      found = true;
+    });
+
+    if (listenerCount > 1 && !warnedMultipleListeners_) {
+      Logger::Warn("UpdateListenerTransformSystem: " + std::to_string(listenerCount) +
+                   " AudioListenerComponent entities found; using the first one.");
+      warnedMultipleListeners_ = true;
+    }
+  }
+
+ private:
+  std::unique_ptr<ComponentQuery<GlobalTransformComponent, AudioListenerComponent>> query_;
+  bool warnedMultipleListeners_ = false;
+};


### PR DESCRIPTION
## Summary
- Introduces `AudioListenerComponent` + `AudioListenerCache` singleton; per-frame snapshot via `UpdateListenerTransformSystem` (bulk, runs after `TransformSystem`).
- Adds `SpatialAudioSystem` (per-emitter): distance attenuation `1/(1 + rolloff * t)` with `min/maxDistance` clamp, stereo pan via `MIX_SetTrackStereo`.
- Extends `AudioSourceComponent` with `spatial`, `minDistance`, `maxDistance`; Lua factory + usertype updated. Non-spatial sources unchanged.

Stage 3 of [ai/SoundPlan.md](../blob/main/ai/SoundPlan.md). Listener basis is fixed to world axes for 2D top-down — camera-rotation decoupling is additive when scenes gain rotated cameras (cache already splits position from forward/right).

## Test plan
- [ ] Lua scene with one `audio_listener` + one looping `audio_source` `spatial = true`. Move emitter past listener; verify volume tapers and pan sweeps L→R.
- [ ] Toggle `spatial = false` at runtime; verify gain resets to `source.volume` and stereo override clears.
- [ ] Confirm existing non-spatial event-driven `play_sound` + looping music sources behave unchanged.