### PR TITLE
Add Export Build toolbar action backed by ExportBuilder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,7 @@ if (OCTARINE_WITH_EDITOR)
     list(APPEND SRC_FILES src/Editor/EditorLayoutPresets.cpp)
     list(APPEND SRC_FILES src/Editor/Inspectors/RegisterAllInspectors.cpp)
     list(APPEND SRC_FILES src/Editor/PlayerLauncher.cpp)
+    list(APPEND SRC_FILES src/Editor/ExportBuilder.cpp)
 endif ()
 
 if (UNIX AND NOT APPLE AND NOT ANDROID)

--- a/src/Editor/EditorPersistence.h
+++ b/src/Editor/EditorPersistence.h
@@ -44,12 +44,13 @@ struct EditorPersistence {
   bool showEngineOptions = true;
   bool showEditorSettings = true;
   bool showPlayerOutput = false;
+  bool showExportOutput = false;
 
   // Single source of truth for persisted window-visibility flags. Both the project-prefs
   // serializer (EditorPersistence.cpp) and the layout-preset serializer (EditorLayoutPresets.cpp)
   // iterate this table, so a new window = one entry here.
   using FlagRef = std::pair<const char*, bool EditorPersistence::*>;
-  static constexpr std::array<FlagRef, 9> kWindowFlags = {{
+  static constexpr std::array<FlagRef, 10> kWindowFlags = {{
       {"showProfiler", &EditorPersistence::showProfiler},
       {"showHierarchy", &EditorPersistence::showHierarchy},
       {"showAssetBrowser", &EditorPersistence::showAssetBrowser},
@@ -59,6 +60,7 @@ struct EditorPersistence {
       {"showEngineOptions", &EditorPersistence::showEngineOptions},
       {"showEditorSettings", &EditorPersistence::showEditorSettings},
       {"showPlayerOutput", &EditorPersistence::showPlayerOutput},
+      {"showExportOutput", &EditorPersistence::showExportOutput},
   }};
 
   void LoadGlobal();

--- a/src/Editor/ExportBuilder.cpp
+++ b/src/Editor/ExportBuilder.cpp
@@ -1,0 +1,236 @@
+#include "Editor/ExportBuilder.h"
+
+#ifdef OCTARINE_WITH_EDITOR
+
+#include "General/Logger.h"
+#include "Project/ProjectIni.h"
+
+#include <system_error>
+#include <utility>
+
+namespace octarine::editor
+{
+    namespace
+    {
+#ifdef _WIN32
+        constexpr const char* kBuildScriptFile = "build-desktop.ps1";
+#else
+        constexpr const char* kBuildScriptFile = "build-desktop.sh";
+#endif
+
+        bool FileExists(const std::filesystem::path& p)
+        {
+            std::error_code ec;
+            return std::filesystem::exists(p, ec) && !std::filesystem::is_directory(p, ec);
+        }
+    } // namespace
+
+    std::optional<std::filesystem::path>
+    ExportBuilder::ResolveBuildScript(const std::filesystem::path& project_dir)
+    {
+        std::filesystem::path candidate = project_dir / "scripts" / kBuildScriptFile;
+        if (FileExists(candidate))
+        {
+            return candidate;
+        }
+        return std::nullopt;
+    }
+
+    std::vector<std::string> ExportBuilder::Validate(const std::filesystem::path& project_dir)
+    {
+        std::vector<std::string> errors;
+
+        auto ini = octarine::project::ProjectIni::Load(project_dir);
+        if (!ini)
+        {
+            errors.push_back("project.ini not found at " + (project_dir / "project.ini").string());
+        }
+        else
+        {
+            for (auto& err : ini->ValidateForShipping())
+            {
+                errors.push_back("project.ini: " + err);
+            }
+        }
+
+        if (!ResolveBuildScript(project_dir))
+        {
+            errors.push_back(
+                "missing scripts/" + std::string(kBuildScriptFile) +
+                " — run scripts/octarine-init-build to scaffold it");
+        }
+
+        return errors;
+    }
+
+    bool ExportBuilder::Run(const ExportOptions& opts)
+    {
+        if (status_ == ExportStatus::Building)
+        {
+            return true;
+        }
+
+        last_exit_code_.reset();
+        stdout_partial_.clear();
+        stderr_partial_.clear();
+
+        auto errors = Validate(opts.project_dir);
+        if (!errors.empty())
+        {
+            for (auto& e : errors)
+            {
+                AppendLine(true, "[export] " + e);
+            }
+            status_ = ExportStatus::Failed;
+            return false;
+        }
+
+        auto resolved = ResolveBuildScript(opts.project_dir);
+        // ResolveBuildScript already non-null because Validate passed; double-check to silence the
+        // optional unwrap and to keep behaviour explicit if Validate's policy diverges later.
+        if (!resolved)
+        {
+            AppendLine(true, "[export] build script vanished between validation and spawn");
+            status_ = ExportStatus::Failed;
+            return false;
+        }
+        resolved_script_ = *resolved;
+
+        octarine::process::SpawnOptions po;
+#ifdef _WIN32
+        // PowerShell launcher: -ExecutionPolicy Bypass so a freshly scaffolded unsigned .ps1 runs
+        // without the dev having to relax their machine-wide policy.
+        po.argv.push_back("powershell.exe");
+        po.argv.push_back("-NoProfile");
+        po.argv.push_back("-ExecutionPolicy");
+        po.argv.push_back("Bypass");
+        po.argv.push_back("-File");
+        po.argv.push_back(resolved_script_.string());
+#else
+        po.argv.push_back("bash");
+        po.argv.push_back(resolved_script_.string());
+#endif
+        po.cwd = opts.project_dir.string();
+
+        if (!opts.version_name.empty())
+        {
+            po.env.emplace_back("OCTARINE_VERSION_NAME", opts.version_name);
+        }
+        if (!opts.version_code.empty())
+        {
+            po.env.emplace_back("OCTARINE_VERSION_CODE", opts.version_code);
+        }
+        if (!opts.preset.empty())
+        {
+            po.env.emplace_back("OCTARINE_PRESET", opts.preset);
+        }
+
+        auto p = octarine::process::Process::Spawn(po);
+        if (!p)
+        {
+            AppendLine(true, "[export] failed to spawn " + resolved_script_.string());
+            status_ = ExportStatus::Failed;
+            return false;
+        }
+
+        p->OnStdout([this](std::string_view sv) { SplatChunk(sv, /*is_stderr=*/false); });
+        p->OnStderr([this](std::string_view sv) { SplatChunk(sv, /*is_stderr=*/true); });
+
+        process_ = std::move(p);
+        status_ = ExportStatus::Building;
+        AppendLine(false, "[export] launched " + resolved_script_.string());
+        Logger::Info("ExportBuilder: spawned " + resolved_script_.string() + " in " + po.cwd);
+        return true;
+    }
+
+    void ExportBuilder::Stop()
+    {
+        if (status_ != ExportStatus::Building || !process_)
+        {
+            return;
+        }
+        process_->Kill();
+        AppendLine(false, "[export] stop requested");
+    }
+
+    void ExportBuilder::Pump()
+    {
+        if (!process_)
+        {
+            return;
+        }
+        const bool still_running = process_->Pump();
+        if (!still_running && status_ == ExportStatus::Building)
+        {
+            FlushPartialLines();
+            last_exit_code_ = process_->ExitCode();
+            const int code = last_exit_code_.value_or(-1);
+            status_ = (code == 0) ? ExportStatus::Succeeded : ExportStatus::Failed;
+            AppendLine(false, "[export] exited with code " + std::to_string(code));
+            process_.reset();
+        }
+    }
+
+    void ExportBuilder::SplatChunk(std::string_view chunk, bool is_stderr)
+    {
+        std::string& partial = is_stderr ? stderr_partial_ : stdout_partial_;
+        partial.append(chunk);
+        std::size_t start = 0;
+        while (true)
+        {
+            const std::size_t nl = partial.find('\n', start);
+            if (nl == std::string::npos)
+            {
+                break;
+            }
+            std::string line(partial, start, nl - start);
+            if (!line.empty() && line.back() == '\r')
+            {
+                line.pop_back();
+            }
+            AppendLine(is_stderr, std::move(line));
+            start = nl + 1;
+        }
+        partial.erase(0, start);
+    }
+
+    void ExportBuilder::FlushPartialLines()
+    {
+        if (!stdout_partial_.empty())
+        {
+            AppendLine(false, std::move(stdout_partial_));
+            stdout_partial_.clear();
+        }
+        if (!stderr_partial_.empty())
+        {
+            AppendLine(true, std::move(stderr_partial_));
+            stderr_partial_.clear();
+        }
+    }
+
+    void ExportBuilder::AppendLine(bool is_stderr, std::string text)
+    {
+        if (log_.size() >= kLogCap)
+        {
+            log_.pop_front();
+            ++dropped_;
+        }
+        log_.push_back(ExportLogLine{is_stderr, std::move(text)});
+    }
+
+    ExportBuilder::LogSnapshot ExportBuilder::LogCopy() const
+    {
+        LogSnapshot snap;
+        snap.total_dropped = dropped_;
+        snap.lines.assign(log_.begin(), log_.end());
+        return snap;
+    }
+
+    void ExportBuilder::ClearLog()
+    {
+        log_.clear();
+        dropped_ = 0;
+    }
+} // namespace octarine::editor
+
+#endif // OCTARINE_WITH_EDITOR

--- a/src/Editor/ExportBuilder.h
+++ b/src/Editor/ExportBuilder.h
@@ -1,0 +1,108 @@
+#pragma once
+
+#ifdef OCTARINE_WITH_EDITOR
+
+// ExportBuilder — Stage 5 of ai/EditorBuildAndDeployPlan.md (PR-A: runner + UI for host-OS desktop).
+//
+// Wraps the spawn of the project's `scripts/build-desktop.{sh,ps1}` scaffolded by Stage 4. Mirrors
+// PlayerLauncher: a Registry singleton with a state machine (Idle -> Building -> Succeeded/Failed),
+// a ring-capped log of subprocess stdout/stderr, and a per-frame Pump() drained on the main thread.
+//
+// Out of scope this PR (deferred per plan): Android targets, signing-credentials prompt, SHA256
+// of artifact, "Reveal in Explorer" / clipboard install hint.
+
+#include "Process/Process.h"
+
+#include <cstddef>
+#include <deque>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace octarine::editor
+{
+    enum class ExportStatus
+    {
+        Idle,
+        Building,
+        Succeeded,
+        Failed,
+    };
+
+    struct ExportLogLine
+    {
+        bool is_stderr = false;
+        std::string text;
+    };
+
+    struct ExportOptions
+    {
+        std::filesystem::path project_dir;
+        std::string version_name; // optional; empty -> falls through to project.ini
+        std::string version_code; // optional; empty -> falls through to project.ini
+        std::string preset;       // optional; empty -> emitted script default (ship-release)
+    };
+
+    class ExportBuilder
+    {
+    public:
+        // Pre-flight checks before Run() can succeed. Returns the list of error messages; empty =
+        // ready to build. Mirrors the policy enforced by the scaffolded script + Gradle/CMake
+        // identity validators so the UI can surface failures inline.
+        //   - project_dir contains project.ini, and ProjectIni::ValidateForShipping passes
+        //   - scripts/build-desktop.sh (POSIX) or scripts/build-desktop.ps1 (Windows) exists
+        //   - cmake is on PATH
+        static std::vector<std::string> Validate(const std::filesystem::path& project_dir);
+
+        // Spawns the scaffolded build-desktop script with env vars set per the ExportOptions.
+        // Returns false when Validate() fails (errors are pushed into the log as stderr lines and
+        // status flips to Failed) or when spawning the script fails. A no-op (returning true) when
+        // a build is already Building.
+        bool Run(const ExportOptions& opts);
+
+        // Terminates the running script subprocess if any. No-op when not Building.
+        void Stop();
+
+        // Drains captured stdout/stderr into the log, updates status when the process exits.
+        // Cheap to call every frame.
+        void Pump();
+
+        ExportStatus Status() const { return status_; }
+        std::optional<int> LastExitCode() const { return last_exit_code_; }
+        const std::filesystem::path& ResolvedScript() const { return resolved_script_; }
+
+        struct LogSnapshot
+        {
+            std::vector<ExportLogLine> lines;
+            std::size_t total_dropped = 0;
+        };
+        LogSnapshot LogCopy() const;
+        void ClearLog();
+
+        // Picks scripts/build-desktop.ps1 on Windows, scripts/build-desktop.sh elsewhere. Returns
+        // nullopt if neither flavor exists. Public for unit testing.
+        static std::optional<std::filesystem::path> ResolveBuildScript(const std::filesystem::path& project_dir);
+
+    private:
+        static constexpr std::size_t kLogCap = 4096;
+
+        std::optional<octarine::process::Process> process_;
+        ExportStatus status_ = ExportStatus::Idle;
+        std::optional<int> last_exit_code_;
+        std::filesystem::path resolved_script_;
+
+        std::string stdout_partial_;
+        std::string stderr_partial_;
+
+        std::deque<ExportLogLine> log_;
+        std::size_t dropped_ = 0;
+
+        void SplatChunk(std::string_view chunk, bool is_stderr);
+        void AppendLine(bool is_stderr, std::string text);
+        void FlushPartialLines();
+    };
+} // namespace octarine::editor
+
+#endif // OCTARINE_WITH_EDITOR

--- a/src/Game/Game.cpp
+++ b/src/Game/Game.cpp
@@ -80,6 +80,7 @@
 #ifdef OCTARINE_WITH_EDITOR
 #include "../Editor/EditorLayoutPresets.h"
 #include "../Editor/EditorPersistence.h"
+#include "../Editor/ExportBuilder.h"
 #include "../Editor/PlayerLauncher.h"
 #include "../Editor/Inspectors/RegisterAllInspectors.h"
 #endif
@@ -222,6 +223,7 @@ bool Game::Initialize(const std::string& assetPath)
     auto& editorPersistence = registry_->Get<EditorPersistence>();
     editorPersistence.LoadGlobal();
     registry_->Set<octarine::editor::PlayerLauncher>(octarine::editor::PlayerLauncher());
+    registry_->Set<octarine::editor::ExportBuilder>(octarine::editor::ExportBuilder());
     if (effectivePath.empty())
     {
         effectivePath = editorPersistence.lastProjectPath;

--- a/src/Systems/RenderDebugGUISystem.cpp
+++ b/src/Systems/RenderDebugGUISystem.cpp
@@ -34,7 +34,9 @@
 #include "../Editor/EditorPersistence.h"
 #include "../Editor/Inspectors/ComponentInspectorRegistry.h"
 #include "../Editor/Inspectors/InspectorWidgets.h"
+#include "../Editor/ExportBuilder.h"
 #include "../Editor/PlayerLauncher.h"
+#include "../Project/ProjectIni.h"
 
 namespace
 {
@@ -90,6 +92,8 @@ const float deltaTime) {
 auto& editorPersistence = registry->Get<EditorPersistence>();
 auto& playerLauncher = registry->Get<octarine::editor::PlayerLauncher>();
 playerLauncher.Pump();
+auto& exportBuilder = registry->Get<octarine::editor::ExportBuilder>();
+exportBuilder.Pump();
 const bool editorSession = gameConfig.IsEditorMode() || !projectLoaded;
 const bool showEditorUI = editorSession;
 #endif
@@ -125,6 +129,7 @@ ImGui::NewFrame();
 #ifdef OCTARINE_WITH_EDITOR
 static bool showProjectSelector = false;
 static bool openSaveLayoutModal = false;
+static bool openExportBuildModal = false;
 
   if (showEditorUI)
 {
@@ -202,6 +207,7 @@ static bool openSaveLayoutModal = false;
             ImGui::MenuItem("Engine Options", nullptr, &editorPersistence.showEngineOptions);
             ImGui::MenuItem("Editor Settings", nullptr, &editorPersistence.showEditorSettings);
             ImGui::MenuItem("Player Output", nullptr, &editorPersistence.showPlayerOutput);
+            ImGui::MenuItem("Export Output", nullptr, &editorPersistence.showExportOutput);
             ImGui::MenuItem("Game Debug Overlays", "Grave", &engineOptions.showDebugGUI);
             ImGui::Separator();
             ImGui::MenuItem("FPS Counter", nullptr, &engineOptions.showFpsCounter);
@@ -288,6 +294,29 @@ static bool openSaveLayoutModal = false;
                     }
                     ImGui::EndDisabled();
                 }
+
+                ImGui::SameLine();
+                // Export Build: opens a modal to spawn the project's scaffolded
+                // scripts/build-desktop.{sh,ps1}. Disabled while a build is in flight; reads as
+                // "Stop Export" so the dev can cancel.
+                {
+                    const bool exportRunning =
+                        exportBuilder.Status() == octarine::editor::ExportStatus::Building;
+                    const bool canExport = projectLoaded || !registry->Get<AssetManager>().GetBasePath().empty();
+                    ImGui::BeginDisabled(!exportRunning && !canExport);
+                    if (ImGui::Button(exportRunning ? "Stop Export" : "Export Build..."))
+                    {
+                        if (exportRunning)
+                        {
+                            exportBuilder.Stop();
+                        }
+                        else
+                        {
+                            openExportBuildModal = true;
+                        }
+                    }
+                    ImGui::EndDisabled();
+                }
                 ImGui::EndMenuBar();
             }
         }
@@ -298,6 +327,89 @@ static bool openSaveLayoutModal = false;
     {
         ImGui::OpenPopup("Save Layout Preset");
         openSaveLayoutModal = false;
+    }
+
+    if (openExportBuildModal)
+    {
+        ImGui::OpenPopup("Export Build");
+        openExportBuildModal = false;
+    }
+    if (ImGui::BeginPopupModal("Export Build", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
+    {
+        static char versionNameBuf[32] = "";
+        static char versionCodeBuf[16] = "";
+        static std::string lastProjectDir;
+        static std::vector<std::string> validationErrors;
+
+        const std::string projectDir = registry->Get<AssetManager>().GetBasePath();
+
+        // Refresh the version-field defaults and validation when the project switches under the
+        // modal. The buffers themselves are static so a dev can edit and have the override stick
+        // across reopens within the same project.
+        if (projectDir != lastProjectDir)
+        {
+            lastProjectDir = projectDir;
+            versionNameBuf[0] = '\0';
+            versionCodeBuf[0] = '\0';
+            if (!projectDir.empty())
+            {
+                if (auto ini = octarine::project::ProjectIni::Load(std::filesystem::path(projectDir)))
+                {
+                    std::snprintf(versionNameBuf, sizeof(versionNameBuf), "%s", ini->version_name.c_str());
+                    std::snprintf(versionCodeBuf, sizeof(versionCodeBuf), "%s", ini->version_code.c_str());
+                }
+            }
+            validationErrors = octarine::editor::ExportBuilder::Validate(std::filesystem::path(projectDir));
+        }
+
+        ImGui::Text("Target: host OS (ship-release preset)");
+        ImGui::TextDisabled("Project: %s", projectDir.empty() ? "(none)" : projectDir.c_str());
+        ImGui::Separator();
+
+        ImGui::SetNextItemWidth(180);
+        ImGui::InputText("Version name", versionNameBuf, sizeof(versionNameBuf));
+        ImGui::SetNextItemWidth(180);
+        ImGui::InputText("Version code", versionCodeBuf, sizeof(versionCodeBuf));
+        ImGui::TextDisabled("Leave blank to fall through to project.ini.");
+
+        if (!validationErrors.empty())
+        {
+            ImGui::Separator();
+            ImGui::TextColored(ImVec4(1.0F, 0.5F, 0.5F, 1.0F), "Validation errors:");
+            for (const auto& e : validationErrors)
+            {
+                ImGui::BulletText("%s", e.c_str());
+            }
+        }
+
+        ImGui::Separator();
+
+        const bool canBuild = validationErrors.empty() && !projectDir.empty();
+        ImGui::BeginDisabled(!canBuild);
+        if (ImGui::Button("Build"))
+        {
+            octarine::editor::ExportOptions opts;
+            opts.project_dir = std::filesystem::path(projectDir);
+            opts.version_name = versionNameBuf;
+            opts.version_code = versionCodeBuf;
+
+            editorPersistence.showExportOutput = true;
+            exportBuilder.ClearLog();
+            exportBuilder.Run(opts);
+            ImGui::CloseCurrentPopup();
+        }
+        ImGui::EndDisabled();
+        ImGui::SameLine();
+        if (ImGui::Button("Cancel"))
+        {
+            ImGui::CloseCurrentPopup();
+        }
+        ImGui::SameLine();
+        if (ImGui::Button("Re-validate"))
+        {
+            validationErrors = octarine::editor::ExportBuilder::Validate(std::filesystem::path(projectDir));
+        }
+        ImGui::EndPopup();
     }
     if (ImGui::BeginPopupModal("Save Layout Preset", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
     {
@@ -337,6 +449,8 @@ static bool openSaveLayoutModal = false;
         EditorSettingsWindow(editorPersistence, &editorPersistence.showEditorSettings);
     if (editorPersistence.showPlayerOutput)
         PlayerOutputWindow(game, &editorPersistence.showPlayerOutput);
+    if (editorPersistence.showExportOutput)
+        ExportOutputWindow(game, &editorPersistence.showExportOutput);
 
     if (engineOptions.showImGuiDemoWindow)
     {
@@ -977,6 +1091,87 @@ void RenderDebugGUISystem::PlayerOutputWindow(Game* game, bool* p_open)
 
     ImGui::BeginChild("PlayerOutputScroll", ImVec2(0, 0), false, ImGuiWindowFlags_HorizontalScrollbar);
     const auto snap = launcher.LogCopy();
+    if (snap.total_dropped > 0)
+    {
+        ImGui::TextDisabled("[older %zu lines dropped]", snap.total_dropped);
+    }
+    for (const auto& line : snap.lines)
+    {
+        if (line.is_stderr)
+        {
+            ImGui::TextColored(ImVec4(1.0F, 0.5F, 0.5F, 1.0F), "%s", line.text.c_str());
+        }
+        else
+        {
+            ImGui::TextUnformatted(line.text.c_str());
+        }
+    }
+    if (autoScroll && ImGui::GetScrollY() >= ImGui::GetScrollMaxY())
+    {
+        ImGui::SetScrollHereY(1.0F);
+    }
+    ImGui::EndChild();
+
+    ImGui::End();
+}
+
+void RenderDebugGUISystem::ExportOutputWindow(Game* game, bool* p_open)
+{
+    auto& builder = game->GetRegistry()->Get<octarine::editor::ExportBuilder>();
+
+    ImGui::SetNextWindowSize(ImVec2(620, 420), ImGuiCond_FirstUseEver);
+    if (!ImGui::Begin("Export Output", p_open, ImGuiWindowFlags_NoScrollbar))
+    {
+        ImGui::End();
+        return;
+    }
+
+    const auto status = builder.Status();
+    const char* statusText = "Idle";
+    ImVec4 statusColor = ImVec4(0.7F, 0.7F, 0.7F, 1.0F);
+    switch (status)
+    {
+    case octarine::editor::ExportStatus::Building:
+        statusText = "Building";
+        statusColor = ImVec4(0.4F, 1.0F, 0.4F, 1.0F);
+        break;
+    case octarine::editor::ExportStatus::Succeeded:
+        statusText = "Succeeded";
+        statusColor = ImVec4(0.4F, 1.0F, 0.4F, 1.0F);
+        break;
+    case octarine::editor::ExportStatus::Failed:
+        statusText = "Failed";
+        statusColor = ImVec4(1.0F, 0.4F, 0.4F, 1.0F);
+        break;
+    case octarine::editor::ExportStatus::Idle:
+    default:
+        break;
+    }
+    ImGui::TextDisabled("Status:");
+    ImGui::SameLine();
+    ImGui::TextColored(statusColor, "%s", statusText);
+    if (const auto code = builder.LastExitCode())
+    {
+        ImGui::SameLine();
+        ImGui::TextDisabled("(exit %d)", *code);
+    }
+    if (!builder.ResolvedScript().empty())
+    {
+        ImGui::TextDisabled("Script: %s", builder.ResolvedScript().string().c_str());
+    }
+
+    if (ImGui::Button("Clear"))
+    {
+        builder.ClearLog();
+    }
+    ImGui::SameLine();
+    static bool autoScroll = true;
+    ImGui::Checkbox("Auto-scroll", &autoScroll);
+
+    ImGui::Separator();
+
+    ImGui::BeginChild("ExportOutputScroll", ImVec2(0, 0), false, ImGuiWindowFlags_HorizontalScrollbar);
+    const auto snap = builder.LogCopy();
     if (snap.total_dropped > 0)
     {
         ImGui::TextDisabled("[older %zu lines dropped]", snap.total_dropped);

--- a/src/Systems/RenderDebugGUISystem.h
+++ b/src/Systems/RenderDebugGUISystem.h
@@ -115,6 +115,7 @@ class RenderDebugGUISystem {
   static void AssetBrowserWindow(Registry* registry);
   static void LuaConsoleWindow(sol::state& lua);
   static void PlayerOutputWindow(Game* game, bool* p_open);
+  static void ExportOutputWindow(Game* game, bool* p_open);
 #endif
   static void FPSWindow(float deltaTime);
   static void EntityInfoWindow(const Registry* registry);


### PR DESCRIPTION
## Summary

Stage 5 PR-A of `ai/EditorBuildAndDeployPlan.md` — editor-side runner + UI for the host-OS desktop export. Spawns the scaffolded `scripts/build-desktop.{sh,ps1}` from Stage 4 and streams output back into an editor window.

- New `src/Editor/ExportBuilder.{h,cpp}` — Registry singleton. State machine: `Idle` → `Building` → `Succeeded`/`Failed`. Ring-capped log; per-frame `Pump()`. Same shape as `PlayerLauncher`.
- New toolbar button "Export Build..." (next to "Run Player") opens a modal. Toggles to "Stop Export" while a build runs.
- Modal: target = host OS, version-name / version-code fields auto-filled from `project.ini` (blank = fall through), inline validation errors (from `ProjectIni::ValidateForShipping` + scaffolded-script presence), Build / Cancel / Re-validate.
- New "Export Output" ImGui window (toggle persisted via `EditorPersistence::showExportOutput`); mirrors Player Output (status chip, exit code, clear, auto-scroll, stderr in red).
- Windows: spawns `powershell -NoProfile -ExecutionPolicy Bypass -File scripts/build-desktop.ps1`. POSIX: spawns `bash scripts/build-desktop.sh`. Identity / preset override via `OCTARINE_VERSION_NAME`, `_VERSION_CODE`, `OCTARINE_PRESET` env vars.

Out of scope (deferred per plan):
- Android targets (PR depends on signing storage)
- OS-secret signing credential storage (PR-B: DPAPI / keychain / libsecret)
- SHA256 of artifact + Reveal-in-Explorer + clipboard install hint (PR-C)

## Test plan

- [x] `cmake --preset editor-debug && cmake --build build/editor-debug` — clean compile (44/44 objects, no errors; existing `/W4` overrides in stb-using TUs are pre-existing warnings).
- [x] New `.cpp` appended to `SRC_FILES` editor section in `CMakeLists.txt`.
- [x] `showExportOutput` registered in `EditorPersistence::kWindowFlags` so layout presets serialize it.
- [ ] Manual: open editor against `Octarine-Engine-Example`, run `scripts/octarine-init-build.sh` to scaffold build-desktop, click Export Build, confirm subprocess spawns and output streams.
- [ ] Manual: edit `project.ini` to break `package_id` regex; reopen modal; confirm validation error shows and Build button disables.
- [ ] Manual: while Building, click Stop Export; confirm subprocess terminates and status flips to Failed.