### PR TITLE
Polish docs: drop local-scratchpad refs, fix formatting + accuracy bugs

### DIFF
--- a/.github/workflows/android-emulator.yml
+++ b/.github/workflows/android-emulator.yml
@@ -104,7 +104,7 @@ jobs:
           #!/usr/bin/env bash
           # Boot emulator → install APK → launch activity → poll logcat for the manifest-load line.
           # Mirrors ios.yml's launch+assert step. Tag is `Octarine` (set by Logger::Init's
-          # spdlog::android_logger_mt — see CLAUDE.md). The catalog logs
+          # spdlog::android_logger_mt). The catalog logs
           # "AssetCatalog: loaded N entries from manifest" once the bake is consumed; absence
           # within the budget means the APK never reached scene load.
           set -e

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ cmake --list-presets
 cmake --preset editor-debug
 cmake --build --preset editor-debug
 
-# Build the Player (Shipping build)
+# Build the Player (optimized dev runtime, live-scan catalog)
 cmake --preset player-release
 cmake --build --preset player-release
 
@@ -99,8 +99,8 @@ Octarine Engine accepts the game directory as a positional argument:
 
 The engine runs automated performance benchmarks via GitHub Actions on every push to `main` and Pull Request.
 
-You can view the interactive historical performance dashboard here:
-👉 **[Octarine Engine Performance Dashboard](https://mblackman.github.io/Octarine-Engine/dev/bench/)**
+Interactive historical performance dashboard:
+**[Octarine Engine Performance Dashboard](https://mblackman.github.io/Octarine-Engine/dev/bench/)**
 
 ### Local Profiling
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -17,7 +17,7 @@ CMake presets live in `CMakePresets.json`. The common ones:
 | `editor-debug`    | Day-to-day dev with editor + ImGui debug overlays |
 | `editor-release`  | Optimized editor build                            |
 | `player-release`  | Optimized runtime, no editor (live-scan catalog)  |
-| `player-profile`  | RelWithDebInfo + `OCTARINE_PROFILING` for timing  |
+| `player-profile`  | RelWithDebInfo + `OCTARINE_ENABLE_PROFILING` for timing |
 | `ship-release`    | Canonical shipping config (manifest-load catalog) |
 
 ## 2. Run

--- a/docs/device-builds.md
+++ b/docs/device-builds.md
@@ -57,8 +57,9 @@ The two pieces that make this work end to end:
    execute), so the **project commits its `asset_manifest.lua`** or passes a
    host-native binary via `-Poctarine.bakeExe=`.
 
-Read `CLAUDE.md` for the broader engine architecture; this doc is strictly
-about how the build system reaches a shippable artifact.
+For the broader engine architecture see [`docs/ecs-architecture.md`](ecs-architecture.md)
+and [`docs/lua-scripting.md`](lua-scripting.md); this doc is strictly about how the build
+system reaches a shippable artifact.
 
 ---
 

--- a/docs/ecs-architecture.md
+++ b/docs/ecs-architecture.md
@@ -30,8 +30,8 @@ archetype.
 
 ### Chunks and SoA
 
-Within an Archetype, data is stored in fixed-size **Chunks** (default 16KB). Each chunk uses a **Structure of Arrays (
-SoA)** layout:
+Within an Archetype, data is stored in fixed-size **Chunks** (default 16KB). Each chunk uses a
+**Structure of Arrays (SoA)** layout:
 
 ```text
 Chunk (16KB)
@@ -74,8 +74,8 @@ The `Registry` is the central manager for the entire ECS. It handles:
 
 ### Component Queries
 
-Systems interact with data via `ComponentQuery<TComponents...>`. A query identifies all archetypes that are a **superset
-** of the requested components.
+Systems interact with data via `ComponentQuery<TComponents...>`. A query identifies all archetypes
+that are a **superset** of the requested components.
 
 Queries are cached; they only re-evaluate the archetype graph when the registry's `archetype_generation` increases.
 
@@ -109,8 +109,8 @@ Octarine supports three primary ways to process entities:
 The ECS supports **Pairs** to model relationships between entities:
 
 - **Pairs:** Represented as `(Relationship, Target)`.
-- **Hierarchy:** Built using the `ChildOf` relationship. The `TransformSystem` optimizedly handles nested transforms
-  using this mechanism.
+- **Hierarchy:** Built using the `ChildOf` relationship. The `TransformSystem` handles nested
+  transforms efficiently via this mechanism.
 
 ### Command Buffers
 

--- a/docs/lua-scripting.md
+++ b/docs/lua-scripting.md
@@ -66,8 +66,8 @@ load_asset({
 
 Entities are created by passing a table to `load_entity`. They are composed of a `tag` (optional) and several `components`.
 
-For a full list of available components and their fields, see:
-👉 **[ECS Component Reference](ecs-components.md)**
+For a full list of available components and their fields, see
+**[ECS Component Reference](ecs-components.md)**.
 
 ```lua
 local player = {


### PR DESCRIPTION
## Summary

Final review pass over tracked docs after the `ai/` scrub (#80, #81). Six fixes.

### Local-only scratchpad references

A gitignored, local-only agent scratchpad file should not be referenced by tracked files. Same rule as `ai/`.

- `docs/device-builds.md` — replaced a pointer to that scratchpad file ("for the broader engine architecture") with pointers to `docs/ecs-architecture.md` + `docs/lua-scripting.md`.
- `.github/workflows/android-emulator.yml` — dropped a trailing scratchpad-file pointer from a comment.

### Accuracy bugs

- `README.md` — `cmake --preset player-release` was commented "Build the Player (Shipping build)". Wrong: `player-release` is the optimized dev runtime (live-scan asset catalog), **not** a shippable artifact. Shipping config is `ship-release` (already linked one line above). Reworded comment.
- `docs/QUICKSTART.md` — the `player-profile` row showed `OCTARINE_PROFILING` as if it were the CMake option, but that is the compile define; the CMake option is `OCTARINE_ENABLE_PROFILING`. A reader copying `-DOCTARINE_PROFILING=ON` would silently get no profiling. Corrected.

### Formatting bugs

`docs/ecs-architecture.md` had two mid-bold-span line breaks rendering as literal newlines inside the bold:
- `**Structure of Arrays (\nSoA)**`
- `**superset\n**`

Both reflowed. Also replaced "optimizedly" with "efficiently" (not a word).

### Style

Dropped two stray 👉 pointer emojis from `README.md` and `docs/lua-scripting.md` — links work fine without them.

Doc-only diff; no behavior change.

## Test plan

- [x] `git grep -nE 'optimizedly|👉'` returns no tracked-doc hits.
- [x] `git grep -nE '\bai/'` still returns zero hits (unchanged from #81).
- [ ] Spot-check rendered Markdown on the PR diff.
