### PR TITLE
Add Android targets to Export Build modal

### DIFF
--- a/src/Editor/ExportBuilder.cpp
+++ b/src/Editor/ExportBuilder.cpp
@@ -13,10 +13,23 @@ namespace octarine::editor
     namespace
     {
 #ifdef _WIN32
-        constexpr const char* kBuildScriptFile = "build-desktop.ps1";
+        constexpr const char* kScriptExt = ".ps1";
 #else
-        constexpr const char* kBuildScriptFile = "build-desktop.sh";
+        constexpr const char* kScriptExt = ".sh";
 #endif
+
+        const char* ScriptStem(ExportTarget target)
+        {
+            switch (target)
+            {
+            case ExportTarget::Desktop:
+                return "build-desktop";
+            case ExportTarget::AndroidDebug:
+            case ExportTarget::AndroidRelease:
+                return "build-android";
+            }
+            return "build-desktop";
+        }
 
         bool FileExists(const std::filesystem::path& p)
         {
@@ -26,9 +39,10 @@ namespace octarine::editor
     } // namespace
 
     std::optional<std::filesystem::path>
-    ExportBuilder::ResolveBuildScript(const std::filesystem::path& project_dir)
+    ExportBuilder::ResolveBuildScript(const std::filesystem::path& project_dir, ExportTarget target)
     {
-        std::filesystem::path candidate = project_dir / "scripts" / kBuildScriptFile;
+        const std::string filename = std::string(ScriptStem(target)) + kScriptExt;
+        std::filesystem::path candidate = project_dir / "scripts" / filename;
         if (FileExists(candidate))
         {
             return candidate;
@@ -36,7 +50,8 @@ namespace octarine::editor
         return std::nullopt;
     }
 
-    std::vector<std::string> ExportBuilder::Validate(const std::filesystem::path& project_dir)
+    std::vector<std::string>
+    ExportBuilder::Validate(const std::filesystem::path& project_dir, ExportTarget target)
     {
         std::vector<std::string> errors;
 
@@ -53,10 +68,11 @@ namespace octarine::editor
             }
         }
 
-        if (!ResolveBuildScript(project_dir))
+        if (!ResolveBuildScript(project_dir, target))
         {
+            const std::string filename = std::string(ScriptStem(target)) + kScriptExt;
             errors.push_back(
-                "missing scripts/" + std::string(kBuildScriptFile) +
+                "missing scripts/" + filename +
                 " — run scripts/octarine-init-build to scaffold it");
         }
 
@@ -74,7 +90,7 @@ namespace octarine::editor
         stdout_partial_.clear();
         stderr_partial_.clear();
 
-        auto errors = Validate(opts.project_dir);
+        auto errors = Validate(opts.project_dir, opts.target);
         if (!errors.empty())
         {
             for (auto& e : errors)
@@ -85,7 +101,7 @@ namespace octarine::editor
             return false;
         }
 
-        auto resolved = ResolveBuildScript(opts.project_dir);
+        auto resolved = ResolveBuildScript(opts.project_dir, opts.target);
         // ResolveBuildScript already non-null because Validate passed; double-check to silence the
         // optional unwrap and to keep behaviour explicit if Validate's policy diverges later.
         if (!resolved)
@@ -95,6 +111,21 @@ namespace octarine::editor
             return false;
         }
         resolved_script_ = *resolved;
+
+        // build-android takes a positional `release|debug` mode arg; build-desktop ignores extra
+        // positional args. Pass it for Android only so the script header stays single-purpose.
+        const char* android_mode = nullptr;
+        switch (opts.target)
+        {
+        case ExportTarget::AndroidDebug:
+            android_mode = "debug";
+            break;
+        case ExportTarget::AndroidRelease:
+            android_mode = "release";
+            break;
+        case ExportTarget::Desktop:
+            break;
+        }
 
         octarine::process::SpawnOptions po;
 #ifdef _WIN32
@@ -106,9 +137,18 @@ namespace octarine::editor
         po.argv.push_back("Bypass");
         po.argv.push_back("-File");
         po.argv.push_back(resolved_script_.string());
+        if (android_mode)
+        {
+            po.argv.emplace_back("-Mode");
+            po.argv.emplace_back(android_mode);
+        }
 #else
         po.argv.push_back("bash");
         po.argv.push_back(resolved_script_.string());
+        if (android_mode)
+        {
+            po.argv.emplace_back(android_mode);
+        }
 #endif
         po.cwd = opts.project_dir.string();
 
@@ -120,10 +160,14 @@ namespace octarine::editor
         {
             po.env.emplace_back("OCTARINE_VERSION_CODE", opts.version_code);
         }
-        if (!opts.preset.empty())
+        if (opts.target == ExportTarget::Desktop && !opts.preset.empty())
         {
             po.env.emplace_back("OCTARINE_PRESET", opts.preset);
         }
+        // AndroidRelease signing creds are inherited from the editor process's env (the user sets
+        // OCTARINE_ANDROID_KEYSTORE_PATH etc. before launching the editor). The Process wrapper's
+        // default inherit_env=true is what carries them through; PR-C adds in-editor secret storage
+        // so the dev no longer has to manage their shell env.
 
         auto p = octarine::process::Process::Spawn(po);
         if (!p)

--- a/src/Editor/ExportBuilder.h
+++ b/src/Editor/ExportBuilder.h
@@ -2,14 +2,16 @@
 
 #ifdef OCTARINE_WITH_EDITOR
 
-// ExportBuilder — Stage 5 of ai/EditorBuildAndDeployPlan.md (PR-A: runner + UI for host-OS desktop).
+// ExportBuilder — Stage 5 of ai/EditorBuildAndDeployPlan.md.
 //
-// Wraps the spawn of the project's `scripts/build-desktop.{sh,ps1}` scaffolded by Stage 4. Mirrors
-// PlayerLauncher: a Registry singleton with a state machine (Idle -> Building -> Succeeded/Failed),
-// a ring-capped log of subprocess stdout/stderr, and a per-frame Pump() drained on the main thread.
+// Wraps the spawn of a project's scaffolded build script (`scripts/build-desktop.{sh,ps1}` for the
+// host-OS desktop target, `scripts/build-android.{sh,ps1}` for Android). Mirrors PlayerLauncher: a
+// Registry singleton with a state machine (Idle -> Building -> Succeeded/Failed), a ring-capped log
+// of subprocess stdout/stderr, and a per-frame Pump() drained on the main thread.
 //
-// Out of scope this PR (deferred per plan): Android targets, signing-credentials prompt, SHA256
-// of artifact, "Reveal in Explorer" / clipboard install hint.
+// Out of scope (deferred per plan): in-editor signing-credential storage (PR-C: DPAPI/keychain),
+// SHA256 of artifact, "Reveal in Explorer" / clipboard install hint. AndroidRelease signing creds
+// flow via the editor process's existing env vars (OCTARINE_ANDROID_KEYSTORE_PATH, etc.).
 
 #include "Process/Process.h"
 
@@ -31,6 +33,13 @@ namespace octarine::editor
         Failed,
     };
 
+    enum class ExportTarget
+    {
+        Desktop,        // host-OS via scripts/build-desktop.{sh,ps1}
+        AndroidDebug,   // assembleDebug via scripts/build-android.{sh,ps1} debug
+        AndroidRelease, // bundleRelease via scripts/build-android.{sh,ps1} release
+    };
+
     struct ExportLogLine
     {
         bool is_stderr = false;
@@ -40,9 +49,10 @@ namespace octarine::editor
     struct ExportOptions
     {
         std::filesystem::path project_dir;
+        ExportTarget target = ExportTarget::Desktop;
         std::string version_name; // optional; empty -> falls through to project.ini
         std::string version_code; // optional; empty -> falls through to project.ini
-        std::string preset;       // optional; empty -> emitted script default (ship-release)
+        std::string preset;       // Desktop only; empty -> emitted script default (ship-release)
     };
 
     class ExportBuilder
@@ -52,14 +62,14 @@ namespace octarine::editor
         // ready to build. Mirrors the policy enforced by the scaffolded script + Gradle/CMake
         // identity validators so the UI can surface failures inline.
         //   - project_dir contains project.ini, and ProjectIni::ValidateForShipping passes
-        //   - scripts/build-desktop.sh (POSIX) or scripts/build-desktop.ps1 (Windows) exists
-        //   - cmake is on PATH
-        static std::vector<std::string> Validate(const std::filesystem::path& project_dir);
+        //   - the scaffolded build script for the target exists under <project>/scripts/
+        static std::vector<std::string>
+        Validate(const std::filesystem::path& project_dir, ExportTarget target = ExportTarget::Desktop);
 
-        // Spawns the scaffolded build-desktop script with env vars set per the ExportOptions.
-        // Returns false when Validate() fails (errors are pushed into the log as stderr lines and
-        // status flips to Failed) or when spawning the script fails. A no-op (returning true) when
-        // a build is already Building.
+        // Spawns the scaffolded build script for `opts.target` with env vars set per the
+        // ExportOptions. Returns false when Validate() fails (errors are pushed into the log as
+        // stderr lines and status flips to Failed) or when spawning the script fails. A no-op
+        // (returning true) when a build is already Building.
         bool Run(const ExportOptions& opts);
 
         // Terminates the running script subprocess if any. No-op when not Building.
@@ -81,9 +91,11 @@ namespace octarine::editor
         LogSnapshot LogCopy() const;
         void ClearLog();
 
-        // Picks scripts/build-desktop.ps1 on Windows, scripts/build-desktop.sh elsewhere. Returns
-        // nullopt if neither flavor exists. Public for unit testing.
-        static std::optional<std::filesystem::path> ResolveBuildScript(const std::filesystem::path& project_dir);
+        // Picks the script flavor (.ps1 on Windows, .sh elsewhere) for the requested target. Returns
+        // nullopt if the script is missing. Public for unit testing.
+        static std::optional<std::filesystem::path>
+        ResolveBuildScript(const std::filesystem::path& project_dir,
+                           ExportTarget target = ExportTarget::Desktop);
 
     private:
         static constexpr std::size_t kLogCap = 4096;

--- a/src/Systems/RenderDebugGUISystem.cpp
+++ b/src/Systems/RenderDebugGUISystem.cpp
@@ -340,6 +340,21 @@ static bool openExportBuildModal = false;
         static char versionCodeBuf[16] = "";
         static std::string lastProjectDir;
         static std::vector<std::string> validationErrors;
+        static int targetIdx = 0; // 0=Desktop, 1=AndroidDebug, 2=AndroidRelease
+
+        constexpr const char* kTargetLabels[] = {
+            "Desktop (host OS, ship-release)",
+            "Android (debug APK)",
+            "Android (release AAB)",
+        };
+        const auto targetForIdx = [](int idx) {
+            switch (idx)
+            {
+            case 1: return octarine::editor::ExportTarget::AndroidDebug;
+            case 2: return octarine::editor::ExportTarget::AndroidRelease;
+            default: return octarine::editor::ExportTarget::Desktop;
+            }
+        };
 
         const std::string projectDir = registry->Get<AssetManager>().GetBasePath();
 
@@ -359,11 +374,17 @@ static bool openExportBuildModal = false;
                     std::snprintf(versionCodeBuf, sizeof(versionCodeBuf), "%s", ini->version_code.c_str());
                 }
             }
-            validationErrors = octarine::editor::ExportBuilder::Validate(std::filesystem::path(projectDir));
+            validationErrors = octarine::editor::ExportBuilder::Validate(
+                std::filesystem::path(projectDir), targetForIdx(targetIdx));
         }
 
-        ImGui::Text("Target: host OS (ship-release preset)");
         ImGui::TextDisabled("Project: %s", projectDir.empty() ? "(none)" : projectDir.c_str());
+        ImGui::SetNextItemWidth(260);
+        if (ImGui::Combo("Target", &targetIdx, kTargetLabels, IM_ARRAYSIZE(kTargetLabels)))
+        {
+            validationErrors = octarine::editor::ExportBuilder::Validate(
+                std::filesystem::path(projectDir), targetForIdx(targetIdx));
+        }
         ImGui::Separator();
 
         ImGui::SetNextItemWidth(180);
@@ -371,6 +392,19 @@ static bool openExportBuildModal = false;
         ImGui::SetNextItemWidth(180);
         ImGui::InputText("Version code", versionCodeBuf, sizeof(versionCodeBuf));
         ImGui::TextDisabled("Leave blank to fall through to project.ini.");
+
+        if (targetIdx == 2)
+        {
+            ImGui::Separator();
+            ImGui::TextColored(ImVec4(1.0F, 0.85F, 0.4F, 1.0F),
+                               "Android-release expects signing creds in env:");
+            ImGui::BulletText("OCTARINE_ANDROID_KEYSTORE_PATH");
+            ImGui::BulletText("OCTARINE_ANDROID_STORE_PASSWORD");
+            ImGui::BulletText("OCTARINE_ANDROID_KEY_ALIAS");
+            ImGui::BulletText("OCTARINE_ANDROID_KEY_PASSWORD");
+            ImGui::TextDisabled(
+                "Unset = falls back to the Gradle debug key. In-editor secret storage lands in PR-C.");
+        }
 
         if (!validationErrors.empty())
         {
@@ -390,6 +424,7 @@ static bool openExportBuildModal = false;
         {
             octarine::editor::ExportOptions opts;
             opts.project_dir = std::filesystem::path(projectDir);
+            opts.target = targetForIdx(targetIdx);
             opts.version_name = versionNameBuf;
             opts.version_code = versionCodeBuf;
 
@@ -407,7 +442,8 @@ static bool openExportBuildModal = false;
         ImGui::SameLine();
         if (ImGui::Button("Re-validate"))
         {
-            validationErrors = octarine::editor::ExportBuilder::Validate(std::filesystem::path(projectDir));
+            validationErrors = octarine::editor::ExportBuilder::Validate(
+                std::filesystem::path(projectDir), targetForIdx(targetIdx));
         }
         ImGui::EndPopup();
     }


### PR DESCRIPTION
## Summary

Stage 5 PR-B of `ai/EditorBuildAndDeployPlan.md` — extends the Export Build flow with Android targets so the editor can drive `scripts/build-android.{sh,ps1}` from Stage 4.

- `ExportBuilder` gains an `ExportTarget` enum (`Desktop` / `AndroidDebug` / `AndroidRelease`). `ResolveBuildScript` + `Validate` now take a target and pick `build-android` vs `build-desktop` accordingly.
- POSIX spawn passes the positional `release` / `debug` arg the bash script expects; the PS1 flavor receives `-Mode release|debug` to match its param block.
- `Process` default `inherit_env=true` carries the editor's signing env into the subprocess for AndroidRelease (`OCTARINE_ANDROID_KEYSTORE_PATH`, `_STORE_PASSWORD`, `_KEY_ALIAS`, `_KEY_PASSWORD`). Unset = Gradle falls back to the debug key per the scaffolded script.
- Modal gains a Target combo and an inline signing-creds contract callout for `AndroidRelease`.

Out of scope (deferred):
- In-editor signing-credential storage (PR-C: DPAPI on Windows, Keychain on macOS; Linux stays env-var-driven for now).
- SHA256 of artifact + Reveal-in-Explorer + install-cmd clipboard hint (PR-C).

## Test plan

- [x] `cmake --preset editor-debug && cmake --build build/editor-debug` — clean compile, 44/44 objects.
- [x] `ResolveBuildScript` returns the per-target filename (`build-android.ps1` / `.sh` for Android, unchanged for Desktop).
- [x] `Validate` surfaces a missing-script error keyed off the target.
- [ ] Manual: open Example project, scaffold via `octarine-init-build`, switch modal to Android (debug APK), confirm `gradlew assembleDebug` runs.
- [ ] Manual: set `OCTARINE_ANDROID_KEYSTORE_PATH` etc. in shell, relaunch editor, run Android (release AAB), confirm signed AAB produced.
- [ ] Manual: unset signing env, run Android (release AAB), confirm fallback to debug key (Gradle warning surfaces in the Export Output panel).