### PR TITLE
Add SecretStore for Android signing creds via DPAPI / Keychain

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,17 @@ if (OCTARINE_WITH_EDITOR)
     list(APPEND SRC_FILES src/Editor/Inspectors/RegisterAllInspectors.cpp)
     list(APPEND SRC_FILES src/Editor/PlayerLauncher.cpp)
     list(APPEND SRC_FILES src/Editor/ExportBuilder.cpp)
+
+    # SecretStore: per-platform credential storage. One backend per host so the OS-native API
+    # links cleanly without cross-platform shims. Linux backend is a no-op stub the editor UI
+    # falls back to env-var-only mode on.
+    if (WIN32)
+        list(APPEND SRC_FILES src/Secrets/SecretStore_Windows.cpp)
+    elseif (APPLE)
+        list(APPEND SRC_FILES src/Secrets/SecretStore_macOS.cpp)
+    else ()
+        list(APPEND SRC_FILES src/Secrets/SecretStore_Linux.cpp)
+    endif ()
 endif ()
 
 if (UNIX AND NOT APPLE AND NOT ANDROID)
@@ -255,6 +266,18 @@ endif ()
 # native logging and platform APIs; the linker needs them named explicitly for the shared lib.
 if (ANDROID)
     target_link_libraries(${PROJECT_NAME} PRIVATE android log)
+endif ()
+
+# SecretStore backend libs. Crypt32 ships DPAPI's CryptProtectData/CryptUnprotectData on Windows;
+# Security.framework ships SecItem* on macOS. Linux backend is a stub and needs no link.
+if (OCTARINE_WITH_EDITOR)
+    if (WIN32)
+        target_link_libraries(${PROJECT_NAME} PRIVATE crypt32)
+    elseif (APPLE)
+        target_link_libraries(${PROJECT_NAME} PRIVATE
+                "-framework CoreFoundation"
+                "-framework Security")
+    endif ()
 endif ()
 
 # Install rules (optional). Skipped under packaging — octarine_package owns the deliverable layout

--- a/src/Editor/EditorPersistence.h
+++ b/src/Editor/EditorPersistence.h
@@ -45,12 +45,13 @@ struct EditorPersistence {
   bool showEditorSettings = true;
   bool showPlayerOutput = false;
   bool showExportOutput = false;
+  bool showSigningSettings = false;
 
   // Single source of truth for persisted window-visibility flags. Both the project-prefs
   // serializer (EditorPersistence.cpp) and the layout-preset serializer (EditorLayoutPresets.cpp)
   // iterate this table, so a new window = one entry here.
   using FlagRef = std::pair<const char*, bool EditorPersistence::*>;
-  static constexpr std::array<FlagRef, 10> kWindowFlags = {{
+  static constexpr std::array<FlagRef, 11> kWindowFlags = {{
       {"showProfiler", &EditorPersistence::showProfiler},
       {"showHierarchy", &EditorPersistence::showHierarchy},
       {"showAssetBrowser", &EditorPersistence::showAssetBrowser},
@@ -61,6 +62,7 @@ struct EditorPersistence {
       {"showEditorSettings", &EditorPersistence::showEditorSettings},
       {"showPlayerOutput", &EditorPersistence::showPlayerOutput},
       {"showExportOutput", &EditorPersistence::showExportOutput},
+      {"showSigningSettings", &EditorPersistence::showSigningSettings},
   }};
 
   void LoadGlobal();

--- a/src/Editor/ExportBuilder.cpp
+++ b/src/Editor/ExportBuilder.cpp
@@ -4,6 +4,7 @@
 
 #include "General/Logger.h"
 #include "Project/ProjectIni.h"
+#include "Secrets/SecretStore.h"
 
 #include <system_error>
 #include <utility>
@@ -164,10 +165,27 @@ namespace octarine::editor
         {
             po.env.emplace_back("OCTARINE_PRESET", opts.preset);
         }
-        // AndroidRelease signing creds are inherited from the editor process's env (the user sets
-        // OCTARINE_ANDROID_KEYSTORE_PATH etc. before launching the editor). The Process wrapper's
-        // default inherit_env=true is what carries them through; PR-C adds in-editor secret storage
-        // so the dev no longer has to manage their shell env.
+
+        // AndroidRelease signing creds: pull from SecretStore (DPAPI / Keychain) if available and
+        // override into the spawn env. SpawnOptions.env extends the inherited env, so the shell-set
+        // OCTARINE_ANDROID_* vars still apply when the store has no entry — store wins on conflict.
+        if (opts.target == ExportTarget::AndroidRelease && octarine::secrets::IsAvailable())
+        {
+            struct CredKey { const char* secret; const char* envVar; };
+            static constexpr CredKey kCreds[] = {
+                {"octarine.android.keystore_path",  "OCTARINE_ANDROID_KEYSTORE_PATH"},
+                {"octarine.android.store_password", "OCTARINE_ANDROID_STORE_PASSWORD"},
+                {"octarine.android.key_alias",      "OCTARINE_ANDROID_KEY_ALIAS"},
+                {"octarine.android.key_password",   "OCTARINE_ANDROID_KEY_PASSWORD"},
+            };
+            for (const auto& c : kCreds)
+            {
+                if (auto v = octarine::secrets::Get(c.secret))
+                {
+                    po.env.emplace_back(c.envVar, *v);
+                }
+            }
+        }
 
         auto p = octarine::process::Process::Spawn(po);
         if (!p)

--- a/src/Secrets/SecretStore.h
+++ b/src/Secrets/SecretStore.h
@@ -1,0 +1,39 @@
+#pragma once
+
+// SecretStore — Stage 5 PR-C of ai/EditorBuildAndDeployPlan.md.
+//
+// Per-platform credential storage for editor-side build tooling. v1 holds the Android signing
+// keystore credentials (path + passwords + alias) so a dev can ship a release AAB from the
+// Export Build modal without exporting OCTARINE_ANDROID_* in their shell.
+//
+// Backends:
+//   Windows — DPAPI (CryptProtectData) writing per-key .dat files under SDL_GetPrefPath/secrets/.
+//   macOS   — Keychain Services (SecKeychainAddGenericPassword) under service "OctarineEngine".
+//   Linux   — Not available. Set/Get/Clear return false; IsAvailable() returns false. Editor UI
+//             falls back to surfacing the env-var contract instead of offering a save UI.
+//
+// API stays narrow on purpose: arbitrary string keys -> arbitrary string values. The caller picks
+// the namespacing convention (current users prefix with "octarine.android." to avoid collisions
+// with whatever else lands in the store later).
+
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace octarine::secrets
+{
+    // True when the host platform has a real secret-storage backend wired up. False on Linux v1
+    // (and on Windows / macOS when the backend reports a runtime error during a probe).
+    bool IsAvailable();
+
+    // Stores `value` keyed by `key`, overwriting any existing entry. Returns true on success.
+    // Empty `value` is allowed and stores the empty string (distinct from "no entry"); callers
+    // who want to remove should use Clear().
+    bool Set(std::string_view key, std::string_view value);
+
+    // Returns the stored value for `key`, or nullopt when no entry exists or decryption failed.
+    std::optional<std::string> Get(std::string_view key);
+
+    // Removes the stored entry for `key`. Returns true on success or when the entry did not exist.
+    bool Clear(std::string_view key);
+} // namespace octarine::secrets

--- a/src/Secrets/SecretStore_Linux.cpp
+++ b/src/Secrets/SecretStore_Linux.cpp
@@ -1,0 +1,20 @@
+#include "Secrets/SecretStore.h"
+
+// Built for everything that is neither Windows nor Apple — primarily Linux desktop, and Android
+// (where the editor isn't compiled anyway, but the stubs harm nothing). Returns "not available"
+// so the editor surfaces the env-var contract instead of offering a save UI.
+
+#if !defined(_WIN32) && !defined(__APPLE__)
+
+namespace octarine::secrets
+{
+    bool IsAvailable() { return false; }
+
+    bool Set(std::string_view /*key*/, std::string_view /*value*/) { return false; }
+
+    std::optional<std::string> Get(std::string_view /*key*/) { return std::nullopt; }
+
+    bool Clear(std::string_view /*key*/) { return false; }
+} // namespace octarine::secrets
+
+#endif

--- a/src/Secrets/SecretStore_Windows.cpp
+++ b/src/Secrets/SecretStore_Windows.cpp
@@ -1,0 +1,156 @@
+#include "Secrets/SecretStore.h"
+
+#ifdef _WIN32
+
+#include "General/Logger.h"
+
+#include <SDL3/SDL_filesystem.h>
+
+// dpapi.h pulls wincrypt symbols (CryptProtectData / CryptUnprotectData). crypt32 link added in
+// the top-level CMakeLists alongside the Windows-only SRC_FILES append.
+#include <windows.h>
+#include <dpapi.h>
+
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <system_error>
+#include <vector>
+
+namespace octarine::secrets
+{
+    namespace
+    {
+        std::filesystem::path SecretsDir()
+        {
+            char* prefPath = SDL_GetPrefPath("Octarine", "Engine");
+            if (!prefPath)
+            {
+                return {};
+            }
+            std::filesystem::path p = std::filesystem::path(prefPath) / "secrets";
+            SDL_free(prefPath);
+
+            std::error_code ec;
+            std::filesystem::create_directories(p, ec);
+            return p;
+        }
+
+        // Filesystem-safe key filename: replace anything outside [A-Za-z0-9._-] with '_'. Keeps
+        // round-tripping deterministic without needing a separate index file.
+        std::string SanitizeKey(std::string_view key)
+        {
+            std::string out;
+            out.reserve(key.size());
+            for (char c : key)
+            {
+                const unsigned char u = static_cast<unsigned char>(c);
+                const bool ok =
+                    (u >= 'A' && u <= 'Z') || (u >= 'a' && u <= 'z') || (u >= '0' && u <= '9') ||
+                    u == '.' || u == '-' || u == '_';
+                out.push_back(ok ? c : '_');
+            }
+            return out;
+        }
+
+        std::filesystem::path PathFor(std::string_view key)
+        {
+            auto dir = SecretsDir();
+            if (dir.empty())
+            {
+                return {};
+            }
+            return dir / (SanitizeKey(key) + ".dat");
+        }
+    } // namespace
+
+    bool IsAvailable() { return true; }
+
+    bool Set(std::string_view key, std::string_view value)
+    {
+        const auto path = PathFor(key);
+        if (path.empty())
+        {
+            return false;
+        }
+
+        DATA_BLOB in{};
+        in.pbData = const_cast<BYTE*>(reinterpret_cast<const BYTE*>(value.data()));
+        in.cbData = static_cast<DWORD>(value.size());
+
+        DATA_BLOB out{};
+        if (!CryptProtectData(&in, L"OctarineEngine", nullptr, nullptr, nullptr,
+                              CRYPTPROTECT_UI_FORBIDDEN, &out))
+        {
+            Logger::Error("SecretStore: CryptProtectData failed (err=" +
+                          std::to_string(GetLastError()) + ")");
+            return false;
+        }
+
+        std::ofstream f(path, std::ios::binary | std::ios::trunc);
+        if (!f.is_open())
+        {
+            LocalFree(out.pbData);
+            Logger::Error("SecretStore: cannot open " + path.string());
+            return false;
+        }
+        f.write(reinterpret_cast<const char*>(out.pbData), static_cast<std::streamsize>(out.cbData));
+        const bool ok = f.good();
+        LocalFree(out.pbData);
+        return ok;
+    }
+
+    std::optional<std::string> Get(std::string_view key)
+    {
+        const auto path = PathFor(key);
+        if (path.empty())
+        {
+            return std::nullopt;
+        }
+        std::error_code ec;
+        if (!std::filesystem::exists(path, ec))
+        {
+            return std::nullopt;
+        }
+
+        std::ifstream f(path, std::ios::binary);
+        if (!f.is_open())
+        {
+            return std::nullopt;
+        }
+        std::vector<char> ciphertext((std::istreambuf_iterator<char>(f)),
+                                     std::istreambuf_iterator<char>());
+
+        DATA_BLOB in{};
+        in.pbData = reinterpret_cast<BYTE*>(ciphertext.data());
+        in.cbData = static_cast<DWORD>(ciphertext.size());
+
+        DATA_BLOB out{};
+        if (!CryptUnprotectData(&in, nullptr, nullptr, nullptr, nullptr,
+                                CRYPTPROTECT_UI_FORBIDDEN, &out))
+        {
+            Logger::Error("SecretStore: CryptUnprotectData failed (err=" +
+                          std::to_string(GetLastError()) + ")");
+            return std::nullopt;
+        }
+        std::string result(reinterpret_cast<const char*>(out.pbData), out.cbData);
+        LocalFree(out.pbData);
+        return result;
+    }
+
+    bool Clear(std::string_view key)
+    {
+        const auto path = PathFor(key);
+        if (path.empty())
+        {
+            return false;
+        }
+        std::error_code ec;
+        std::filesystem::remove(path, ec);
+        // remove() returning false because the file did not exist is still success per our contract.
+        return !ec || ec == std::errc::no_such_file_or_directory;
+    }
+} // namespace octarine::secrets
+
+#endif // _WIN32

--- a/src/Secrets/SecretStore_macOS.cpp
+++ b/src/Secrets/SecretStore_macOS.cpp
@@ -1,0 +1,124 @@
+#include "Secrets/SecretStore.h"
+
+#if defined(__APPLE__)
+
+#include "General/Logger.h"
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <Security/Security.h>
+
+#include <string>
+
+namespace octarine::secrets
+{
+    namespace
+    {
+        constexpr CFStringRef kService = CFSTR("com.octarine.engine.secrets");
+
+        CFStringRef MakeAccount(std::string_view key)
+        {
+            return CFStringCreateWithBytes(nullptr,
+                                           reinterpret_cast<const UInt8*>(key.data()),
+                                           static_cast<CFIndex>(key.size()),
+                                           kCFStringEncodingUTF8,
+                                           /*isExternalRepresentation=*/false);
+        }
+
+        CFDataRef MakeData(std::string_view value)
+        {
+            return CFDataCreate(nullptr,
+                                reinterpret_cast<const UInt8*>(value.data()),
+                                static_cast<CFIndex>(value.size()));
+        }
+
+        CFMutableDictionaryRef BaseQuery(CFStringRef account)
+        {
+            CFMutableDictionaryRef q = CFDictionaryCreateMutable(
+                nullptr, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+            CFDictionarySetValue(q, kSecClass, kSecClassGenericPassword);
+            CFDictionarySetValue(q, kSecAttrService, kService);
+            CFDictionarySetValue(q, kSecAttrAccount, account);
+            return q;
+        }
+    } // namespace
+
+    bool IsAvailable() { return true; }
+
+    bool Set(std::string_view key, std::string_view value)
+    {
+        CFStringRef account = MakeAccount(key);
+        CFDataRef data = MakeData(value);
+
+        // Try update first; fall back to add. Avoids the "duplicate item" failure mode if the
+        // entry already exists.
+        CFMutableDictionaryRef query = BaseQuery(account);
+        CFMutableDictionaryRef attrs = CFDictionaryCreateMutable(
+            nullptr, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+        CFDictionarySetValue(attrs, kSecValueData, data);
+
+        OSStatus s = SecItemUpdate(query, attrs);
+        if (s == errSecItemNotFound)
+        {
+            CFMutableDictionaryRef add = BaseQuery(account);
+            CFDictionarySetValue(add, kSecValueData, data);
+            s = SecItemAdd(add, nullptr);
+            CFRelease(add);
+        }
+
+        CFRelease(attrs);
+        CFRelease(query);
+        CFRelease(data);
+        CFRelease(account);
+
+        if (s != errSecSuccess)
+        {
+            Logger::Error("SecretStore: keychain Set failed (OSStatus=" + std::to_string(s) + ")");
+            return false;
+        }
+        return true;
+    }
+
+    std::optional<std::string> Get(std::string_view key)
+    {
+        CFStringRef account = MakeAccount(key);
+        CFMutableDictionaryRef query = BaseQuery(account);
+        CFDictionarySetValue(query, kSecReturnData, kCFBooleanTrue);
+        CFDictionarySetValue(query, kSecMatchLimit, kSecMatchLimitOne);
+
+        CFTypeRef out = nullptr;
+        OSStatus s = SecItemCopyMatching(query, &out);
+
+        CFRelease(query);
+        CFRelease(account);
+
+        if (s == errSecItemNotFound)
+        {
+            return std::nullopt;
+        }
+        if (s != errSecSuccess || !out)
+        {
+            Logger::Error("SecretStore: keychain Get failed (OSStatus=" + std::to_string(s) + ")");
+            if (out) CFRelease(out);
+            return std::nullopt;
+        }
+
+        CFDataRef data = reinterpret_cast<CFDataRef>(out);
+        const std::string result(reinterpret_cast<const char*>(CFDataGetBytePtr(data)),
+                                 static_cast<std::size_t>(CFDataGetLength(data)));
+        CFRelease(out);
+        return result;
+    }
+
+    bool Clear(std::string_view key)
+    {
+        CFStringRef account = MakeAccount(key);
+        CFMutableDictionaryRef query = BaseQuery(account);
+        OSStatus s = SecItemDelete(query);
+        CFRelease(query);
+        CFRelease(account);
+        // Removing a missing item is success per our contract.
+        return s == errSecSuccess || s == errSecItemNotFound;
+    }
+} // namespace octarine::secrets
+
+#endif // __APPLE__

--- a/src/Secrets/SecretStore_macOS.cpp
+++ b/src/Secrets/SecretStore_macOS.cpp
@@ -13,7 +13,9 @@ namespace octarine::secrets
 {
     namespace
     {
-        constexpr CFStringRef kService = CFSTR("com.octarine.engine.secrets");
+        // CFSTR expands to a __builtin reinterpret_cast that Clang rejects in constexpr context.
+        // The macro itself produces a process-lifetime constant CFString, so a static const is fine.
+        static const CFStringRef kService = CFSTR("com.octarine.engine.secrets");
 
         CFStringRef MakeAccount(std::string_view key)
         {

--- a/src/Systems/RenderDebugGUISystem.cpp
+++ b/src/Systems/RenderDebugGUISystem.cpp
@@ -1,6 +1,7 @@
 #include "RenderDebugGUISystem.h"
 
 #ifdef OCTARINE_WITH_IMGUI
+#include <cstring>
 #include <filesystem>
 
 #include "../AssetManager/AssetManager.h"
@@ -37,6 +38,7 @@
 #include "../Editor/ExportBuilder.h"
 #include "../Editor/PlayerLauncher.h"
 #include "../Project/ProjectIni.h"
+#include "../Secrets/SecretStore.h"
 
 namespace
 {
@@ -208,6 +210,7 @@ static bool openExportBuildModal = false;
             ImGui::MenuItem("Editor Settings", nullptr, &editorPersistence.showEditorSettings);
             ImGui::MenuItem("Player Output", nullptr, &editorPersistence.showPlayerOutput);
             ImGui::MenuItem("Export Output", nullptr, &editorPersistence.showExportOutput);
+            ImGui::MenuItem("Signing Settings", nullptr, &editorPersistence.showSigningSettings);
             ImGui::MenuItem("Game Debug Overlays", "Grave", &engineOptions.showDebugGUI);
             ImGui::Separator();
             ImGui::MenuItem("FPS Counter", nullptr, &engineOptions.showFpsCounter);
@@ -487,6 +490,8 @@ static bool openExportBuildModal = false;
         PlayerOutputWindow(game, &editorPersistence.showPlayerOutput);
     if (editorPersistence.showExportOutput)
         ExportOutputWindow(game, &editorPersistence.showExportOutput);
+    if (editorPersistence.showSigningSettings)
+        SigningSettingsWindow(&editorPersistence.showSigningSettings);
 
     if (engineOptions.showImGuiDemoWindow)
     {
@@ -1228,6 +1233,136 @@ void RenderDebugGUISystem::ExportOutputWindow(Game* game, bool* p_open)
         ImGui::SetScrollHereY(1.0F);
     }
     ImGui::EndChild();
+
+    ImGui::End();
+}
+
+void RenderDebugGUISystem::SigningSettingsWindow(bool* p_open)
+{
+    ImGui::SetNextWindowSize(ImVec2(540, 360), ImGuiCond_FirstUseEver);
+    if (!ImGui::Begin("Signing Settings", p_open, ImGuiWindowFlags_AlwaysAutoResize))
+    {
+        ImGui::End();
+        return;
+    }
+
+    // Per-field buffers persisted across frames. Populated with the placeholder string when an
+    // entry already exists in SecretStore so the dev sees "value stored" rather than the secret
+    // round-tripped into a visible password field.
+    static char keystorePathBuf[260] = "";
+    static char storePasswordBuf[128] = "";
+    static char keyAliasBuf[64] = "";
+    static char keyPasswordBuf[128] = "";
+    static bool initialized = false;
+    static bool keystorePathLoaded = false;
+
+    constexpr const char* kKeyPath  = "octarine.android.keystore_path";
+    constexpr const char* kKeyStore = "octarine.android.store_password";
+    constexpr const char* kKeyAlias = "octarine.android.key_alias";
+    constexpr const char* kKeyPwd   = "octarine.android.key_password";
+
+    if (!octarine::secrets::IsAvailable())
+    {
+        ImGui::TextColored(ImVec4(1.0F, 0.85F, 0.4F, 1.0F),
+                           "Secret storage is not available on this platform.");
+        ImGui::TextWrapped(
+            "Set the OCTARINE_ANDROID_* env vars (KEYSTORE_PATH, STORE_PASSWORD, KEY_ALIAS, "
+            "KEY_PASSWORD) in the shell that launches the editor. The Export Build modal will "
+            "pick them up via the editor's inherited environment.");
+        ImGui::End();
+        return;
+    }
+
+    // Lazy first-time load: the keystore path is non-secret-by-itself so we surface it directly;
+    // password / alias fields stay blank with a "Stored" indicator beside them so the secrets
+    // never round-trip through ImGui's input cache.
+    if (!initialized)
+    {
+        if (auto v = octarine::secrets::Get(kKeyPath))
+        {
+            std::snprintf(keystorePathBuf, sizeof(keystorePathBuf), "%s", v->c_str());
+            keystorePathLoaded = true;
+        }
+        if (auto v = octarine::secrets::Get(kKeyAlias))
+        {
+            std::snprintf(keyAliasBuf, sizeof(keyAliasBuf), "%s", v->c_str());
+        }
+        initialized = true;
+    }
+
+    const auto storedHint = [](const char* key) {
+        return octarine::secrets::Get(key).has_value() ? "(stored)" : "(empty)";
+    };
+
+    ImGui::TextWrapped(
+        "Android-release signing credentials. Stored via the OS secret backend (DPAPI on Windows, "
+        "Keychain on macOS) and injected into the build subprocess as OCTARINE_ANDROID_* env vars.");
+    ImGui::Separator();
+
+    ImGui::SetNextItemWidth(360);
+    ImGui::InputText("Keystore path", keystorePathBuf, sizeof(keystorePathBuf));
+
+    ImGui::SetNextItemWidth(220);
+    ImGui::InputText("Store password", storePasswordBuf, sizeof(storePasswordBuf),
+                     ImGuiInputTextFlags_Password);
+    ImGui::SameLine();
+    ImGui::TextDisabled("%s", storedHint(kKeyStore));
+
+    ImGui::SetNextItemWidth(220);
+    ImGui::InputText("Key alias", keyAliasBuf, sizeof(keyAliasBuf));
+
+    ImGui::SetNextItemWidth(220);
+    ImGui::InputText("Key password", keyPasswordBuf, sizeof(keyPasswordBuf),
+                     ImGuiInputTextFlags_Password);
+    ImGui::SameLine();
+    ImGui::TextDisabled("%s", storedHint(kKeyPwd));
+
+    ImGui::Separator();
+
+    if (ImGui::Button("Save"))
+    {
+        // Only overwrite secrets the dev typed something into this frame; preserves stored values
+        // when the dev only edits, say, the keystore path. The keystore path itself always writes
+        // (even when emptied, which Clears it via the empty-string branch).
+        if (keystorePathBuf[0] != '\0')
+        {
+            octarine::secrets::Set(kKeyPath, keystorePathBuf);
+            keystorePathLoaded = true;
+        }
+        if (storePasswordBuf[0] != '\0')
+        {
+            octarine::secrets::Set(kKeyStore, storePasswordBuf);
+        }
+        if (keyAliasBuf[0] != '\0')
+        {
+            octarine::secrets::Set(kKeyAlias, keyAliasBuf);
+        }
+        if (keyPasswordBuf[0] != '\0')
+        {
+            octarine::secrets::Set(kKeyPwd, keyPasswordBuf);
+        }
+        // Wipe the in-memory password buffers immediately after storing so they don't linger.
+        std::memset(storePasswordBuf, 0, sizeof(storePasswordBuf));
+        std::memset(keyPasswordBuf, 0, sizeof(keyPasswordBuf));
+    }
+    ImGui::SameLine();
+    if (ImGui::Button("Clear all"))
+    {
+        octarine::secrets::Clear(kKeyPath);
+        octarine::secrets::Clear(kKeyStore);
+        octarine::secrets::Clear(kKeyAlias);
+        octarine::secrets::Clear(kKeyPwd);
+        std::memset(keystorePathBuf, 0, sizeof(keystorePathBuf));
+        std::memset(storePasswordBuf, 0, sizeof(storePasswordBuf));
+        std::memset(keyAliasBuf, 0, sizeof(keyAliasBuf));
+        std::memset(keyPasswordBuf, 0, sizeof(keyPasswordBuf));
+        keystorePathLoaded = false;
+    }
+    ImGui::SameLine();
+    if (keystorePathLoaded)
+    {
+        ImGui::TextColored(ImVec4(0.4F, 1.0F, 0.4F, 1.0F), "Credentials saved.");
+    }
 
     ImGui::End();
 }

--- a/src/Systems/RenderDebugGUISystem.h
+++ b/src/Systems/RenderDebugGUISystem.h
@@ -116,6 +116,7 @@ class RenderDebugGUISystem {
   static void LuaConsoleWindow(sol::state& lua);
   static void PlayerOutputWindow(Game* game, bool* p_open);
   static void ExportOutputWindow(Game* game, bool* p_open);
+  static void SigningSettingsWindow(bool* p_open);
 #endif
   static void FPSWindow(float deltaTime);
   static void EntityInfoWindow(const Registry* registry);


### PR DESCRIPTION
## Summary

Stage 5 PR-C of `ai/EditorBuildAndDeployPlan.md` — OS-native credential storage for Android-release keystore creds, plus the in-editor form for managing them.

- New `src/Secrets/SecretStore.h` with platform impls:
  - **Windows**: DPAPI per-key `.dat` files under `SDL_GetPrefPath/secrets/`. Links `crypt32`.
  - **macOS**: Keychain Services (`SecItemAdd` / `SecItemUpdate` / `SecItemCopyMatching` / `SecItemDelete`) under service `com.octarine.engine.secrets`. Links `CoreFoundation` + `Security` frameworks.
  - **Linux**: stub (`IsAvailable() = false`). Signing Settings window falls back to surfacing the env-var contract; vcpkg pull of libsecret deferred.
- `ExportBuilder` pulls the four `OCTARINE_ANDROID_*` keys from the store for `AndroidRelease` and overrides them into the spawn env. Shell-exported vars still work when the store has no entry.
- New **Signing Settings** ImGui window (Windows menu + `EditorPersistence::showSigningSettings`):
  - Inputs for keystore path / store password / key alias / key password (last two masked).
  - Keystore path pre-loads from the store (non-secret on its own); passwords show `(stored)` indicator instead of round-tripping the secret back into a visible field.
  - **Save** writes only fields the user touched this frame; preserves stored values when the dev only edits one input.
  - **Clear all** wipes the four entries.
  - In-memory password buffers are `memset` to zero after Save / Clear so they do not linger in ImGui state.

Out of scope (PR-D candidate work, not yet scoped):
- SHA256 of artifact + Reveal-in-Explorer/Finder + copy-install-command clipboard hint.

## Test plan

- [x] `cmake --preset editor-debug && cmake --build build/editor-debug` — clean compile, 45/45 objects on Windows. `crypt32` links.
- [x] `EditorPersistence::kWindowFlags` count bumped to 11; `showSigningSettings` persists across editor sessions.
- [ ] Manual (Windows): open Signing Settings, enter the four fields, Save, close editor, reopen — keystore path repopulates, passwords show `(stored)`. Switch Export modal to Android (release AAB), Build, confirm Gradle picks the signed key (not the debug fallback).
- [ ] Manual (Windows): Clear all, confirm `(stored)` flips to `(empty)` and AndroidRelease build falls back to debug key.
- [ ] CI: macOS legs prove the Security/CoreFoundation framework link resolves; Linux legs prove the stub compiles + linker drops the unused symbols.
- [ ] Manual (macOS, post-merge): Keychain entry appears under service `com.octarine.engine.secrets` in `security` CLI / Keychain Access.