### PR TITLE
Add spatial-audio culling + resume-at-offset (Sound plan Phase 5)

### DIFF
--- a/src/Components/AudioActiveTag.h
+++ b/src/Components/AudioActiveTag.h
@@ -1,0 +1,8 @@
+#pragma once
+
+// Empty tag struct attached to spatial audio emitters currently inside the listener's
+// audible radius. Managed by AudioCullingSystem: added on enter, removed on exit. The
+// sink-lifecycle work (halt + offset capture + sink removal) is also driven off the same
+// transition so the per-frame Spatial/Doppler systems naturally skip culled entries when
+// the sink is gone.
+struct AudioActiveTag {};

--- a/src/Components/AudioSourceComponent.h
+++ b/src/Components/AudioSourceComponent.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <SDL3/SDL_stdinc.h>
+
 #include <string>
 
 struct AudioSourceComponent {
@@ -21,6 +23,12 @@ struct AudioSourceComponent {
   // DopplerSystem applies a per-frame frequency ratio via MIX_SetTrackFrequencyRatio.
   // Independent of `spatial` — a non-spatial doppler source is allowed but unusual.
   bool doppler = false;
+
+  // Phase 5 culling resume: -1 = no pending resume. AudioCullingSystem stashes
+  // MIX_GetTrackPlaybackPosition here when it culls a playing emitter, and AudioSystem
+  // seeks the new track to this offset (then resets to -1) when the emitter comes back
+  // in range and a fresh sink spawns. Looping sources resume mid-loop seamlessly.
+  Sint64 playbackOffsetFrames = -1;
 
   explicit AudioSourceComponent(std::string t_clipId = "", float t_volume = 1.0f, float t_pitch = 1.0f,
                                 bool t_loop = false, bool t_playOnSpawn = true, bool t_despawnOnFinish = false,

--- a/src/ECS/CommandBuffer.h
+++ b/src/ECS/CommandBuffer.h
@@ -67,6 +67,21 @@ class CommandBuffer {
         [entity, c = std::move(component)](Registry* r) mutable { r->AddComponent(entity, std::move(c)); });
   }
 
+  template <typename T>
+  void RemoveComponent(Entity entity) const {
+    state_->deferred.Emplace([entity](Registry* r) { r->RemoveComponent<T>(entity); });
+  }
+
+  template <typename T>
+  void AddTag(Entity entity) const {
+    state_->deferred.Emplace([entity](Registry* r) { r->AddTag<T>(entity); });
+  }
+
+  template <typename T>
+  void RemoveTag(Entity entity) const {
+    state_->deferred.Emplace([entity](Registry* r) { r->RemoveTag<T>(entity); });
+  }
+
   void Playback(Registry* registry) const;
 
  private:

--- a/src/Game/EngineOptions.h
+++ b/src/Game/EngineOptions.h
@@ -11,6 +11,10 @@ struct EngineOptions {
   float masterVolume = 1.0F;
   int audioTrackPoolInitial = 32;
   int audioTrackPoolMax = 128;
+  // Spatial sources beyond this radius from the listener are halted by AudioCullingSystem
+  // (track returned to pool, playback offset stashed on the source for clean resume on
+  // re-entry). Non-spatial sources ignore this cap.
+  float audioListenerRadius = 1500.0F;
   bool isPaused = false;
   float timeScale = 1.0F;
   bool stepFrame = false;

--- a/src/Game/Game.cpp
+++ b/src/Game/Game.cpp
@@ -50,8 +50,10 @@
 #include "Lua/LuaApiManifest.h"
 #include "Lua/LuaEntityLoader.h"
 #include "Lua/Modules/RegisterAllModules.h"
+#include "Components/AudioActiveTag.h"
 #include "Components/AudioListenerComponent.h"
 #include "Systems/AnimationSystem.h"
+#include "Systems/AudioCullingSystem.h"
 #include "Systems/AudioSystem.h"
 #include "Systems/CameraFollowSystem.h"
 #include "Systems/CollisionSystem.h"
@@ -853,6 +855,12 @@ void Game::Setup()
     // is the one that creates the AudioSinkComponent's MIX_Track that these mutate.
     registry_->Set<AudioListenerCache>(AudioListenerCache{});
     registry_->RegisterBulkSystem<GlobalTransformComponent>(UpdateListenerTransformSystem());
+    // Phase 5 culling: pre-register the AudioActiveTag so its component entity exists
+    // before any HasTag query fires (Tag<T>() is lazy otherwise). CullingSystem then gates
+    // SpatialAudioSystem / DopplerSystem implicitly — culled emitters lose their sink, and
+    // both downstream systems short-circuit on the missing sink.
+    registry_->Tag<AudioActiveTag>();
+    registry_->RegisterSystem<GlobalTransformComponent, AudioSourceComponent>(AudioCullingSystem());
     registry_->RegisterSystem<GlobalTransformComponent, AudioSourceComponent, AudioSinkComponent>(SpatialAudioSystem());
     // Doppler is independent of spatial: governs frequency ratio via MIX_SetTrackFrequencyRatio.
     // Requires RigidBodyComponent on the emitter (no body → no velocity → no shift).

--- a/src/Systems/AudioCullingSystem.h
+++ b/src/Systems/AudioCullingSystem.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <SDL3_mixer/SDL_mixer.h>
+
+#include <glm/glm.hpp>
+
+#include "../Components/AudioActiveTag.h"
+#include "../Components/AudioListenerComponent.h"
+#include "../Components/AudioSinkComponent.h"
+#include "../Components/AudioSourceComponent.h"
+#include "../Components/GlobalTransformComponent.h"
+#include "../ECS/CommandBuffer.h"
+#include "../ECS/Iterable.h"
+#include "../ECS/Registry.h"
+#include "../Game/GameConfig.h"
+
+// Per-emitter system: gates spatial sources by listener radius. Inside the radius the
+// emitter carries AudioActiveTag and plays normally; outside, the system stashes the
+// MIX_Track's playback frame onto AudioSourceComponent, halts the track, and removes the
+// AudioSinkComponent so the track returns to the pool for some other emitter to use.
+// AudioSystem's "resumingFromCull" path consumes the stored offset on re-entry, so a
+// looping clip picks up mid-loop without an audible glitch.
+//
+// Registered BEFORE SpatialAudioSystem so sinks halted this frame don't make a wasted
+// pass through the spatial / Doppler systems. The query is (GlobalTransform, AudioSource)
+// — sink is optional because a brand-new spatial source may enter the radius before
+// AudioSystem has had a chance to spawn its sink.
+class AudioCullingSystem {
+ public:
+  void operator()(const ContextFacade& ctx, Entity entity, const GlobalTransformComponent& transform,
+                  AudioSourceComponent& source) {
+    if (!source.spatial) return;
+
+    auto* registry = ctx.GetRegistry();
+    if (!cache_) cache_ = &registry->Get<AudioListenerCache>();
+    if (!cache_->valid) return;
+
+    const auto& engineOptions = registry->Get<GameConfig>().GetEngineOptions();
+    const float radius = engineOptions.audioListenerRadius;
+    const float radiusSq = radius * radius;
+
+    const glm::vec2 rel = transform.position - cache_->position;
+    const float distSq = glm::dot(rel, rel);
+    const bool inRange = distSq <= radiusSq;
+    const bool isActive = registry->HasTag<AudioActiveTag>(entity);
+
+    if (inRange && !isActive) {
+      cmd_buffer_.AddTag<AudioActiveTag>(entity);
+      return;
+    }
+
+    if (!inRange && isActive) {
+      if (registry->HasComponent<AudioSinkComponent>(entity)) {
+        auto& sink = registry->GetComponent<AudioSinkComponent>(entity);
+        if (sink.track && !sink.finished) {
+          // Capture position BEFORE Stop — MIX_GetTrackPlaybackPosition on a stopped
+          // track may return 0 or undefined.
+          source.playbackOffsetFrames = MIX_GetTrackPlaybackPosition(sink.track);
+          MIX_StopTrack(sink.track, 0);
+        }
+        cmd_buffer_.RemoveComponent<AudioSinkComponent>(entity);
+      }
+      cmd_buffer_.RemoveTag<AudioActiveTag>(entity);
+    }
+  }
+
+  CommandBuffer& GetCommandBuffer() { return cmd_buffer_; }
+
+ private:
+  const AudioListenerCache* cache_ = nullptr;
+  CommandBuffer cmd_buffer_;
+};

--- a/src/Systems/AudioSystem.cpp
+++ b/src/Systems/AudioSystem.cpp
@@ -6,6 +6,7 @@
 #include <string>
 
 #include "../AssetManager/AssetManager.h"
+#include "../Components/AudioActiveTag.h"
 #include "../Game/GameConfig.h"
 #include "../General/Logger.h"
 
@@ -160,7 +161,18 @@ void AudioSystem::operator()(Entity entity, AudioSourceComponent& source)
 
     if (!registry_->HasComponent<AudioSinkComponent>(entity))
     {
-        if (!source.playOnSpawn) return;
+        // Spatial sources are gated by AudioCullingSystem's AudioActiveTag: an out-of-range
+        // emitter has no tag, so even a resume-pending source waits here until it comes back
+        // into the listener radius. Without this gate the resume + cull pair would oscillate
+        // (AudioSystem re-spawns the sink, CullingSystem culls it again next frame).
+        if (source.spatial && !registry_->HasTag<AudioActiveTag>(entity)) return;
+
+        // Resume-from-cull is a second valid play trigger alongside playOnSpawn: when
+        // AudioCullingSystem halts a culled emitter it stashes the frame offset on the
+        // source and removes the sink, so the entity arrives here with a >=0 offset
+        // waiting to be consumed.
+        const bool resumingFromCull = source.playbackOffsetFrames >= 0;
+        if (!source.playOnSpawn && !resumingFromCull) return;
 
         auto& assetManager = registry_->Get<AssetManager>();
         MIX_Audio* clip = assetManager.GetAudioClip(source.clipId);
@@ -199,6 +211,14 @@ void AudioSystem::operator()(Entity entity, AudioSourceComponent& source)
         {
             Logger::Warn("MIX_PlayTrack failed for " + source.clipId + ": " + std::string(SDL_GetError()));
             return;
+        }
+
+        // Seek AFTER play: SDL_mixer accepts position changes on a playing track and the
+        // seek-then-play path skips an extra paused-state transition.
+        if (resumingFromCull)
+        {
+            MIX_SetTrackPlaybackPosition(acquired.track, source.playbackOffsetFrames);
+            source.playbackOffsetFrames = -1;
         }
         cmd_buffer_.AddComponent<AudioSinkComponent>(entity, AudioSinkComponent(acquired.track, acquired.generation));
         return;


### PR DESCRIPTION
## Summary
- Adds `AudioCullingSystem` (per spatial source) + `AudioActiveTag` to bound the audible voice count by `EngineOptions::audioListenerRadius` (default 1500).
- Out-of-range spatial emitters: `MIX_GetTrackPlaybackPosition` → stash on source, `MIX_StopTrack`, drop sink → MIX_Track returns to the pool.
- Back-in-range: `AudioSystem`'s new \"resume-from-cull\" branch spawns a fresh sink and seeks via `MIX_SetTrackPlaybackPosition` so looping clips pick up mid-loop.
- Spatial sources gated on `HasTag<AudioActiveTag>` in `AudioSystem` to prevent the resume↔cull oscillation.
- `CommandBuffer` gains `RemoveComponent` / `AddTag` / `RemoveTag` deferred-op templates (parallel to existing `AddComponent`).

Stage 5 of [ai/SoundPlan.md](../blob/main/ai/SoundPlan.md).

## Out of scope
- Spatial-hash broadphase. Plan defers it past ~1k emitters; flat sweep is sufficient at current scales and reuses the same hot-path cache hoist as `SpatialAudioSystem` / `DopplerSystem`.

## Test plan
- [ ] Spawn 200 looping spatial emitters in a grid; walk listener across them. Active track count (use `MIX_*` logs or pool size) stays near a small constant tied to radius density, not 200.
- [ ] Re-enter an emitter's radius after culling. Loop resumes mid-loop, not from sample 0.
- [ ] Set `audioListenerRadius` smaller / larger via Lua at runtime — voice count changes accordingly.
- [ ] Non-spatial sources (music, UI sfx) unaffected — they never get the tag, never get culled.
- [ ] One-shot spatial source with `despawnOnFinish` that ends mid-cull is still cleaned up correctly (sink removed by culling, source persists unless something else despawns it).