### PR TITLE
Add Doppler shift for spatial audio (Sound plan Phase 4)

### DIFF
--- a/src/Components/AudioListenerComponent.h
+++ b/src/Components/AudioListenerComponent.h
@@ -8,21 +8,35 @@ struct AudioListenerComponent {
   float maxDistance = 1000.0f;
   float rolloff = 1.0f;
 
+  // Phase 4 Doppler. Factor 0 disables the shift, 1 is physical, >1 exaggerates.
+  // speedOfSound is in world units / second; tune per project (default 343 ≈ m/s if
+  // 1 world unit ≈ 1 m).
+  float dopplerFactor = 1.0f;
+  float speedOfSound = 343.0f;
+
   AudioListenerComponent() = default;
-  explicit AudioListenerComponent(float t_maxDistance, float t_rolloff = 1.0f)
-      : maxDistance(t_maxDistance), rolloff(t_rolloff) {}
+  explicit AudioListenerComponent(float t_maxDistance, float t_rolloff = 1.0f, float t_dopplerFactor = 1.0f,
+                                  float t_speedOfSound = 343.0f)
+      : maxDistance(t_maxDistance),
+        rolloff(t_rolloff),
+        dopplerFactor(t_dopplerFactor),
+        speedOfSound(t_speedOfSound) {}
 };
 
 // Singleton cache populated each frame by UpdateListenerTransformSystem and read by
-// SpatialAudioSystem. Decouples spatial-audio math from the listener-entity query so the
-// per-emitter callback can short-circuit without re-iterating archetypes. `valid` flips to
-// false when no listener entity exists; emitters skip spatial logic in that case.
+// SpatialAudioSystem / DopplerSystem. Decouples spatial-audio math from the listener-entity
+// query so per-emitter callbacks can short-circuit without re-iterating archetypes.
+// `valid` flips to false when no listener entity exists; emitters skip spatial logic in
+// that case.
 struct AudioListenerCache {
   Entity entity{};
   glm::vec2 position{0.0f, 0.0f};
+  glm::vec2 velocity{0.0f, 0.0f};
   glm::vec2 forward{0.0f, 1.0f};
   glm::vec2 right{1.0f, 0.0f};
   float maxDistance = 1000.0f;
   float rolloff = 1.0f;
+  float dopplerFactor = 1.0f;
+  float speedOfSound = 343.0f;
   bool valid = false;
 };

--- a/src/Components/AudioSourceComponent.h
+++ b/src/Components/AudioSourceComponent.h
@@ -17,9 +17,15 @@ struct AudioSourceComponent {
   float minDistance = 50.0f;
   float maxDistance = 1000.0f;
 
+  // Phase 4 doppler: when `doppler` is true AND the entity has a RigidBodyComponent,
+  // DopplerSystem applies a per-frame frequency ratio via MIX_SetTrackFrequencyRatio.
+  // Independent of `spatial` — a non-spatial doppler source is allowed but unusual.
+  bool doppler = false;
+
   explicit AudioSourceComponent(std::string t_clipId = "", float t_volume = 1.0f, float t_pitch = 1.0f,
                                 bool t_loop = false, bool t_playOnSpawn = true, bool t_despawnOnFinish = false,
-                                bool t_spatial = false, float t_minDistance = 50.0f, float t_maxDistance = 1000.0f)
+                                bool t_spatial = false, float t_minDistance = 50.0f, float t_maxDistance = 1000.0f,
+                                bool t_doppler = false)
       : clipId(std::move(t_clipId)),
         volume(t_volume),
         pitch(t_pitch),
@@ -28,5 +34,6 @@ struct AudioSourceComponent {
         despawnOnFinish(t_despawnOnFinish),
         spatial(t_spatial),
         minDistance(t_minDistance),
-        maxDistance(t_maxDistance) {}
+        maxDistance(t_maxDistance),
+        doppler(t_doppler) {}
 };

--- a/src/Game/Game.cpp
+++ b/src/Game/Game.cpp
@@ -56,6 +56,7 @@
 #include "Systems/CameraFollowSystem.h"
 #include "Systems/CollisionSystem.h"
 #include "Systems/DamageSystem.h"
+#include "Systems/DopplerSystem.h"
 #include "Systems/DrawColliderSystem.h"
 #include "Systems/EntityPoolSystem.h"
 #include "Systems/InputSystem.h"
@@ -853,6 +854,11 @@ void Game::Setup()
     registry_->Set<AudioListenerCache>(AudioListenerCache{});
     registry_->RegisterBulkSystem<GlobalTransformComponent>(UpdateListenerTransformSystem());
     registry_->RegisterSystem<GlobalTransformComponent, AudioSourceComponent, AudioSinkComponent>(SpatialAudioSystem());
+    // Doppler is independent of spatial: governs frequency ratio via MIX_SetTrackFrequencyRatio.
+    // Requires RigidBodyComponent on the emitter (no body → no velocity → no shift).
+    registry_
+        ->RegisterSystem<GlobalTransformComponent, RigidBodyComponent, AudioSourceComponent, AudioSinkComponent>(
+            DopplerSystem());
 
     // Camera follows after gameplay-driven transform updates
     registry_->RegisterSystem<PositionComponent, CameraFollowComponent>(CameraFollowSystem());

--- a/src/Lua/Bindings/AudioListenerComponentLuaBinding.h
+++ b/src/Lua/Bindings/AudioListenerComponentLuaBinding.h
@@ -18,13 +18,17 @@ struct LuaBinding<AudioListenerComponent>
         const auto t = data.as<sol::table>();
         const float maxDistance = SafeGetOptionalValue<float>(t, "max_distance", 1000.0f);
         const float rolloff = SafeGetOptionalValue<float>(t, "rolloff", 1.0f);
-        return AudioListenerComponent(maxDistance, rolloff);
+        const float dopplerFactor = SafeGetOptionalValue<float>(t, "doppler_factor", 1.0f);
+        const float speedOfSound = SafeGetOptionalValue<float>(t, "speed_of_sound", 343.0f);
+        return AudioListenerComponent(maxDistance, rolloff, dopplerFactor, speedOfSound);
     }
 
     static void bindUsertype(sol::state& lua)
     {
         lua.new_usertype<AudioListenerComponent>(kUsertypeName,
                                                  "max_distance", &AudioListenerComponent::maxDistance,
-                                                 "rolloff", &AudioListenerComponent::rolloff);
+                                                 "rolloff", &AudioListenerComponent::rolloff,
+                                                 "doppler_factor", &AudioListenerComponent::dopplerFactor,
+                                                 "speed_of_sound", &AudioListenerComponent::speedOfSound);
     }
 };

--- a/src/Lua/Bindings/AudioSourceComponentLuaBinding.h
+++ b/src/Lua/Bindings/AudioSourceComponentLuaBinding.h
@@ -24,8 +24,9 @@ struct LuaBinding<AudioSourceComponent>
         const bool spatial = SafeGetOptionalValue<bool>(t, "spatial", false);
         const float minDistance = SafeGetOptionalValue<float>(t, "min_distance", 50.0f);
         const float maxDistance = SafeGetOptionalValue<float>(t, "max_distance", 1000.0f);
+        const bool doppler = SafeGetOptionalValue<bool>(t, "doppler", false);
         return AudioSourceComponent(clipId, volume, pitch, loop, playOnSpawn, despawnOnFinish, spatial, minDistance,
-                                    maxDistance);
+                                    maxDistance, doppler);
     }
 
     static void bindUsertype(sol::state& lua)
@@ -39,6 +40,7 @@ struct LuaBinding<AudioSourceComponent>
                                                "despawn_on_finish", &AudioSourceComponent::despawnOnFinish,
                                                "spatial", &AudioSourceComponent::spatial,
                                                "min_distance", &AudioSourceComponent::minDistance,
-                                               "max_distance", &AudioSourceComponent::maxDistance);
+                                               "max_distance", &AudioSourceComponent::maxDistance,
+                                               "doppler", &AudioSourceComponent::doppler);
     }
 };

--- a/src/Systems/DopplerSystem.h
+++ b/src/Systems/DopplerSystem.h
@@ -24,34 +24,40 @@
 // SDL3_mixer's MIX_Track exposes a built-in per-track frequency ratio (added in the
 // MIX_Track API revision). The original plan called for a Mix_RegisterEffect / postmix
 // resampler or an SDL_AudioStream rewrite — both unnecessary against this surface.
+//
+// Cache pointer is hoisted to a member (mirrors SpatialAudioSystem) so the per-emitter
+// callback avoids a Registry::Get<AudioListenerCache>() hashmap lookup per call.
+// MIX_SetTrackFrequencyRatio fires only when the computed ratio differs from
+// sink.lastRatio so an unchanged ratio (the steady-state case) costs zero mixer calls.
 class DopplerSystem {
  public:
   void operator()(const ContextFacade& ctx, const GlobalTransformComponent& transform,
                   const RigidBodyComponent& rigidBody, AudioSourceComponent& source, AudioSinkComponent& sink) {
     if (sink.finished || !sink.track) return;
 
-    auto* registry = ctx.GetRegistry();
-    const auto& cache = registry->Get<AudioListenerCache>();
+    if (!cache_) cache_ = &ctx.GetRegistry()->Get<AudioListenerCache>();
+    const auto& cache = *cache_;
 
-    if (!source.doppler || !cache.valid) {
-      MIX_SetTrackFrequencyRatio(sink.track, 1.0f);
-      return;
+    const float ratio = ComputeRatio(transform, rigidBody, source, cache);
+    if (ratio != sink.lastRatio) {
+      MIX_SetTrackFrequencyRatio(sink.track, ratio);
+      sink.lastRatio = ratio;
     }
+  }
+
+ private:
+  static float ComputeRatio(const GlobalTransformComponent& transform, const RigidBodyComponent& rigidBody,
+                            const AudioSourceComponent& source, const AudioListenerCache& cache) {
+    if (!source.doppler || !cache.valid) return 1.0f;
 
     const float c = std::max(1.0f, cache.speedOfSound);
     const float factor = std::max(0.0f, cache.dopplerFactor);
-    if (factor <= 0.0f) {
-      MIX_SetTrackFrequencyRatio(sink.track, 1.0f);
-      return;
-    }
+    if (factor <= 0.0f) return 1.0f;
 
     const glm::vec2 rel = transform.position - cache.position;
     constexpr float kEpsilon = 1e-4f;
     const float distance = glm::length(rel);
-    if (distance <= kEpsilon) {
-      MIX_SetTrackFrequencyRatio(sink.track, 1.0f);
-      return;
-    }
+    if (distance <= kEpsilon) return 1.0f;
     const glm::vec2 dir = rel / distance;
 
     // Radial components: positive = receding from listener, negative = approaching.
@@ -63,8 +69,8 @@ class DopplerSystem {
     // exaggerated dopplerFactor doesn't yank a track into ultrasonic / DC territory.
     const float denom = std::max(c - vsRadial * factor, c * 0.01f);
     const float numer = c + vlRadial * factor;
-    const float ratio = std::clamp(numer / denom, 0.25f, 4.0f);
-
-    MIX_SetTrackFrequencyRatio(sink.track, ratio);
+    return std::clamp(numer / denom, 0.25f, 4.0f);
   }
+
+  const AudioListenerCache* cache_ = nullptr;
 };

--- a/src/Systems/DopplerSystem.h
+++ b/src/Systems/DopplerSystem.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <SDL3_mixer/SDL_mixer.h>
+
+#include <algorithm>
+#include <cmath>
+#include <glm/glm.hpp>
+
+#include "../Components/AudioListenerComponent.h"
+#include "../Components/AudioSinkComponent.h"
+#include "../Components/AudioSourceComponent.h"
+#include "../Components/GlobalTransformComponent.h"
+#include "../Components/RigidBodyComponent.h"
+#include "../ECS/Iterable.h"
+#include "../ECS/Registry.h"
+
+// Per-emitter system: applies Doppler shift via MIX_SetTrackFrequencyRatio. Registered on
+// the (GlobalTransform, RigidBody, AudioSource, AudioSink) archetype — a doppler-flagged
+// source on an entity without a RigidBodyComponent is silently ignored (no velocity, no
+// shift). Runs alongside SpatialAudioSystem; the two are independent: spatial governs
+// gain + pan, this governs frequency ratio. Toggling `source.doppler` false at runtime
+// resets the ratio to 1.0 on the next frame.
+//
+// SDL3_mixer's MIX_Track exposes a built-in per-track frequency ratio (added in the
+// MIX_Track API revision). The original plan called for a Mix_RegisterEffect / postmix
+// resampler or an SDL_AudioStream rewrite — both unnecessary against this surface.
+class DopplerSystem {
+ public:
+  void operator()(const ContextFacade& ctx, const GlobalTransformComponent& transform,
+                  const RigidBodyComponent& rigidBody, AudioSourceComponent& source, AudioSinkComponent& sink) {
+    if (sink.finished || !sink.track) return;
+
+    auto* registry = ctx.GetRegistry();
+    const auto& cache = registry->Get<AudioListenerCache>();
+
+    if (!source.doppler || !cache.valid) {
+      MIX_SetTrackFrequencyRatio(sink.track, 1.0f);
+      return;
+    }
+
+    const float c = std::max(1.0f, cache.speedOfSound);
+    const float factor = std::max(0.0f, cache.dopplerFactor);
+    if (factor <= 0.0f) {
+      MIX_SetTrackFrequencyRatio(sink.track, 1.0f);
+      return;
+    }
+
+    const glm::vec2 rel = transform.position - cache.position;
+    constexpr float kEpsilon = 1e-4f;
+    const float distance = glm::length(rel);
+    if (distance <= kEpsilon) {
+      MIX_SetTrackFrequencyRatio(sink.track, 1.0f);
+      return;
+    }
+    const glm::vec2 dir = rel / distance;
+
+    // Radial components: positive = receding from listener, negative = approaching.
+    const float vsRadial = glm::dot(rigidBody.velocity, dir);
+    const float vlRadial = glm::dot(cache.velocity, dir);
+
+    // Clamp denominator away from zero to avoid the Mach-1 singularity (object moving
+    // toward listener at the speed of sound). Cap ratio to a sane musical range so an
+    // exaggerated dopplerFactor doesn't yank a track into ultrasonic / DC territory.
+    const float denom = std::max(c - vsRadial * factor, c * 0.01f);
+    const float numer = c + vlRadial * factor;
+    const float ratio = std::clamp(numer / denom, 0.25f, 4.0f);
+
+    MIX_SetTrackFrequencyRatio(sink.track, ratio);
+  }
+};

--- a/src/Systems/UpdateListenerTransformSystem.h
+++ b/src/Systems/UpdateListenerTransformSystem.h
@@ -4,6 +4,7 @@
 
 #include "../Components/AudioListenerComponent.h"
 #include "../Components/GlobalTransformComponent.h"
+#include "../Components/RigidBodyComponent.h"
 #include "../ECS/Iterable.h"
 #include "../ECS/Query.h"
 #include "../ECS/Registry.h"
@@ -34,6 +35,9 @@ class UpdateListenerTransformSystem {
       if (found) return;
       cache.entity = entity;
       cache.position = transform.position;
+      cache.velocity = registry->HasComponent<RigidBodyComponent>(entity)
+                           ? registry->GetComponent<RigidBodyComponent>(entity).velocity
+                           : glm::vec2(0.0f, 0.0f);
       // 2D top-down basis. When camera rotation lands later, derive forward/right from
       // the camera's world rotation here so the spatial math stays decoupled from any
       // listener-entity rotation (the "Listener Dilemma" decoupling).
@@ -41,6 +45,8 @@ class UpdateListenerTransformSystem {
       cache.right = glm::vec2(1.0f, 0.0f);
       cache.maxDistance = listener.maxDistance;
       cache.rolloff = listener.rolloff;
+      cache.dopplerFactor = listener.dopplerFactor;
+      cache.speedOfSound = listener.speedOfSound;
       cache.valid = true;
       found = true;
     });


### PR DESCRIPTION
## Summary
- Adds `DopplerSystem` registered on `(GlobalTransform, RigidBody, AudioSource, AudioSink)`; computes radial velocities (emitter + listener) and applies `MIX_SetTrackFrequencyRatio` per emitter.
- Extends `AudioListenerComponent` with `dopplerFactor` + `speedOfSound`; extends `AudioSourceComponent` with `doppler` bool. Lua bindings updated.
- `UpdateListenerTransformSystem` now snapshots listener velocity + Doppler params into `AudioListenerCache`.
- Same perf hygiene as the Spatial pass: cache pointer hoisted to a system member, `MIX_SetTrackFrequencyRatio` fires only on `sink.lastRatio` change.

Replaces #83 (closed when its base branch `sound-phase3` was deleted on merge of #82). Now based on main.

Stage 4 of [ai/SoundPlan.md](../blob/main/ai/SoundPlan.md). Plan called for a `Mix_RegisterEffect` resampler or `SDL_AudioStream` rewrite — neither needed: SDL3_mixer's `MIX_Track` exposes `MIX_SetTrackFrequencyRatio` directly. Plan note about that constraint is now obsolete.

## Safety guards
- Denominator clamped to `max(c - vs * factor, c * 0.01)` (Mach-1 singularity).
- Output ratio clamped to `[0.25, 4.0]` (musical range; prevents exaggerated `dopplerFactor` from driving a track to DC / ultrasonic).
- `dopplerFactor <= 0` short-circuits to ratio 1.0.
- Distance-zero (emitter on listener) short-circuits to ratio 1.0.

## Test plan
- [ ] Lua pass-by scene: siren entity with `doppler = true` + `RigidBodyComponent.velocity` passes stationary listener. Verify pitch rises then falls.
- [ ] Set `doppler_factor = 0` on listener → pitch stays flat.
- [ ] Circular motion at constant radius around listener → no pitch change.
- [ ] Toggle `source.doppler = false` at runtime → ratio resets to 1.0 next frame.
- [ ] Doppler-flagged source on entity *without* RigidBodyComponent → silently ignored.