### PR TITLE
Lua script hot reload (file-backed ScriptComponent + mtime watcher)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,8 @@ set(SRC_FILES
         src/Lua/Modules/IoModuleLuaBinding.cpp
         src/Lua/Modules/LogModuleLuaBinding.cpp
         src/Lua/Modules/SceneModuleLuaBinding.cpp
+        src/Lua/HotReload/ScriptWatcher.cpp
+        src/Lua/HotReload/ScriptHotReload.cpp
         src/Process/Process.cpp
         src/Project/ProjectIni.cpp
         src/Renderer/Renderer.cpp

--- a/src/Components/ScriptComponent.h
+++ b/src/Components/ScriptComponent.h
@@ -1,17 +1,24 @@
 #pragma once
 
 #include <sol/sol.hpp>
+#include <string>
 #include <utility>
 
 struct ScriptComponent {
   sol::table scriptTable;
   sol::protected_function updateFunction;
   sol::protected_function onDebugGUIFunction;
+  // Absolute path of the script file this component was loaded from, when the author opted into
+  // the file-backed form (`script = { source = "scripts/foo.lua" }`). Empty for inline tables —
+  // those are not eligible for hot reload.
+  std::string sourcePath;
 
   explicit ScriptComponent(sol::table t_scriptTable = sol::lua_nil,
                            sol::protected_function t_updateFunction = sol::lua_nil,
-                           sol::protected_function t_onDebugGUIFunction = sol::lua_nil)
+                           sol::protected_function t_onDebugGUIFunction = sol::lua_nil,
+                           std::string t_sourcePath = {})
       : scriptTable(std::move(t_scriptTable)),
         updateFunction(std::move(t_updateFunction)),
-        onDebugGUIFunction(std::move(t_onDebugGUIFunction)) {}
+        onDebugGUIFunction(std::move(t_onDebugGUIFunction)),
+        sourcePath(std::move(t_sourcePath)) {}
 };

--- a/src/Game/EngineOptions.h
+++ b/src/Game/EngineOptions.h
@@ -17,4 +17,8 @@ struct EngineOptions {
   // When true, a scene whose asset references fail validation aborts the load (dev gate). Off by
   // default so players never hard-fail; the bake step is the CI enforcement point.
   bool assetValidationFatal = false;
+  // Lua script hot reload. Compiled out under OCTARINE_SHIPPED; in dev/editor builds this is the
+  // runtime toggle. Poll cadence is mtime-based, single-threaded, on the main loop.
+  bool hotReloadEnabled = true;
+  float hotReloadPollSeconds = 0.25F;
 };

--- a/src/Game/Game.cpp
+++ b/src/Game/Game.cpp
@@ -47,6 +47,7 @@
 #include "Lua/Bindings/InputSystemLuaBinding.h"
 #include "Lua/Bindings/LuaSystemRegistry.h"
 #include "Lua/Bindings/RegisterAllBindings.h"
+#include "Lua/HotReload/ScriptHotReload.h"
 #include "Lua/LuaApiManifest.h"
 #include "Lua/LuaEntityLoader.h"
 #include "Lua/Modules/RegisterAllModules.h"
@@ -875,6 +876,10 @@ void Game::Setup()
 
     // Pre-build the debug-collider query once so we don't allocate per render frame.
     collider_query_ = registry_->CreateQuery<GlobalTransformComponent, BoxColliderComponent>();
+
+    // Hot reload owns its own ScriptWatcher + (path -> entities) discovery loop. Compiled out
+    // under OCTARINE_SHIPPED; in dev/editor builds the runtime gate lives on EngineOptions.
+    registry_->Set<ScriptHotReload>(ScriptHotReload());
 }
 
 void Game::ProcessInput() const
@@ -959,6 +964,18 @@ void Game::Update(const float deltaTime)
     {
         inputSystem->BeginFrame();
     }
+
+#ifndef OCTARINE_SHIPPED
+    // Run hot reload even when paused — authors iterate code with the editor paused all the time,
+    // and the swap is cheap. Uses real deltaTime (not time-scaled) so the poll cadence is stable.
+    if (options.hotReloadEnabled)
+    {
+        if (auto* hotReload = registry_->TryGet<ScriptHotReload>())
+        {
+            hotReload->Tick(*registry_, lua, deltaTime, options.hotReloadPollSeconds);
+        }
+    }
+#endif
 
     if (!options.isPaused || options.stepFrame)
     {

--- a/src/Game/GameConfig.cpp
+++ b/src/Game/GameConfig.cpp
@@ -173,6 +173,8 @@ bool GameConfig::LoadConfig(const std::unordered_map<std::string, std::string> &
   success &= SetValue(settings, "DefaultScalingMode", &GameConfig::SetDefaultScaleMode, false);
   success &= SetValue(settings, "DefaultWindowWidth", &GameConfig::SetDefaultWidth, false);
   success &= SetValue(settings, "DefaultWindowHeight", &GameConfig::SetDefaultHeight, false);
+  success &= SetValue(settings, "HotReload", &GameConfig::SetHotReloadEnabled, false);
+  success &= SetValue(settings, "HotReloadPollSeconds", &GameConfig::SetHotReloadPollSeconds, false);
 
   return success;
 }
@@ -248,6 +250,19 @@ void GameConfig::SetDefaultScaleMode(const std::string &defaultScaleMode) {
 }
 void GameConfig::SetDefaultWidth(const int defaultWidth) { default_width_ = defaultWidth; }
 void GameConfig::SetDefaultHeight(const int defaultHeight) { default_height_ = defaultHeight; }
+
+void GameConfig::SetHotReloadEnabled(const bool enabled) {
+  engine_options_.hotReloadEnabled = enabled;
+  Logger::Info(std::string("Hot reload ") + (enabled ? "enabled" : "disabled"));
+}
+
+void GameConfig::SetHotReloadPollSeconds(const float seconds) {
+  if (seconds <= 0.0F) {
+    Logger::Warn("HotReloadPollSeconds must be > 0; keeping current value.");
+    return;
+  }
+  engine_options_.hotReloadPollSeconds = seconds;
+}
 
 void GameConfig::SetLogLevel(const std::string &logLevel) {
   if (logLevel.empty()) return;

--- a/src/Game/GameConfig.h
+++ b/src/Game/GameConfig.h
@@ -91,12 +91,29 @@ class GameConfig {
     return SetValue<int>(config, key, setter, [](const std::string& s) { return std::stoi(s); }, required);
   }
 
+  bool SetValue(const std::unordered_map<std::string, std::string>& config, const std::string& key,
+                void (GameConfig::*setter)(bool), const bool required = false) {
+    return SetValue<bool>(
+        config, key, setter,
+        [](const std::string& s) {
+          return s == "true" || s == "1" || s == "yes" || s == "on";
+        },
+        required);
+  }
+
+  bool SetValue(const std::unordered_map<std::string, std::string>& config, const std::string& key,
+                void (GameConfig::*setter)(float), const bool required = false) {
+    return SetValue<float>(config, key, setter, [](const std::string& s) { return std::stof(s); }, required);
+  }
+
   void SetAssetPath(const std::string& assetPath);
   void SetGameTitle(const std::string& gameTitle);
   void SetStartupScript(const std::string& startupScript);
   void SetDefaultScaleMode(const std::string& defaultScaleMode);
   void SetDefaultWidth(int defaultWidth);
   void SetDefaultHeight(int defaultHeight);
+  void SetHotReloadEnabled(bool enabled);
+  void SetHotReloadPollSeconds(float seconds);
   // Runtime override of the compile-time default log level. Invoked from LoadConfig; pushes the
   // value straight into spdlog via Logger::SetLevel, so subsequent Logger calls honor it.
   void SetLogLevel(const std::string& logLevel);

--- a/src/Lua/Bindings/ScriptComponentLuaBinding.h
+++ b/src/Lua/Bindings/ScriptComponentLuaBinding.h
@@ -75,12 +75,12 @@ struct LuaBinding<ScriptComponent>
         sol::protected_function_result result = dofile(absPath);
         if (!result.valid())
         {
-            const sol::error err = result;
+            const auto err = result.get<sol::error>();
             Logger::ErrorLua("ScriptComponent dofile '" + absPath + "': " + err.what());
             return ScriptComponent(spec, sol::lua_nil, sol::lua_nil, absPath);
         }
 
-        const sol::object returned = result;
+        const auto returned = result.get<sol::object>();
         if (!returned.is<sol::table>())
         {
             Logger::Error("ScriptComponent: '" + absPath + "' did not return a table");

--- a/src/Lua/Bindings/ScriptComponentLuaBinding.h
+++ b/src/Lua/Bindings/ScriptComponentLuaBinding.h
@@ -43,7 +43,9 @@ struct LuaBinding<ScriptComponent>
     static ScriptComponent FromSource(const sol::table& spec, const std::string& relPath)
     {
         sol::state_view lua(spec.lua_state());
-        sol::protected_function getAssetPath = lua["get_asset_path"];
+        // Explicit .get<>() — implicit conversion from sol::table_proxy to protected_function is
+        // ambiguous under GCC's -Wconversion (two viable overloads; ours is the operator T()).
+        auto getAssetPath = lua["get_asset_path"].get<sol::protected_function>();
         if (!getAssetPath.valid())
         {
             Logger::Error("ScriptComponent: get_asset_path not installed; cannot resolve '" + relPath + "'");
@@ -63,7 +65,7 @@ struct LuaBinding<ScriptComponent>
 
         // protected_function so a syntax error in the file returns an invalid result instead of
         // propagating as a C++ exception (engine compiles without /EHsc).
-        sol::protected_function dofile = lua["dofile"];
+        auto dofile = lua["dofile"].get<sol::protected_function>();
         if (!dofile.valid())
         {
             Logger::Error("ScriptComponent: dofile not installed (Lua setup ordering bug)");

--- a/src/Lua/Bindings/ScriptComponentLuaBinding.h
+++ b/src/Lua/Bindings/ScriptComponentLuaBinding.h
@@ -1,8 +1,10 @@
 #pragma once
 
 #include <sol/sol.hpp>
+#include <string>
 
 #include "Components/ScriptComponent.h"
+#include "General/Logger.h"
 #include "Lua/Bindings/LuaBinding.h"
 
 template <>
@@ -13,15 +15,80 @@ struct LuaBinding<ScriptComponent>
 
     static ScriptComponent fromLua(const sol::object& data)
     {
-        const auto t = data.as<sol::table>();
+        const auto spec = data.as<sol::table>();
         using namespace LuaComponentHelpers;
-        const sol::protected_function updateFn = SafeGetProtectedFunction(t, "on_update");
-        const sol::protected_function onDebugGuiFn = SafeGetProtectedFunction(t, "on_debug_gui");
-        return ScriptComponent(t, updateFn, onDebugGuiFn);
+
+        // File-backed form: `{ source = "scripts/foo.lua" }`. The named file must return a table
+        // whose `on_update` / `on_debug_gui` / `data` fields drive the component. Recorded
+        // sourcePath flags the component for hot reload.
+        const sol::object sourceObj = spec.get<sol::object>("source");
+        if (sourceObj.is<std::string>())
+        {
+            return FromSource(spec, sourceObj.as<std::string>());
+        }
+
+        // Inline form (status quo): table itself carries on_update / on_debug_gui. sourcePath stays
+        // empty so the hot-reload subsystem leaves it alone.
+        const sol::protected_function updateFn = SafeGetProtectedFunction(spec, "on_update");
+        const sol::protected_function onDebugGuiFn = SafeGetProtectedFunction(spec, "on_debug_gui");
+        return ScriptComponent(spec, updateFn, onDebugGuiFn, /*sourcePath=*/"");
     }
 
     static void bindUsertype(sol::state& lua)
     {
         lua.new_usertype<ScriptComponent>(kUsertypeName, "data", &ScriptComponent::scriptTable);
+    }
+
+ private:
+    static ScriptComponent FromSource(const sol::table& spec, const std::string& relPath)
+    {
+        sol::state_view lua(spec.lua_state());
+        sol::protected_function getAssetPath = lua["get_asset_path"];
+        if (!getAssetPath.valid())
+        {
+            Logger::Error("ScriptComponent: get_asset_path not installed; cannot resolve '" + relPath + "'");
+            return ScriptComponent();
+        }
+
+        std::string absPath;
+        try
+        {
+            absPath = getAssetPath(relPath).get<std::string>();
+        }
+        catch (const std::exception& ex)
+        {
+            Logger::Error("ScriptComponent: get_asset_path('" + relPath + "') failed: " + ex.what());
+            return ScriptComponent();
+        }
+
+        // protected_function so a syntax error in the file returns an invalid result instead of
+        // propagating as a C++ exception (engine compiles without /EHsc).
+        sol::protected_function dofile = lua["dofile"];
+        if (!dofile.valid())
+        {
+            Logger::Error("ScriptComponent: dofile not installed (Lua setup ordering bug)");
+            return ScriptComponent();
+        }
+
+        sol::protected_function_result result = dofile(absPath);
+        if (!result.valid())
+        {
+            const sol::error err = result;
+            Logger::ErrorLua("ScriptComponent dofile '" + absPath + "': " + err.what());
+            return ScriptComponent(spec, sol::lua_nil, sol::lua_nil, absPath);
+        }
+
+        const sol::object returned = result;
+        if (!returned.is<sol::table>())
+        {
+            Logger::Error("ScriptComponent: '" + absPath + "' did not return a table");
+            return ScriptComponent(spec, sol::lua_nil, sol::lua_nil, absPath);
+        }
+
+        const sol::table loaded = returned.as<sol::table>();
+        using namespace LuaComponentHelpers;
+        const sol::protected_function updateFn = SafeGetProtectedFunction(loaded, "on_update");
+        const sol::protected_function onDebugGuiFn = SafeGetProtectedFunction(loaded, "on_debug_gui");
+        return ScriptComponent(loaded, updateFn, onDebugGuiFn, absPath);
     }
 };

--- a/src/Lua/HotReload/ScriptHotReload.cpp
+++ b/src/Lua/HotReload/ScriptHotReload.cpp
@@ -78,8 +78,9 @@ void ScriptHotReload::RefreshTracking(Registry& registry) {
 
 void ScriptHotReload::ReloadFile(const std::string& canonicalPath, Registry& registry, sol::state& lua) {
   // protected_function (not plain sol::function) so Lua errors return invalid results instead of
-  // propagating as C++ exceptions — engine + tests compile without /EHsc.
-  sol::protected_function dofile = lua["dofile"];
+  // propagating as C++ exceptions — engine + tests compile without /EHsc. Explicit .get<>()
+  // dodges GCC -Wconversion ambiguity between operator T() and the ctor overload.
+  auto dofile = lua["dofile"].get<sol::protected_function>();
   if (!dofile.valid()) {
     RecordFailure(canonicalPath, "dofile not installed");
     return;

--- a/src/Lua/HotReload/ScriptHotReload.cpp
+++ b/src/Lua/HotReload/ScriptHotReload.cpp
@@ -1,0 +1,151 @@
+#include "ScriptHotReload.h"
+
+#ifndef OCTARINE_SHIPPED
+
+#include <filesystem>
+#include <system_error>
+
+#include "../../Components/ScriptComponent.h"
+#include "../../ECS/Query.h"
+#include "../../ECS/Registry.h"
+#include "../../General/Logger.h"
+#include "../Bindings/LuaBinding.h"
+
+namespace {
+std::string Canonicalize(const std::string& absPath) {
+  std::error_code ec;
+  auto canon = std::filesystem::weakly_canonical(std::filesystem::path(absPath), ec);
+  if (ec) {
+    return absPath;
+  }
+  return canon.string();
+}
+}  // namespace
+
+void ScriptHotReload::Tick(Registry& registry, sol::state& lua, float dt, float pollSeconds) {
+  accumulator_ += dt;
+  if (accumulator_ < pollSeconds) {
+    return;
+  }
+  accumulator_ = 0.0F;
+
+  RefreshTracking(registry);
+  if (watcher_.Empty()) {
+    return;
+  }
+  for (const auto& dirty : watcher_.Poll()) {
+    ReloadFile(dirty, registry, lua);
+  }
+}
+
+void ScriptHotReload::ForceReloadAll(Registry& registry, sol::state& lua) {
+  std::unordered_set<std::string> paths;
+  auto query = registry.CreateQuery<ScriptComponent>();
+  query->ForEach([&](const ScriptComponent& sc) {
+    if (!sc.sourcePath.empty()) {
+      paths.insert(Canonicalize(sc.sourcePath));
+    }
+  });
+  for (const auto& p : paths) {
+    ReloadFile(p, registry, lua);
+  }
+}
+
+void ScriptHotReload::RefreshTracking(Registry& registry) {
+  std::unordered_set<std::string> seen;
+  auto query = registry.CreateQuery<ScriptComponent>();
+  query->ForEach([&](const ScriptComponent& sc) {
+    if (!sc.sourcePath.empty()) {
+      seen.insert(Canonicalize(sc.sourcePath));
+    }
+  });
+
+  for (const auto& path : seen) {
+    if (tracked_.find(path) == tracked_.end()) {
+      watcher_.Track(path);
+      tracked_.insert(path);
+    }
+  }
+  for (auto it = tracked_.begin(); it != tracked_.end();) {
+    if (seen.find(*it) == seen.end()) {
+      watcher_.Untrack(*it);
+      it = tracked_.erase(it);
+    } else {
+      ++it;
+    }
+  }
+}
+
+void ScriptHotReload::ReloadFile(const std::string& canonicalPath, Registry& registry, sol::state& lua) {
+  // protected_function (not plain sol::function) so Lua errors return invalid results instead of
+  // propagating as C++ exceptions — engine + tests compile without /EHsc.
+  sol::protected_function dofile = lua["dofile"];
+  if (!dofile.valid()) {
+    RecordFailure(canonicalPath, "dofile not installed");
+    return;
+  }
+
+  sol::protected_function_result result = dofile(canonicalPath);
+  if (!result.valid()) {
+    const sol::error err = result;
+    RecordFailure(canonicalPath, err.what());
+    return;
+  }
+
+  const sol::object returned = result;
+  if (!returned.is<sol::table>()) {
+    RecordFailure(canonicalPath, "script did not return a table");
+    return;
+  }
+  const sol::table newTable = returned.as<sol::table>();
+
+  int swapped = 0;
+  auto query = registry.CreateQuery<ScriptComponent>();
+  query->ForEach([&](ScriptComponent& sc) {
+    if (Canonicalize(sc.sourcePath) == canonicalPath) {
+      if (SwapComponent(sc, newTable)) {
+        ++swapped;
+      }
+    }
+  });
+  RecordSuccess(canonicalPath);
+  Logger::Info("Hot reload: " + canonicalPath + " (" + std::to_string(swapped) + " entities)");
+}
+
+bool ScriptHotReload::SwapComponent(ScriptComponent& sc, const sol::table& newTable) {
+  using namespace LuaComponentHelpers;
+  // Preserve per-entity state (`data` sub-table) across the swap. Authors mutate this at
+  // runtime; clobbering it would defeat the point of hot reload.
+  const sol::object preservedData = sc.scriptTable["data"];
+
+  // Resolve new callbacks first so we never end up with a half-swapped state if Lua throws.
+  sol::protected_function newUpdate = SafeGetProtectedFunction(newTable, "on_update");
+  sol::protected_function newDebugGui = SafeGetProtectedFunction(newTable, "on_debug_gui");
+
+  // Drop old protected_function refs before assigning the new table — pins on the old chunk
+  // would otherwise leak across reloads (sol2 holds Lua-side registry refs).
+  sc.updateFunction = sol::lua_nil;
+  sc.onDebugGUIFunction = sol::lua_nil;
+  sc.scriptTable = newTable;
+  if (preservedData.valid() && preservedData.get_type() != sol::type::lua_nil) {
+    sc.scriptTable["data"] = preservedData;
+  }
+  sc.updateFunction = newUpdate;
+  sc.onDebugGUIFunction = newDebugGui;
+  return true;
+}
+
+void ScriptHotReload::RecordSuccess(const std::string& path) {
+  last_.path = path;
+  last_.error.clear();
+  ++last_.totalReloads;
+}
+
+void ScriptHotReload::RecordFailure(const std::string& path, const std::string& error) {
+  last_.path = path;
+  last_.error = error;
+  ++last_.totalFailures;
+  Logger::ErrorLua("Hot reload failed for '" + path + "': " + error);
+}
+
+#endif  // OCTARINE_SHIPPED

--- a/src/Lua/HotReload/ScriptHotReload.cpp
+++ b/src/Lua/HotReload/ScriptHotReload.cpp
@@ -88,12 +88,12 @@ void ScriptHotReload::ReloadFile(const std::string& canonicalPath, Registry& reg
 
   sol::protected_function_result result = dofile(canonicalPath);
   if (!result.valid()) {
-    const sol::error err = result;
+    const auto err = result.get<sol::error>();
     RecordFailure(canonicalPath, err.what());
     return;
   }
 
-  const sol::object returned = result;
+  const auto returned = result.get<sol::object>();
   if (!returned.is<sol::table>()) {
     RecordFailure(canonicalPath, "script did not return a table");
     return;
@@ -117,7 +117,7 @@ bool ScriptHotReload::SwapComponent(ScriptComponent& sc, const sol::table& newTa
   using namespace LuaComponentHelpers;
   // Preserve per-entity state (`data` sub-table) across the swap. Authors mutate this at
   // runtime; clobbering it would defeat the point of hot reload.
-  const sol::object preservedData = sc.scriptTable["data"];
+  const auto preservedData = sc.scriptTable.get<sol::object>("data");
 
   // Resolve new callbacks first so we never end up with a half-swapped state if Lua throws.
   sol::protected_function newUpdate = SafeGetProtectedFunction(newTable, "on_update");

--- a/src/Lua/HotReload/ScriptHotReload.h
+++ b/src/Lua/HotReload/ScriptHotReload.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <sol/sol.hpp>
+#include <string>
+#include <unordered_set>
+
+#include "ScriptWatcher.h"
+
+class Registry;
+struct ScriptComponent;
+
+#ifndef OCTARINE_SHIPPED
+
+// Owns the watcher + auto-discovers file-backed ScriptComponents via a Registry query each tick.
+// One instance lives in the Registry singleton set; ticked from the main loop. Inline
+// ScriptComponents (empty sourcePath) are ignored.
+class ScriptHotReload {
+ public:
+  struct ReloadInfo {
+    std::string path;       // empty until first reload
+    std::string error;      // non-empty if last reload failed
+    int totalReloads = 0;
+    int totalFailures = 0;
+  };
+
+  ScriptHotReload() = default;
+
+  // Called from main loop. dt is real time (not time-scaled) so paused editor sessions still
+  // iterate. lua state must be the same one ScriptComponents bound their tables against.
+  void Tick(Registry& registry, sol::state& lua, float dt, float pollSeconds);
+
+  // Forced reload of every file-backed ScriptComponent, ignoring mtime.
+  void ForceReloadAll(Registry& registry, sol::state& lua);
+
+  [[nodiscard]] const ReloadInfo& LastReload() const { return last_; }
+
+ private:
+  void RefreshTracking(Registry& registry);
+  void ReloadFile(const std::string& canonicalPath, Registry& registry, sol::state& lua);
+  bool SwapComponent(ScriptComponent& sc, const sol::table& newTable);
+  void RecordSuccess(const std::string& path);
+  void RecordFailure(const std::string& path, const std::string& error);
+
+  ScriptWatcher watcher_;
+  std::unordered_set<std::string> tracked_;  // canonical paths the watcher currently watches
+  float accumulator_ = 0.0F;
+  ReloadInfo last_;
+};
+
+#else
+
+// Shipped stub.
+class ScriptHotReload {
+ public:
+  struct ReloadInfo {};
+  void Tick(Registry&, sol::state&, float, float) {}
+  void ForceReloadAll(Registry&, sol::state&) {}
+  [[nodiscard]] ReloadInfo LastReload() const { return {}; }
+};
+
+#endif

--- a/src/Lua/HotReload/ScriptWatcher.cpp
+++ b/src/Lua/HotReload/ScriptWatcher.cpp
@@ -1,0 +1,60 @@
+#include "ScriptWatcher.h"
+
+#ifndef OCTARINE_SHIPPED
+
+#include <system_error>
+
+#include "../../General/Logger.h"
+
+namespace fs = std::filesystem;
+
+std::string ScriptWatcher::Canonical(const std::string& absPath) {
+  std::error_code ec;
+  // weakly_canonical so partial-existent paths still resolve (caller may register before the
+  // file exists in some edge cases). On error, fall back to the input.
+  auto canon = fs::weakly_canonical(fs::path(absPath), ec);
+  if (ec) {
+    return absPath;
+  }
+  return canon.string();
+}
+
+void ScriptWatcher::Track(const std::string& absPath) {
+  const std::string key = Canonical(absPath);
+  if (mtimes_.find(key) != mtimes_.end()) {
+    return;
+  }
+
+  std::error_code ec;
+  const auto mtime = fs::last_write_time(key, ec);
+  if (ec) {
+    Logger::Warn("ScriptWatcher: cannot stat '" + key + "': " + ec.message());
+    return;
+  }
+  mtimes_.emplace(key, mtime);
+}
+
+void ScriptWatcher::Untrack(const std::string& absPath) {
+  const std::string key = Canonical(absPath);
+  mtimes_.erase(key);
+}
+
+std::vector<std::string> ScriptWatcher::Poll() {
+  std::vector<std::string> dirty;
+  for (auto& [path, lastMtime] : mtimes_) {
+    std::error_code ec;
+    const auto now = fs::last_write_time(path, ec);
+    if (ec) {
+      // File temporarily missing (atomic-save rename window). Skip this round, try again next
+      // poll without updating the cached mtime so we'll catch the post-rename state.
+      continue;
+    }
+    if (now != lastMtime) {
+      lastMtime = now;
+      dirty.push_back(path);
+    }
+  }
+  return dirty;
+}
+
+#endif  // OCTARINE_SHIPPED

--- a/src/Lua/HotReload/ScriptWatcher.h
+++ b/src/Lua/HotReload/ScriptWatcher.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#ifndef OCTARINE_SHIPPED
+
+// Mtime-polling file watcher. Single-threaded, called from the main loop. Track files we care
+// about, ask Poll() periodically for the subset whose last_write_time advanced since the last
+// call. Atomic-save editors (temp + rename) are handled because we resolve the canonical path
+// at Track() time and re-stat it each Poll.
+class ScriptWatcher {
+ public:
+  ScriptWatcher() = default;
+
+  // Add a file to the watch set. Path is canonicalized; duplicates and unknown files are
+  // silently ignored (the second case logs and stays untracked — caller bug, not user error).
+  void Track(const std::string& absPath);
+
+  // Drop a file from the watch set. No-op if untracked.
+  void Untrack(const std::string& absPath);
+
+  // Returns canonical paths whose mtime has advanced since the last Poll. Order is unspecified.
+  // Files that disappeared between Track and Poll are skipped (no error) and re-armed on next
+  // call.
+  std::vector<std::string> Poll();
+
+  [[nodiscard]] bool Empty() const { return mtimes_.empty(); }
+  [[nodiscard]] std::size_t TrackedCount() const { return mtimes_.size(); }
+
+ private:
+  static std::string Canonical(const std::string& absPath);
+
+  std::unordered_map<std::string, std::filesystem::file_time_type> mtimes_;
+};
+
+#else
+
+// Shipped builds: zero-cost stub so callers compile without #ifdef sprinkling. Track/Untrack
+// drop their args, Poll always returns empty.
+class ScriptWatcher {
+ public:
+  void Track(const std::string&) {}
+  void Untrack(const std::string&) {}
+  std::vector<std::string> Poll() { return {}; }
+  [[nodiscard]] bool Empty() const { return true; }
+  [[nodiscard]] std::size_t TrackedCount() const { return 0; }
+};
+
+#endif

--- a/tests/LuaApiSmokeTest.cpp
+++ b/tests/LuaApiSmokeTest.cpp
@@ -10,13 +10,18 @@
 
 #include <sol/sol.hpp>
 
+#include <filesystem>
+#include <fstream>
 #include <iostream>
 #include <set>
 #include <string>
 #include <vector>
 
+#include "Components/ScriptComponent.h"
 #include "ECS/Registry.h"
 #include "Game/Game.h"
+#include "General/Logger.h"
+#include "Lua/HotReload/ScriptHotReload.h"
 #ifdef OCTARINE_WITH_EDITOR
 #include "Editor/Inspectors/ComponentInspectorRegistry.h"
 #include "Editor/Inspectors/RegisterAllInspectors.h"
@@ -65,6 +70,11 @@ namespace
 
 int main()
 {
+    // Logger::Init brings up the dual main/lua spdlog sinks. ScriptHotReload calls
+    // Logger::ErrorLua on failed reloads; without Init the lua sink shared_ptr is null and the
+    // call AVs. Real binary calls this from Main; tests must do it explicitly.
+    Logger::Init();
+
     Game game; // SDL-free constructor — allocates Registry/EventBus/Renderer, opens no window.
     sol::state& lua = game.GetLua();
     lua.open_libraries(sol::lib::base, sol::lib::math, sol::lib::io, sol::lib::string, sol::lib::table);
@@ -165,6 +175,85 @@ int main()
 #endif
 #ifdef LUA_API_MODULES_OUTPUT
     Check(LuaApiManifest::WriteModulesJson(LUA_API_MODULES_OUTPUT), "modules.json written");
+#endif
+
+#ifndef OCTARINE_SHIPPED
+    std::cout << "[hot-reload] ScriptHotReload swap + state preservation + error containment\n";
+    {
+        auto* reg = game.GetRegistry();
+        reg->Set<ScriptHotReload>(ScriptHotReload());
+        auto& hotReload = reg->Get<ScriptHotReload>();
+
+        const auto tempDir = std::filesystem::temp_directory_path() / "octarine-hotreload-test";
+        std::error_code ec;
+        std::filesystem::create_directories(tempDir, ec);
+        const auto scriptPath = (tempDir / "fixture.lua").string();
+
+        const auto WriteScript = [&](const std::string& body) {
+            std::ofstream f(scriptPath, std::ios::trunc);
+            f << body;
+            f.close();
+        };
+
+        // v1: on_update writes 'kind = "v1"' into self.data.
+        WriteScript(
+            "return {\n"
+            "  data = { kind = 'initial', persisted = 42 },\n"
+            "  on_update = function(self, e, dt) self.data.kind = 'v1' end,\n"
+            "}\n");
+
+        // Load v1 manually via dofile (mirrors what FromSource does in the binding).
+        sol::protected_function_result loadV1 = lua["dofile"](scriptPath);
+        Check(loadV1.valid(), "fixture v1 loads");
+        sol::table v1Table = loadV1;
+        const sol::protected_function v1Update = v1Table["on_update"];
+
+        // Author-side mutation before reload: bump a value that must survive the swap.
+        v1Table["data"]["persisted"] = 99;
+
+        ScriptComponent sc(v1Table, v1Update, sol::protected_function(sol::lua_nil), scriptPath);
+        const Entity ent = reg->CreateEntity();
+        reg->AddComponent(ent, std::move(sc));
+
+        // Drive v1 once so 'kind' is set to "v1".
+        {
+            auto& live = reg->GetComponent<ScriptComponent>(ent);
+            live.updateFunction(live.scriptTable, ent, 0.016F);
+            sol::optional<std::string> kindOpt = live.scriptTable["data"]["kind"];
+            Check(kindOpt.value_or("<missing>") == "v1", "v1 on_update fires (kind == 'v1')");
+        }
+
+        // v2: same file, different behavior. Save *should* be picked up by ForceReloadAll.
+        WriteScript(
+            "return {\n"
+            "  data = { kind = 'shadow', persisted = 0 },\n"
+            "  on_update = function(self, e, dt) self.data.kind = 'v2' end,\n"
+            "}\n");
+        hotReload.ForceReloadAll(*reg, lua);
+        {
+            auto& live = reg->GetComponent<ScriptComponent>(ent);
+            live.updateFunction(live.scriptTable, ent, 0.016F);
+            sol::optional<sol::table> dataOpt = live.scriptTable["data"];
+            sol::optional<std::string> kindOpt = dataOpt ? dataOpt->get<sol::optional<std::string>>("kind") : sol::nullopt;
+            Check(kindOpt.value_or("<missing>") == "v2", "v2 on_update fires after reload (kind == 'v2')");
+            sol::optional<int> persistedOpt = dataOpt ? dataOpt->get<sol::optional<int>>("persisted") : sol::nullopt;
+            Check(persistedOpt.value_or(-1) == 99, "scriptTable.data preserved across reload (persisted == 99)");
+            Check(hotReload.LastReload().error.empty(), "successful reload leaves no last-error");
+        }
+
+        // Syntax error: reload must log + leave prior callbacks intact.
+        WriteScript("return { on_update = function(self, e, dt) self.data.kind = 'v3' end,\n");  // missing closing }
+        hotReload.ForceReloadAll(*reg, lua);
+        {
+            auto& live = reg->GetComponent<ScriptComponent>(ent);
+            live.updateFunction(live.scriptTable, ent, 0.016F);
+            sol::optional<std::string> kindOpt = live.scriptTable["data"]["kind"];
+            Check(kindOpt.value_or("<missing>") == "v2", "syntax-error reload preserves prior callback (kind still 'v2')");
+            Check(!hotReload.LastReload().error.empty(), "failed reload records error");
+        }
+
+        std::filesystem::remove_all(tempDir, ec);
+    }
 #endif
 
     if (g_failures == 0)


### PR DESCRIPTION
## Summary

- Author opts into hot reload per `ScriptComponent` via `{ source = "scripts/foo.lua" }`. File is `dofile`'d at attach time; returned table backs the component.
- `ScriptHotReload` (Registry singleton) polls tracked source files at `hotReloadPollSeconds` (default 0.25s), re-evaluates dirty files, and swaps each component's `updateFunction` / `onDebugGUIFunction` in place. `scriptTable.data` is preserved across the swap so per-entity state survives.
- Failed reloads (syntax error, file gone, non-table return) leave prior callbacks intact and surface via `Logger::ErrorLua`.
- Compiled out under `OCTARINE_SHIPPED` via stubs; runtime gate on `EngineOptions.hotReloadEnabled` + `config.ini` keys `HotReload=` / `HotReloadPollSeconds=`.
- Polls on real `dt` (not `timeScale`-scaled), so the loop stays alive while gameplay is paused in the editor.

## Test plan

- [x] `ctest --test-dir build/editor-debug` — `LuaApiSmokeTest` + `AssetPipelineTest` both pass.
- [x] New hot-reload checks in `OctarineLuaApiTest`: v1 fires, v2 fires after `ForceReloadAll`, `data.persisted` preserved (==99), no last-error on success, syntax-error reload preserves prior callback (kind still 'v2'), failed reload records error.
- [x] Engine boots `Octarine-Engine-Example` cleanly (status quo inline `script = { on_update = ... }` form unchanged).
- [ ] Manual editor smoke against a project using the file-backed form (none in the example yet — follow-up in `Octarine-Engine-Example` to flip a script to `{ source = "..." }` and watch reload fire).

## Out of scope (follow-up stages)

- `on_reload(self)` author hook
- `package.loaded` cascade for `require`d modules
- `game.reload_scripts()` + `F5` editor keybind
- Debug HUD reload counter
- `config.ini` hot reload