### PR TITLE
Add Lua-behavior and Game::Bake test suites

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -467,5 +467,35 @@ if (OCTARINE_ENABLE_TESTS)
         add_test(NAME DevListenServerTest COMMAND OctarineDevListenServerTest)
     endif ()
 
+    # Lua behavior test: calls bound component methods from Lua and verifies the C++ side mutated
+    # (damage/heal round-trip, clamping setters, fromLua defaults). Links the full engine via
+    # octarine_engine — same surface as the smoke test, minus Main.cpp.
+    add_executable(OctarineLuaBehaviorTest tests/LuaBehaviorTest.cpp)
+    set_target_properties(OctarineLuaBehaviorTest PROPERTIES
+            CXX_STANDARD 20
+            CXX_STANDARD_REQUIRED ON
+            CXX_EXTENSIONS OFF)
+    target_link_libraries(OctarineLuaBehaviorTest PRIVATE octarine_engine)
+    if (MSVC)
+        target_compile_options(OctarineLuaBehaviorTest PRIVATE /MP /bigobj /permissive- /wd4201 /wd5321)
+    endif ()
+    add_test(NAME LuaBehaviorTest COMMAND OctarineLuaBehaviorTest)
+
+    # Game bake test: headless Game construction + Game::Bake against a minimal fixture project +
+    # SceneAssetScanner::CollectRefs provenance / cross-scene delta. BAKE_FIXTURE_DIR points the
+    # end-to-end bake check at tests/fixtures/bake-project.
+    add_executable(OctarineGameBakeTest tests/GameBakeTest.cpp)
+    set_target_properties(OctarineGameBakeTest PROPERTIES
+            CXX_STANDARD 20
+            CXX_STANDARD_REQUIRED ON
+            CXX_EXTENSIONS OFF)
+    target_compile_definitions(OctarineGameBakeTest PRIVATE
+            BAKE_FIXTURE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/tests/fixtures/bake-project")
+    target_link_libraries(OctarineGameBakeTest PRIVATE octarine_engine)
+    if (MSVC)
+        target_compile_options(OctarineGameBakeTest PRIVATE /MP /bigobj /permissive- /wd4201 /wd5321)
+    endif ()
+    add_test(NAME GameBakeTest COMMAND OctarineGameBakeTest)
+
     message(STATUS "Octarine: Tests ENABLED")
 endif ()

--- a/tests/GameBakeTest.cpp
+++ b/tests/GameBakeTest.cpp
@@ -1,0 +1,157 @@
+// Headless Game + bake pipeline checks.
+// - Constructor allocates Registry/EventBus/Lua without touching SDL (matches the documented
+//   "Game game;" shape used by the smoke test).
+// - Game::Bake(fixtureDir) runs end-to-end against a minimal project fixture: loads config,
+//   scans the catalog, runs the startup script, writes asset_manifest.lua. Verifies the
+//   manifest lands on disk.
+// - SceneAssetScanner::CollectRefs preserves duplicates + provenance (Collect's dedup wrapper
+//   is exercised by AssetPipelineTest).
+
+#include <filesystem>
+#include <sol/sol.hpp>
+#include <string>
+
+#include "AssetManager/AssetReference.h"
+#include "AssetManager/SceneAssetScanner.h"
+#include "ECS/Registry.h"
+#include "EventBus/EventBus.h"
+#include "Game/Game.h"
+#include "General/Logger.h"
+#include "TestHarness.h"
+
+using octarine::test::Check;
+using octarine::test::CheckEq;
+
+int main() {
+  // Bake calls Logger::Info widely (works without Init via spdlog's default), but the bound
+  // Lua log_i / log_e in the startup script dereference lua_logger_ which Init sets up.
+  Logger::Init();
+
+  std::cout << "[headless Game construction]\n";
+  {
+    // The constructor must not open a window, init SDL, or create a renderer — only allocate
+    // the registry/eventbus/lua state. Smoke + behavior tests both rely on this guarantee.
+    Game game;
+    Check(game.GetRegistry() != nullptr, "Game::GetRegistry() returns a live Registry");
+    Check(game.GetWindow() == nullptr, "Game::GetWindow() is nullptr before Initialize()");
+    Check(game.GetRenderer() == nullptr, "Game::GetRenderer() is nullptr before Initialize()");
+
+    // Registry is usable: create an entity, verify counters.
+    const Entity e = game.GetRegistry()->CreateEntity();
+    Check(game.GetRegistry()->IsAlive(e), "Registry held by headless Game accepts CreateEntity");
+    CheckEq(game.GetRegistry()->GetUserEntityCount(), 1ULL, "user entity count visible on headless Game");
+  }
+
+  std::cout << "[scanner: CollectRefs preserves duplicates + provenance]\n";
+  {
+    sol::state lua;
+    lua.open_libraries(sol::lib::base);
+    const auto scene = lua.script(R"lua(
+          return {
+            preload = { "shared-tex" },
+            entities = {
+              {
+                components = {
+                  sprite = { texture_asset_id = "shared-tex" },
+                },
+              },
+              {
+                components = {
+                  sprite = { texture_asset_id = "shared-tex" },  -- duplicate id, distinct ref
+                },
+              },
+              {
+                components = {
+                  audio_source = { clip_id = "blip" },
+                },
+              },
+            },
+          }
+        )lua");
+
+    const std::vector<AssetReference> refs = SceneAssetScanner::CollectRefs(scene);
+    // 1 preload + 2 sprite refs + 1 audio = 4 references with the same dup id present twice.
+    CheckEq(refs.size(), size_t{4}, "CollectRefs returns one entry per reference site");
+
+    int sharedTexCount = 0;
+    bool foundBlip = false;
+    for (const auto& ref : refs) {
+      if (ref.id == "shared-tex") ++sharedTexCount;
+      if (ref.id == "blip") foundBlip = true;
+      Check(!ref.context.empty(), "every ref carries provenance context");
+    }
+    CheckEq(sharedTexCount, 3, "shared-tex appears 3x in CollectRefs (preload + 2 sprites)");
+    Check(foundBlip, "CollectRefs picks up audio_source.clip_id");
+
+    // The dedup wrapper (Collect) is the production path for "what's in this scene".
+    const auto ids = SceneAssetScanner::Collect(scene);
+    CheckEq(ids.size(), size_t{2}, "Collect dedups CollectRefs down to 2 distinct ids");
+  }
+
+  std::cout << "[scanner: cross-scene delta — shared vs. exclusive ids]\n";
+  {
+    sol::state lua;
+    lua.open_libraries(sol::lib::base);
+    const auto sceneA = lua.script(R"lua(
+          return {
+            preload = { "shared", "only-in-a" },
+            entities = {},
+          }
+        )lua");
+    const auto sceneB = lua.script(R"lua(
+          return {
+            preload = { "shared", "only-in-b-1", "only-in-b-2" },
+            entities = {},
+          }
+        )lua");
+
+    const auto a = SceneAssetScanner::Collect(sceneA);
+    const auto b = SceneAssetScanner::Collect(sceneB);
+    Check(a.count("shared") == 1 && b.count("shared") == 1, "shared id present in both scenes");
+    Check(a.count("only-in-a") == 1 && b.count("only-in-a") == 0, "only-in-a exclusive to scene A");
+    Check(a.count("only-in-b-1") == 0 && b.count("only-in-b-1") == 1, "only-in-b-1 exclusive to scene B");
+
+    // Acquire-before-release semantics from Game::LoadScene depend on this set difference being
+    // correct: ids only in A get released, ids only in B get acquired, shared ids untouched.
+    std::vector<std::string> toRelease;
+    for (const auto& id : a) {
+      if (b.find(id) == b.end()) toRelease.push_back(id);
+    }
+    std::vector<std::string> toAcquire;
+    for (const auto& id : b) {
+      if (a.find(id) == a.end()) toAcquire.push_back(id);
+    }
+    CheckEq(toRelease.size(), size_t{1}, "exactly one id to release across A→B swap");
+    CheckEq(toAcquire.size(), size_t{2}, "exactly two new ids to acquire on A→B swap");
+  }
+
+#ifdef BAKE_FIXTURE_DIR
+  std::cout << "[bake: end-to-end against fixture project]\n";
+  {
+    const std::filesystem::path fixtureDir = BAKE_FIXTURE_DIR;
+    const std::filesystem::path manifestPath = fixtureDir / "asset_manifest.lua";
+
+    // Bake writes several artifacts next to the project (manifest + asset pak + atlas output dir).
+    // The test owns all of them: wipe before and after so the source tree stays clean on CI and
+    // re-runs start from the same pre-state.
+    const auto CleanBakeOutputs = [&] {
+      std::error_code ec;
+      std::filesystem::remove(manifestPath, ec);
+      std::filesystem::remove(fixtureDir / "asset_bundle.pak", ec);
+      std::filesystem::remove_all(fixtureDir / "atlases", ec);
+    };
+
+    CleanBakeOutputs();
+
+    const bool ok = Game::Bake(fixtureDir.string());
+    Check(ok, "Game::Bake returns true on a clean fixture project");
+    Check(std::filesystem::exists(manifestPath), "Game::Bake wrote asset_manifest.lua next to the project");
+
+    CleanBakeOutputs();
+  }
+#else
+  std::cerr << "  WARN BAKE_FIXTURE_DIR not defined; skipping Game::Bake check\n";
+#endif
+
+  return octarine::test::ReportSummary("Game bake test");
+}

--- a/tests/LuaBehaviorTest.cpp
+++ b/tests/LuaBehaviorTest.cpp
@@ -1,0 +1,138 @@
+// Behavioral checks for the Lua binding surface — call bound component methods from Lua
+// and verify the C++ component mutated. Layered on top of LuaApiSmokeTest, which only
+// validates that the surface exists. Catches the "binding compiles, method does nothing"
+// class of regression that drift checks miss.
+//
+// Headless Game (constructor allocates Registry/EventBus/Lua, opens no SDL window/renderer).
+
+#include <sol/sol.hpp>
+#include <string>
+
+#include "Components/HealthComponent.h"
+#include "Components/PositionComponent.h"
+#include "ECS/Registry.h"
+#include "Game/Game.h"
+#include "General/Logger.h"
+#include "Lua/Bindings/HealthComponentLuaBinding.h"
+#include "Lua/Bindings/LuaBinding.h"
+#include "Lua/Bindings/LuaComponentRegistry.h"
+#include "Lua/Bindings/PositionComponentLuaBinding.h"
+#include "Lua/Bindings/RegisterAllBindings.h"
+#include "Lua/Modules/RegisterAllModules.h"
+#include "Systems/ScriptSystem.h"
+#include "TestHarness.h"
+
+using octarine::test::Check;
+using octarine::test::CheckEq;
+
+namespace {
+bool RunLua(sol::state& lua, const std::string& script) {
+  const auto r = lua.safe_script(script, sol::script_pass_on_error);
+  if (!r.valid()) {
+    const sol::error err = r;
+    std::cerr << "    lua error: " << err.what() << "\n";
+    return false;
+  }
+  return true;
+}
+}  // namespace
+
+int main() {
+  // Logger::Init wires the lua_logger_ that Logger::LogLua / Logger::InfoLua dereference.
+  // Without it, the bound Lua `log` / `log_i` functions crash on null logger.
+  Logger::Init();
+
+  Game game;  // SDL-free constructor.
+  sol::state& lua = game.GetLua();
+  lua.open_libraries(sol::lib::base, sol::lib::math, sol::lib::io, sol::lib::string, sol::lib::table);
+
+  RegisterAllLuaBindings();
+  ScriptSystem scriptSystem;
+  scriptSystem.CreateLuaBindings(lua);  // primitives + every LuaBinding<T>::bindUsertype
+  RegisterAllLuaModules(lua, game);     // installs `registry.has_/get_<key>` + free functions
+
+  Registry* reg = game.GetRegistry();
+
+  std::cout << "[health: damage / heal round-trip via Lua]\n";
+  {
+    const Entity e = reg->CreateEntity();
+    reg->AddComponent<HealthComponent>(e, HealthComponent(100));
+    lua["test_entity"] = e;
+
+    Check(RunLua(lua, "registry.get_health(test_entity):damage(30)"), "Lua: damage(30) call succeeds");
+    CheckEq(reg->GetComponent<HealthComponent>(e).currentHealth, 70, "health.damage(30) reduced currentHealth to 70");
+
+    Check(RunLua(lua, "registry.get_health(test_entity):heal(10)"), "Lua: heal(10) call succeeds");
+    CheckEq(reg->GetComponent<HealthComponent>(e).currentHealth, 80, "health.heal(10) bumped currentHealth to 80");
+
+    // damage() floors at 0; heal() caps at maxHealth — invariants enforced by bound methods.
+    Check(RunLua(lua, "registry.get_health(test_entity):damage(9999)"), "Lua: massive damage call succeeds");
+    CheckEq(reg->GetComponent<HealthComponent>(e).currentHealth, 0, "damage() floors at 0");
+
+    Check(RunLua(lua, "registry.get_health(test_entity):heal(9999)"), "Lua: massive heal call succeeds");
+    CheckEq(reg->GetComponent<HealthComponent>(e).currentHealth, 100, "heal() caps at maxHealth");
+  }
+
+  std::cout << "[health: clamping property setter from Lua]\n";
+  {
+    const Entity e = reg->CreateEntity();
+    reg->AddComponent<HealthComponent>(e, HealthComponent(50));
+    lua["test_entity"] = e;
+
+    // current_health is a clamping property; writing a value above max_health must clamp,
+    // writing a negative value must clamp to 0.
+    Check(RunLua(lua, "registry.get_health(test_entity).current_health = 999"), "Lua write current_health=999");
+    CheckEq(reg->GetComponent<HealthComponent>(e).currentHealth, 50, "current_health setter clamps to maxHealth");
+
+    Check(RunLua(lua, "registry.get_health(test_entity).current_health = -42"), "Lua write current_health=-42");
+    CheckEq(reg->GetComponent<HealthComponent>(e).currentHealth, 0, "current_health setter clamps to 0");
+  }
+
+  std::cout << "[position: write field through bound usertype]\n";
+  {
+    const Entity e = reg->CreateEntity();
+    reg->AddComponent<PositionComponent>(e, PositionComponent(glm::vec2(1.0F, 2.0F)));
+    lua["test_entity"] = e;
+
+    Check(RunLua(lua, "registry.get_position(test_entity).value = vec2.new(7, 9)"), "Lua write position.value");
+    CheckEq(reg->GetComponent<PositionComponent>(e).value.x, 7.0F, "position.value.x written from Lua");
+    CheckEq(reg->GetComponent<PositionComponent>(e).value.y, 9.0F, "position.value.y written from Lua");
+  }
+
+  std::cout << "[has_/get_ accessors]\n";
+  {
+    const Entity hasHealth = reg->CreateEntity();
+    reg->AddComponent<HealthComponent>(hasHealth, HealthComponent(10));
+    const Entity noHealth = reg->CreateEntity();
+
+    lua["with_health"] = hasHealth;
+    lua["without_health"] = noHealth;
+    Check(RunLua(lua, "assert(registry.has_health(with_health))"), "registry.has_health true for owner");
+    Check(RunLua(lua, "assert(not registry.has_health(without_health))"), "registry.has_health false for non-owner");
+  }
+
+  std::cout << "[fromLua: defaults applied when fields omitted]\n";
+  {
+    // HealthComponent has no default-constructor (deleted); fromLua must synthesize one
+    // from an empty table using its 100-max default.
+    const auto t = lua.script("return {}");
+    const HealthComponent defaulted = LuaBinding<HealthComponent>::fromLua(t);
+    CheckEq(defaulted.maxHealth, 100, "fromLua({}) gives default maxHealth=100");
+    CheckEq(defaulted.currentHealth, 100, "fromLua({}) starts at full health");
+
+    const auto t2 = lua.script("return { max_health = 25 }");
+    const HealthComponent custom = LuaBinding<HealthComponent>::fromLua(t2);
+    CheckEq(custom.maxHealth, 25, "fromLua reads max_health");
+    CheckEq(custom.currentHealth, 25, "fromLua initializes current to max");
+  }
+
+  std::cout << "[module callable: log() runs]\n";
+  {
+    // No observable side effect to assert against without wiring a log sink — just confirm
+    // the bound function exists and returns from a Lua call.
+    Check(lua["log"].valid() && lua["log"].get_type() == sol::type::function, "log is bound as a function");
+    Check(RunLua(lua, "log('LuaBehaviorTest: smoke from log()')"), "log('...') runs from Lua without error");
+  }
+
+  return octarine::test::ReportSummary("Lua behavior test");
+}

--- a/tests/TestHarness.h
+++ b/tests/TestHarness.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <iostream>
+#include <sstream>
 #include <string>
 
 namespace octarine::test {
@@ -21,6 +22,30 @@ inline void Check(const bool cond, const std::string& what) {
   }
 }
 
+// Equality check that prints the offending values on failure. Both sides must be ostream-streamable.
+template <typename A, typename B>
+void CheckEq(const A& got, const B& want, const std::string& what) {
+  if (got == want) {
+    std::cout << "  ok   " << what << "\n";
+  } else {
+    std::ostringstream os;
+    os << "  FAIL " << what << " (got=" << got << ", want=" << want << ")";
+    std::cerr << os.str() << "\n";
+    ++g_failures;
+  }
+}
+
 inline int Result() { return g_failures == 0 ? 0 : 1; }
+
+// Named variant: prints a PASS/FAIL summary line for `suiteName` and returns the failure count
+// (0 = success) so a test's main() can `return octarine::test::ReportSummary("...");`.
+inline int ReportSummary(const std::string& suiteName) {
+  if (g_failures == 0) {
+    std::cout << "\n" << suiteName << ": PASS\n";
+  } else {
+    std::cerr << "\n" << suiteName << ": " << g_failures << " FAILED\n";
+  }
+  return g_failures;
+}
 
 }  // namespace octarine::test

--- a/tests/fixtures/bake-project/config.ini
+++ b/tests/fixtures/bake-project/config.ini
@@ -1,0 +1,4 @@
+Title=BakeFixture
+StartupScript=main.lua
+DefaultWindowWidth=320
+DefaultWindowHeight=240

--- a/tests/fixtures/bake-project/main.lua
+++ b/tests/fixtures/bake-project/main.lua
@@ -1,0 +1,3 @@
+-- Minimal startup script for the bake fixture: no scenes, no asset references. Bake's
+-- only job here is to load config + scan + write the manifest, then return cleanly.
+return {}


### PR DESCRIPTION
## Summary
Rebased onto current `main` and reduced to the two test suites `main` doesn't already have. The original branch (cut at #60) also added ECS + EventBus suites and a `TestHelpers.h`, but equivalent coverage landed on main since then (`EcsRegistryTest` / `EcsHierarchyTest` / `EventBusTest` + `TestHarness.h` via the headless-test PR), so those parts are dropped as redundant.

Two engine-linked ctest binaries:
- **OctarineLuaBehaviorTest** — calls bound component methods from Lua and verifies the C++ side mutated: `HealthComponent` damage/heal round-trip, `current_health` clamping setter, `PositionComponent.value` write, `registry.has_/get_` accessors, and `LuaBinding<HealthComponent>::fromLua` defaults.
- **OctarineGameBakeTest** — headless `Game game;` smoke (no window/renderer), `Game::Bake` end-to-end against `tests/fixtures/bake-project`, and `SceneAssetScanner::CollectRefs` provenance + cross-scene delta. Cleans up every bake artifact (manifest + `asset_bundle.pak` + `atlases/`) so the source tree stays clean on CI.

Both link `octarine_engine`, matching how `LuaApiSmokeTest` / `AssetPipelineTest` wire in. Shared `Check` / `CheckEq` / `ReportSummary` helpers live in the existing `tests/TestHarness.h`, extended here with `CheckEq` + `ReportSummary`.

## Test plan
- [x] `cmake --preset editor-debug -DOCTARINE_ENABLE_TESTS=ON` + build — clean
- [x] `ctest -R "LuaBehaviorTest|GameBakeTest"` green; every check exercised (bake end-to-end runs, not skipped); fixture dir left clean
- [ ] CI Linux editor-release leg builds + runs all ctest entries green