### PR TITLE
Add CONTRIBUTING.md and document component-methods rule

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,156 @@
+# Contributing to Octarine Engine
+
+Thanks for considering a contribution. This document covers the conventions
+the project follows so reviews stay focused on the change itself rather than
+on hygiene. If anything here is unclear or out of date, open an issue.
+
+## Quick reference
+
+- New to the codebase? Start with [`docs/QUICKSTART.md`](docs/QUICKSTART.md).
+- Architectural background: [`docs/ecs-architecture.md`](docs/ecs-architecture.md),
+  [`docs/lua-scripting.md`](docs/lua-scripting.md).
+- Shipping artifacts: [`docs/device-builds.md`](docs/device-builds.md).
+
+## Workflow
+
+1. **Branch off `main`.** Feature branches live as long as they need to. Pull
+   `main` before opening a PR so your diff is current.
+2. **One concern per PR.** A bug fix, a feature, or a refactor — not all
+   three. Bundled PRs slow reviews and bury regressions.
+3. **Push the branch to `origin`, open a PR.** CI runs on every push and PR;
+   land green or explain why.
+
+Pull requests target `main`. Releases are cut by tagging `v*` on `main`; see
+[`docs/device-builds.md`](docs/device-builds.md) § CI for what tag pushes
+trigger.
+
+## Building and testing
+
+Build with CMake presets:
+
+```bash
+cmake --preset editor-debug
+cmake --build --preset editor-debug
+```
+
+Engine tests are gated behind `OCTARINE_ENABLE_TESTS=ON`:
+
+```bash
+cmake --preset editor-debug -DOCTARINE_ENABLE_TESTS=ON
+cmake --build --preset editor-debug
+ctest --test-dir build/editor-debug --output-on-failure
+```
+
+Two tests live in `tests/`:
+
+- **`LuaApiSmokeTest`** — replays `Game::Setup`'s Lua-binding sequence
+  headlessly, asserts every component / module / system surface is reachable
+  from Lua, and re-emits the EmmyLua stub at `lua_api.smoke.lua`. CI fails on
+  drift, so commit the regenerated stub whenever a binding changes.
+- **`AssetPipelineTest`** — exercises `.meta` sidecar parsing, catalog build,
+  manifest round-trip, and validation against a fixture asset tree.
+
+CI runs both on the Linux editor-release leg.
+
+## Coding standards
+
+### Format
+
+`.clang-format` is foundational. Run it before committing — most editors do
+this on save with the right config. CI does not currently auto-format, but
+PRs with format-noise diffs will get pushback.
+
+### Lint
+
+`.clang-tidy` enforces a curated check set. Two thresholds worth knowing:
+
+- **Function length:** 120 lines.
+- **Cognitive complexity:** 15 per function.
+
+If you trip either, the right fix is almost always to extract a helper.
+Suppressing with `// NOLINT` is reserved for genuinely unavoidable cases —
+add a one-line comment justifying it.
+
+### Naming
+
+The configured rules:
+
+| Surface | Convention |
+|---------|-----------|
+| Class / struct / enum | `PascalCase` (`HealthComponent`) |
+| Member variable | `camelCase` (`currentHealth`) — trailing underscore for class members where it improves readability |
+| Constant / `constexpr` | `kPascalCase` (`kDefaultWindowWidth`) |
+
+Match the surrounding code if you find a stylistic disagreement; raise it in
+a separate PR rather than reformatting on the side of a feature.
+
+### `SRC_FILES` rule
+
+Every new `.cpp` under `src/` must be appended to `SRC_FILES` in
+`CMakeLists.txt`. Header-only additions don't need this. Forgetting it means
+your file compiles locally but fails CI on the editor-debug leg.
+
+### File organization
+
+- New components: `src/Components/<Name>Component.h`. POD struct, no
+  behavior beyond own-field methods (see [Lua scripting:
+  adding component methods](docs/lua-scripting.md#8-adding-component-methods)).
+- New systems: `src/Systems/<Name>System.{h,cpp}`. Register in `Game::Setup`.
+- New Lua component bindings: `src/Lua/Bindings/<X>ComponentLuaBinding.h` +
+  one line in `RegisterAllBindings.cpp`.
+- New Lua module (free-function globals): `src/Lua/Modules/<X>ModuleLuaBinding.{h,cpp}` +
+  one line in `RegisterAllModules.cpp` + append `.cpp` to `SRC_FILES`.
+- New events: `src/Events/<X>Event.h`. Emit via `EmitEvent<X>`; subscribe in
+  the consuming system's `Init`.
+
+## Commit messages
+
+Plain capitalized summary. No conventional-commit prefixes (`feat:`, `fix:`,
+`chore:` etc.). Keep the subject under ~70 characters; use the body for
+context if "why" isn't obvious from the diff.
+
+Good:
+
+```
+Pack textures into bake-time atlases
+
+Atlas packing happens during the bake step rather than at first-use so
+shipping builds don't pay the cost on cold launch. Bin packer is from
+stb_rect_pack; metadata is emitted alongside asset_manifest.lua.
+```
+
+Avoid:
+
+- `feat: add atlas packing` — no conventional-commit prefix.
+- `Implement atlas packing logic for textures` — verbose subject, no body.
+- `Co-Authored-By: <AI tool>` trailers — do not add these.
+
+## Documentation
+
+Tracked docs live under `docs/` (plus `README.md` and this file at the repo
+root, and `android/README.md` for the Android host app). Two hard rules for
+tracked docs and tracked source comments:
+
+- **No references to `ai/` design plans.** That directory is local-only
+  scratchpad (gitignored). Plans rot, get renamed, get archived — links to
+  them go stale immediately. Inline the rationale instead ("parked on
+  defer/ios pending an Apple Developer account", not "see ai/iOSDeferralPlan.md").
+- **No references to local-only agent files** such as `CLAUDE.md`,
+  `GEMINI.md`, or `.agent/`. Same reasoning.
+
+If you add a doc, cross-link it from
+[`docs/QUICKSTART.md`](docs/QUICKSTART.md) § Deeper reading so it isn't
+orphaned.
+
+## Reporting bugs and proposing features
+
+Open a GitHub issue. For bugs, include:
+
+- The preset you built with (`editor-debug`, `ship-release`, …).
+- OS + compiler version.
+- Repro steps. Minimal `game.lua` snippet if it's reproducible in script.
+- Logs from the run's stdout/stderr (or `adb logcat -s Octarine OctarineLua`
+  on Android).
+
+For feature proposals, describe the problem before the solution — the
+solution space is often wider than it looks.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ For producing shippable artifacts (Windows ZIP/NSIS, Linux TGZ, macOS DMG, Andro
 see [`docs/device-builds.md`](docs/device-builds.md). Shipping config is the `ship-release`
 preset (and `ship-mac-universal` for universal macOS).
 
+Contributing? See [`CONTRIBUTING.md`](CONTRIBUTING.md) for workflow, coding
+standards, commit style, and the `SRC_FILES` rule.
+
 ### Running the Engine
 
 Octarine Engine accepts the game directory as a positional argument:

--- a/docs/ecs-architecture.md
+++ b/docs/ecs-architecture.md
@@ -146,6 +146,12 @@ struct Health {
 };
 ```
 
+If the component is exposed to Lua via a `LuaBinding<T>` specialization, any
+methods bound through `bindUsertype` may read or write the component's own
+fields only — no `Registry&`, no `EventBus*`, no cross-entity touches, no
+allocation. Anything beyond that belongs in a system. See [Lua scripting:
+adding component methods](lua-scripting.md#8-adding-component-methods).
+
 ### Creating a System
 
 Implement your logic in `src/Systems/` and register it in `Game::Setup()`.

--- a/docs/lua-scripting.md
+++ b/docs/lua-scripting.md
@@ -176,3 +176,59 @@ The engine looks for specific functions in your scripts:
 - `on_update(self, entity, delta_time)`: Called every frame.
 - `on_debug_gui(self, entity)`: Called during the ImGui rendering pass.
 - `on_click(self, entity)`: Called if the entity has a `ui_button` component and is clicked.
+
+---
+
+## 8. Adding component methods
+
+When you add a Lua binding for a component (`src/Lua/Bindings/<X>ComponentLuaBinding.h`),
+the `bindUsertype` call exposes both fields and **member functions** to scripts:
+
+```cpp
+lua.new_usertype<HealthComponent>(kUsertypeName,
+    "max_health", &HealthComponent::maxHealth,
+    "damage",     &HealthComponent::damage,   // member function
+    "heal",       &HealthComponent::heal,
+    "is_dead",    sol::property(&HealthComponent::isDead),   // derived read-only
+    "fraction",   sol::property(&HealthComponent::fraction));
+```
+
+### Hard rule
+
+A component method may **read and write the component's own fields only**.
+
+No:
+
+- `Registry&` access (no looking up sibling components, no other entities).
+- `EventBus*` access (no `EmitEvent`).
+- Cross-entity reads or writes.
+- Archetype mutation (`AddComponent` / `RemoveComponent` / `DestroyEntity`).
+- Allocation, file I/O, or any other side effect.
+
+Anything that needs to cross those lines belongs in a **system**, not a method.
+The moment a method wants to touch a sibling entity or fire an event, move the
+logic out and call it from the relevant system's update.
+
+### Why this matters
+
+Component methods run from Lua at unpredictable points in the frame — inside an
+`on_update`, inside an `on_debug_gui`, inside a callback chain. Systems run in
+known order with known invariants (input → simulation → render). Touching the
+registry from a method during, say, a render-pass debug-gui call can mutate
+state mid-frame and cause iterator invalidation, stale archetype caches, or
+visible single-frame glitches. Keeping methods data-only means you can call
+them anywhere safely.
+
+### Patterns
+
+- **Mutators with invariants** — bind the field with `sol::property` and a
+  clamping setter so Lua can't bypass the invariant by direct field assignment.
+  `HealthComponent::currentHealth` is the canonical example: writes clamp to
+  `[0, maxHealth]`.
+- **Derived read-only state** — bind with `sol::property(&T::accessor)` so
+  scripts get field-style access (`health.is_dead`) without exposing a setter.
+- **Plain getters/setters** — bind the member function directly.
+
+For the canonical reference, read the comment block in
+[`src/Lua/Bindings/LuaBinding.h`](../src/Lua/Bindings/LuaBinding.h) and
+[`HealthComponentLuaBinding.h`](../src/Lua/Bindings/HealthComponentLuaBinding.h).

--- a/src/Editor/ExportBuilder.h
+++ b/src/Editor/ExportBuilder.h
@@ -2,16 +2,16 @@
 
 #ifdef OCTARINE_WITH_EDITOR
 
-// ExportBuilder — Stage 5 of ai/EditorBuildAndDeployPlan.md.
+// ExportBuilder.
 //
 // Wraps the spawn of a project's scaffolded build script (`scripts/build-desktop.{sh,ps1}` for the
 // host-OS desktop target, `scripts/build-android.{sh,ps1}` for Android). Mirrors PlayerLauncher: a
 // Registry singleton with a state machine (Idle -> Building -> Succeeded/Failed), a ring-capped log
 // of subprocess stdout/stderr, and a per-frame Pump() drained on the main thread.
 //
-// Out of scope (deferred per plan): in-editor signing-credential storage (PR-C: DPAPI/keychain),
-// SHA256 of artifact, "Reveal in Explorer" / clipboard install hint. AndroidRelease signing creds
-// flow via the editor process's existing env vars (OCTARINE_ANDROID_KEYSTORE_PATH, etc.).
+// Deferred follow-ups: in-editor signing-credential storage (DPAPI/keychain), SHA256 of artifact,
+// "Reveal in Explorer" / clipboard install hint. AndroidRelease signing creds flow via the editor
+// process's existing env vars (OCTARINE_ANDROID_KEYSTORE_PATH, etc.).
 
 #include "Process/Process.h"
 


### PR DESCRIPTION
## Summary

Closes Stage 3 + Stage 4 of the docs-improvement backlog. Two doc gaps land in one PR; the third change is a drive-by scrub.

### 1. Component-methods rule (Stage 3)

`LuaBinding<T>::bindUsertype` methods may read or write the component's **own fields only** — no `Registry&`, no `EventBus*`, no cross-entity touches, no allocation. The rule has lived as a comment block in `src/Lua/Bindings/LuaBinding.h` since the binding template existed, but no tracked doc stated it. New contributors find out through code review.

- `docs/lua-scripting.md` § 8 (new) — states the rule, gives the rationale (component methods run from Lua at unpredictable frame points; touching the registry there breaks invariants), and shows the patterns: `sol::property` with a clamping setter for fields with invariants, `sol::property` with a getter for derived read-only state, plain member-function binding for own-field mutators. `HealthComponent` is the canonical example.
- `docs/ecs-architecture.md` § Adding a New Component — short cross-link to the new section.

### 2. `CONTRIBUTING.md` (Stage 4)

Repo root, covers:

- Workflow (branch off `main`, one concern per PR).
- Build + test commands; `OCTARINE_ENABLE_TESTS=ON` gate.
- `.clang-format` / `.clang-tidy` thresholds (function length 120, cognitive complexity 15).
- Naming conventions table.
- `SRC_FILES` rule.
- File-organization quick reference (where new components / systems / events / Lua bindings go).
- Commit message style — plain capitalized summary, no conventional-commit prefixes, no AI co-author trailer.
- The "no `ai/` refs" rule (and the parallel rule for other local-only agent scratchpad files) from #80 / #81 / #85.

`README.md` links to it from the build section.

### 3. Drive-by: `src/Editor/ExportBuilder.h`

The file landed in #87 with a stray plan-pointer header and a "Out of scope (deferred per plan)" block. Same scrub as #81: strip the plan pointer, inline the deferred-follow-ups list. Caught it via `git grep` while writing CONTRIBUTING.md.

## Test plan

- [x] `git grep -nE '\bai/' -- ':!CONTRIBUTING.md'` returns zero hits. (CONTRIBUTING.md's hits are the rule statement itself + the example of what NOT to do.)
- [x] CONTRIBUTING.md links resolve.
- [ ] Spot-check rendered Markdown on the PR diff.
