### PR TITLE
Add DevListenServer TCP listener with hello/ping handshake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -444,5 +444,28 @@ if (OCTARINE_ENABLE_TESTS)
     endif ()
     add_test(NAME EventBusTest COMMAND OctarineEventBusTest)
 
+    # DevListenServer smoke test (Stage 6 PR-A): standalone — only the server source + Logger.
+    # Bound to the same OCTARINE_SHIPPED gate as the engine-side server.
+    if (NOT OCTARINE_SHIPPED)
+        add_executable(OctarineDevListenServerTest
+                src/Dev/DevListenServer.cpp
+                src/General/Logger.cpp
+                tests/DevListenServerTest.cpp)
+        set_target_properties(OctarineDevListenServerTest PROPERTIES
+                CXX_STANDARD 20
+                CXX_STANDARD_REQUIRED ON
+                CXX_EXTENSIONS OFF)
+        target_include_directories(OctarineDevListenServerTest PRIVATE
+                ${CMAKE_CURRENT_SOURCE_DIR}/src)
+        target_link_libraries(OctarineDevListenServerTest PRIVATE spdlog::spdlog Threads::Threads)
+        if (WIN32)
+            target_link_libraries(OctarineDevListenServerTest PRIVATE ws2_32)
+        endif ()
+        if (MSVC)
+            target_compile_options(OctarineDevListenServerTest PRIVATE /W4 /permissive- /MP /EHsc)
+        endif ()
+        add_test(NAME DevListenServerTest COMMAND OctarineDevListenServerTest)
+    endif ()
+
     message(STATUS "Octarine: Tests ENABLED")
 endif ()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -201,10 +201,16 @@ endif ()
 # symbols (RenderDebugGUISystem::Render, EditorPersistence::*, SecretStore::*) resolve at the
 # final exe link without forcing the engine TU to know about editor concretely.
 # -----------------------------------------------------------------------------
-octarine_library(octarine_engine
+set(OCTARINE_ENGINE_SOURCES
         Engine/EngineBootstrap.cpp
         Game/Game.cpp
 )
+# DevListenServer (Stage 6): TCP listener for the dev iterate loop. Available in editor + player
+# presets; compile-stripped from ship-release (OCTARINE_SHIPPED).
+if (NOT OCTARINE_SHIPPED)
+    list(APPEND OCTARINE_ENGINE_SOURCES Dev/DevListenServer.cpp)
+endif ()
+octarine_library(octarine_engine ${OCTARINE_ENGINE_SOURCES})
 target_link_libraries(octarine_engine PUBLIC
         octarine_core
         octarine_assets
@@ -214,4 +220,9 @@ target_link_libraries(octarine_engine PUBLIC
 )
 if (TARGET octarine_editor)
     target_link_libraries(octarine_engine PUBLIC octarine_editor)
+endif ()
+# Winsock provides the BSD-socket API (ws2_32) on Windows; POSIX sockets come from libc so no
+# extra link is needed there. Only when the dev server is compiled in (non-shipped builds).
+if (NOT OCTARINE_SHIPPED AND WIN32)
+    target_link_libraries(octarine_engine PUBLIC ws2_32)
 endif ()

--- a/src/Dev/DevListenServer.cpp
+++ b/src/Dev/DevListenServer.cpp
@@ -1,0 +1,320 @@
+#include "Dev/DevListenServer.h"
+
+#ifndef OCTARINE_SHIPPED
+
+#include "General/Logger.h"
+
+#ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <winsock2.h>
+#include <ws2tcpip.h>
+using socket_t = SOCKET;
+using io_size_t = int;   // recv/send `len` arg type on Winsock
+using io_ssize_t = int;  // recv/send return type on Winsock
+constexpr socket_t kInvalidSocket = INVALID_SOCKET;
+constexpr int kSocketError = SOCKET_ERROR;
+#else
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <sys/select.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+using socket_t = int;
+using io_size_t = std::size_t;  // recv/send `len` arg type on POSIX
+using io_ssize_t = ssize_t;     // recv/send return type on POSIX
+constexpr socket_t kInvalidSocket = -1;
+constexpr int kSocketError = -1;
+#endif
+
+#include <atomic>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace octarine::dev {
+namespace {
+void CloseSocket(socket_t s) {
+  if (s == kInvalidSocket) return;
+#ifdef _WIN32
+  ::closesocket(s);
+#else
+  ::close(s);
+#endif
+}
+
+// Toggle blocking mode. The listen socket is set non-blocking so accept() never parks the
+// listener thread (Stop() can't wake a blocked accept() by closing the fd on Linux — close()
+// does not interrupt accept() there, unlike Winsock). Accepted client sockets are forced
+// back to blocking so the ReadAll/WriteAll loops keep their simple >0 / <=0 semantics
+// (a non-blocking client would spuriously fail ReadAll with EWOULDBLOCK before data lands;
+// Windows-accepted sockets inherit the listener's non-blocking flag, so this is required).
+void SetSocketBlocking(socket_t s, bool blocking) {
+#ifdef _WIN32
+  u_long mode = blocking ? 0u : 1u;
+  ::ioctlsocket(s, FIONBIO, &mode);
+#else
+  const int flags = ::fcntl(s, F_GETFL, 0);
+  if (flags < 0) return;
+  ::fcntl(s, F_SETFL, blocking ? (flags & ~O_NONBLOCK) : (flags | O_NONBLOCK));
+#endif
+}
+
+int LastSocketError() {
+#ifdef _WIN32
+  return ::WSAGetLastError();
+#else
+  return errno;
+#endif
+}
+
+// Reads exactly `n` bytes from `s` into `out`. Returns false if the peer closed early or
+// the socket errored. Tiny loop is fine — frames are small in PR-A (<= 12 bytes).
+bool ReadAll(socket_t s, void* out, std::size_t n) {
+  auto* p = static_cast<char*>(out);
+  while (n > 0) {
+    const io_ssize_t got = ::recv(s, p, static_cast<io_size_t>(n), 0);
+    if (got <= 0) {
+      return false;
+    }
+    p += got;
+    n -= static_cast<std::size_t>(got);
+  }
+  return true;
+}
+
+bool WriteAll(socket_t s, const void* in, std::size_t n) {
+  const auto* p = static_cast<const char*>(in);
+  while (n > 0) {
+    const io_ssize_t sent = ::send(s, p, static_cast<io_size_t>(n), 0);
+    if (sent <= 0) {
+      return false;
+    }
+    p += sent;
+    n -= static_cast<std::size_t>(sent);
+  }
+  return true;
+}
+
+bool WriteFrame(socket_t s, std::uint32_t op, const void* body, std::uint32_t body_len) {
+  const std::uint32_t length = 4 + body_len;  // op (4) + body
+  if (!WriteAll(s, &length, sizeof(length))) return false;
+  if (!WriteAll(s, &op, sizeof(op))) return false;
+  if (body_len > 0 && !WriteAll(s, body, body_len)) return false;
+  return true;
+}
+
+#ifdef _WIN32
+// Reference-counted WSAStartup so multiple servers (or test threads) can share one init.
+std::atomic<int> g_wsa_refs{0};
+
+void WsaAcquire() {
+  if (g_wsa_refs.fetch_add(1, std::memory_order_acq_rel) == 0) {
+    WSADATA d{};
+    ::WSAStartup(MAKEWORD(2, 2), &d);
+  }
+}
+void WsaRelease() {
+  if (g_wsa_refs.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+    ::WSACleanup();
+  }
+}
+#else
+void WsaAcquire() {}
+void WsaRelease() {}
+#endif
+}  // namespace
+
+struct DevListenServer::Impl {
+  std::atomic<bool> running{false};
+  std::atomic<bool> stop_requested{false};
+  std::uint16_t bound_port{0};
+  socket_t listen_sock{kInvalidSocket};
+  std::thread listener;
+};
+
+DevListenServer::DevListenServer() : impl_(std::make_unique<Impl>()) {}
+
+DevListenServer::~DevListenServer() { Stop(); }
+
+DevListenServer::DevListenServer(DevListenServer&&) noexcept = default;
+DevListenServer& DevListenServer::operator=(DevListenServer&&) noexcept = default;
+
+bool DevListenServer::IsRunning() const { return impl_ && impl_->running.load(std::memory_order_acquire); }
+
+std::uint16_t DevListenServer::BoundPort() const { return impl_ ? impl_->bound_port : 0; }
+
+void DevListenServer::Pump() {
+  // PR-A reserved hook: no off-thread commands queued yet. PR-B will drain a SPSC ring of
+  // EvalLua / ReloadScene / PushScript / PushAsset requests here so they execute on the main
+  // thread (Registry / sol::state / AssetManager are not thread-safe).
+}
+
+bool DevListenServer::Start(const ServerOptions& opts) {
+  if (!impl_) return false;
+  if (impl_->running.load(std::memory_order_acquire)) return true;
+
+  WsaAcquire();
+
+  socket_t s = ::socket(AF_INET, SOCK_STREAM, 0);
+  if (s == kInvalidSocket) {
+    Logger::Error("DevListenServer: socket() failed (err=" + std::to_string(LastSocketError()) + ")");
+    WsaRelease();
+    return false;
+  }
+
+  int reuse = 1;
+  ::setsockopt(s, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<const char*>(&reuse), sizeof(reuse));
+
+  sockaddr_in addr{};
+  addr.sin_family = AF_INET;
+  addr.sin_port = htons(opts.port);
+  addr.sin_addr.s_addr = opts.listen_all ? htonl(INADDR_ANY) : htonl(INADDR_LOOPBACK);
+
+  if (::bind(s, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) == kSocketError) {
+    Logger::Error("DevListenServer: bind() failed (err=" + std::to_string(LastSocketError()) +
+                  ", port=" + std::to_string(opts.port) + ")");
+    CloseSocket(s);
+    WsaRelease();
+    return false;
+  }
+  if (::listen(s, 4) == kSocketError) {
+    Logger::Error("DevListenServer: listen() failed (err=" + std::to_string(LastSocketError()) + ")");
+    CloseSocket(s);
+    WsaRelease();
+    return false;
+  }
+
+  // Non-blocking listen socket: the listener thread waits in select() and only accept()s when
+  // a connection is pending, so it never parks. Stop() then just flips stop_requested and the
+  // loop exits within one select() timeout — no cross-thread fd close to race the accept().
+  SetSocketBlocking(s, false);
+
+  // Read back the ephemeral port the kernel picked when opts.port == 0 so callers/tests can
+  // dial in without racing the bind.
+  sockaddr_in bound{};
+  socklen_t blen = sizeof(bound);
+  if (::getsockname(s, reinterpret_cast<sockaddr*>(&bound), &blen) == 0) {
+    impl_->bound_port = ntohs(bound.sin_port);
+  }
+
+  if (opts.listen_all) {
+    Logger::Warn("DevListenServer: bound 0.0.0.0:" + std::to_string(impl_->bound_port) +
+                 " — exposed to LAN. Prefer 127.0.0.1 unless cross-host dev is intentional.");
+  } else {
+    Logger::Info("DevListenServer: bound 127.0.0.1:" + std::to_string(impl_->bound_port));
+  }
+
+  impl_->listen_sock = s;
+  impl_->stop_requested.store(false, std::memory_order_release);
+  impl_->running.store(true, std::memory_order_release);
+
+  impl_->listener = std::thread([this]() {
+    socket_t ls = impl_->listen_sock;
+    while (!impl_->stop_requested.load(std::memory_order_acquire)) {
+      // Wait up to 100ms for a pending connection, then re-check stop_requested. This is
+      // what makes Stop() prompt and deadlock-free: no blocking accept() to interrupt.
+      fd_set readable;
+      FD_ZERO(&readable);
+      FD_SET(ls, &readable);
+      timeval timeout{};
+      timeout.tv_sec = 0;
+      timeout.tv_usec = 100 * 1000;  // 100ms
+      const int ready = ::select(static_cast<int>(ls + 1), &readable, nullptr, nullptr, &timeout);
+      if (ready <= 0) {
+        // 0 = timeout, <0 = interrupted/error; loop and re-test stop_requested.
+        continue;
+      }
+
+      sockaddr_in client{};
+      socklen_t clen = sizeof(client);
+      socket_t cs = ::accept(ls, reinterpret_cast<sockaddr*>(&client), &clen);
+      if (cs == kInvalidSocket) {
+        // Connection withdrawn between select() and accept(), or a transient error;
+        // not fatal — go back to waiting.
+        continue;
+      }
+      // The accepted socket inherits the listener's non-blocking flag on Windows; force it
+      // blocking so the ReadAll/WriteAll loops below keep their simple semantics.
+      SetSocketBlocking(cs, true);
+      // Handle one frame per connection for v1 simplicity; the matrix of
+      // op x persistent-connection-state is small enough that closing+reopening is fine.
+      std::uint32_t length = 0;
+      if (!ReadAll(cs, &length, sizeof(length))) {
+        CloseSocket(cs);
+        continue;
+      }
+      if (length < 4 || length > 1024 * 1024) {
+        Logger::Warn("DevListenServer: rejecting frame length=" + std::to_string(length));
+        CloseSocket(cs);
+        continue;
+      }
+      std::uint32_t op = 0;
+      if (!ReadAll(cs, &op, sizeof(op))) {
+        CloseSocket(cs);
+        continue;
+      }
+
+      const std::uint32_t body_len = length - 4;
+      std::vector<char> body(body_len);
+      if (body_len > 0 && !ReadAll(cs, body.data(), body_len)) {
+        CloseSocket(cs);
+        continue;
+      }
+
+      switch (static_cast<OpCode>(op)) {
+        case OpCode::Hello: {
+          WriteFrame(cs, static_cast<std::uint32_t>(OpCode::Hello), kHelloBanner,
+                     static_cast<std::uint32_t>(std::strlen(kHelloBanner)));
+          break;
+        }
+        case OpCode::Ping: {
+          // Echo the 8-byte client nonce back. Tolerate other body sizes (some clients
+          // may ping with an empty body); just echo whatever they sent.
+          WriteFrame(cs, static_cast<std::uint32_t>(OpCode::Ping), body.data(), body_len);
+          break;
+        }
+        default: {
+          Logger::Warn("DevListenServer: unknown op=" + std::to_string(op));
+          const std::uint32_t err_op = 0xFFFFFFFFu;
+          WriteFrame(cs, err_op, nullptr, 0);
+          break;
+        }
+      }
+
+      CloseSocket(cs);
+    }
+  });
+
+  return true;
+}
+
+void DevListenServer::Stop() {
+  if (!impl_) return;
+  if (!impl_->running.exchange(false, std::memory_order_acq_rel)) {
+    return;
+  }
+  impl_->stop_requested.store(true, std::memory_order_release);
+
+  // Join first: the listener's select() loop notices stop_requested within one timeout tick
+  // and returns on its own. Closing the listen socket only after the thread is gone avoids
+  // the cross-thread close-during-accept race that hung the listener on Linux.
+  if (impl_->listener.joinable()) {
+    impl_->listener.join();
+  }
+
+  CloseSocket(impl_->listen_sock);
+  impl_->listen_sock = kInvalidSocket;
+  impl_->bound_port = 0;
+
+  WsaRelease();
+}
+}  // namespace octarine::dev
+
+#endif  // !OCTARINE_SHIPPED

--- a/src/Dev/DevListenServer.h
+++ b/src/Dev/DevListenServer.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#ifndef OCTARINE_SHIPPED
+
+// DevListenServer — Stage 6 of ai/EditorBuildAndDeployPlan.md (PR-A foundation: TCP listener +
+// hello/ping handshake; PR-B will add eval_lua / reload_scene / push_script / push_asset).
+//
+// Compile-time stripped from shipped builds (#ifndef OCTARINE_SHIPPED). When enabled, owns a
+// background listener thread bound to 127.0.0.1:<port> (or 0.0.0.0:<port> with --dev-listen-all)
+// and serves a tiny length-prefixed binary protocol:
+//
+//     each message:  uint32 LE length | uint32 LE op | body[length-4]
+//     hello reply:   op=Hello, body = "OCTARINE_DEV_LISTEN/v1\n"
+//     ping reply:    op=Pong,  body = client nonce (8 bytes echoed back)
+//
+// I/O lives on the listener thread; PR-A ops are pure I/O so they reply directly. Pump() exists
+// on the main thread as the seam PR-B will route commands-that-touch-engine-state through (Lua
+// eval, scene reload, asset/script writes) once those land. No engine state is touched off the
+// main thread today.
+
+#include <cstdint>
+#include <memory>
+
+namespace octarine::dev {
+enum class OpCode : std::uint32_t {
+  Hello = 1,  // body: empty       -> reply Hello with banner
+  Ping = 2,   // body: u64 LE nonce -> reply Pong with same nonce
+              // Reserved by PR-B (do not reuse): 10 EvalLua, 11 ReloadScene, 12 PushScript, 13 PushAsset.
+};
+
+struct ServerOptions {
+  std::uint16_t port = 0;   // 0 = pick ephemeral (BoundPort() reads back after Start)
+  bool listen_all = false;  // false = bind 127.0.0.1; true = 0.0.0.0 (warned at Start)
+};
+
+class DevListenServer {
+ public:
+  DevListenServer();
+  ~DevListenServer();
+
+  DevListenServer(const DevListenServer&) = delete;
+  DevListenServer& operator=(const DevListenServer&) = delete;
+  DevListenServer(DevListenServer&&) noexcept;
+  DevListenServer& operator=(DevListenServer&&) noexcept;
+
+  // Spawns the listener thread bound per `opts`. Returns true on bind+listen success and
+  // populates BoundPort(). Returns false (and logs) on socket / bind / listen failure.
+  // Idempotent no-op (returning true) when already running.
+  bool Start(const ServerOptions& opts);
+
+  // Closes the listening socket, signals the thread to exit, and joins. Safe to call from
+  // any thread; idempotent.
+  void Stop();
+
+  bool IsRunning() const;
+  std::uint16_t BoundPort() const;
+
+  // Per-frame drain for commands that must run on the main thread. PR-A queues nothing
+  // (hello/ping reply on the listener thread); PR-B wires eval_lua / reload_scene through
+  // a SPSC ring drained here.
+  void Pump();
+
+ private:
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+// Engine banner returned by the Hello op. Versioned so PR-B can bump and clients can gate.
+inline constexpr const char* kHelloBanner = "OCTARINE_DEV_LISTEN/v1\n";
+}  // namespace octarine::dev
+
+#endif  // !OCTARINE_SHIPPED

--- a/src/Game/Game.cpp
+++ b/src/Game/Game.cpp
@@ -92,6 +92,10 @@
 #include "../Editor/PlayerLauncher.h"
 #endif
 
+#ifndef OCTARINE_SHIPPED
+#include "../Dev/DevListenServer.h"
+#endif
+
 namespace {
 // Read a file's bytes through SDL_IO so the same path resolves on desktop, inside an APK asset
 // root, or inside a .app bundle. Lua's stock fopen-based loader only sees a real filesystem and
@@ -166,6 +170,21 @@ bool Game::Initialize(const std::string& assetPath) {
 
   registry_->Set<GameConfig>(GameConfig());
   auto& gameConfig = registry_->Get<GameConfig>();
+
+#ifndef OCTARINE_SHIPPED
+  // DevListenServer (Stage 6): TCP listener on 127.0.0.1:<port> when --dev-listen given.
+  // Compile-stripped from shipped builds. Available in editor + player presets alike so the
+  // standalone player can host the dev-iterate loop too.
+  auto& devListen = registry_->Set<octarine::dev::DevListenServer>(octarine::dev::DevListenServer());
+  if (dev_listen_port_ > 0) {
+    octarine::dev::ServerOptions opts;
+    opts.port = static_cast<std::uint16_t>(dev_listen_port_);
+    opts.listen_all = dev_listen_all_;
+    if (!devListen.Start(opts)) {
+      Logger::Error("DevListenServer failed to start; --dev-listen flag had no effect.");
+    }
+  }
+#endif
 
   std::string effectivePath = assetPath;
 #ifdef OCTARINE_WITH_EDITOR
@@ -346,6 +365,14 @@ bool Game::Initialize(const std::string& assetPath) {
 
 void Game::Destroy() {
   if (registry_) {
+#ifndef OCTARINE_SHIPPED
+    // Stop the dev listener before the registry teardown drops it so the listener thread
+    // joins cleanly while the engine is still alive.
+    if (auto* devListen = registry_->TryGet<octarine::dev::DevListenServer>()) {
+      devListen->Stop();
+    }
+#endif
+
     auto& gameConfig = registry_->Get<GameConfig>();
     gameConfig.SaveUserPreferences();
 #ifdef OCTARINE_WITH_EDITOR
@@ -786,6 +813,12 @@ void Game::Update(const float deltaTime) {
   PerfUtils::PerfCounters::ResetValues();
 #endif
   PROFILE_NAMED_SCOPE("Game::Update (total)");
+
+#ifndef OCTARINE_SHIPPED
+  if (auto* devListen = registry_->TryGet<octarine::dev::DevListenServer>()) {
+    devListen->Pump();
+  }
+#endif
 
   auto& options = registry_->Get<GameConfig>().GetEngineOptions();
 

--- a/src/Game/Game.h
+++ b/src/Game/Game.h
@@ -66,6 +66,16 @@ class Game : public LuaBindingContext {
   // In a shipped build (OCTARINE_SHIPPED) the manifest is used unconditionally and this is moot.
   void SetUseManifest(bool useManifest) { use_manifest_ = useManifest; }
 
+#ifndef OCTARINE_SHIPPED
+  // Dev-only: opt into the DevListenServer (Stage 6 of EditorBuildAndDeployPlan). port=0 leaves
+  // the server stopped. listenAll=true binds 0.0.0.0; default 127.0.0.1. Called by Main from
+  // --dev-listen / --dev-listen-all and stripped from shipped binaries.
+  void SetDevListen(int port, bool listenAll) {
+    dev_listen_port_ = port;
+    dev_listen_all_ = listenAll;
+  }
+#endif
+
   [[nodiscard]] SDL_Renderer* GetRenderer() const override { return sdl_renderer_; }
   [[nodiscard]] SDL_Window* GetWindow() const { return window_; }
 
@@ -117,6 +127,10 @@ class Game : public LuaBindingContext {
   bool scene_running_ = false;
   bool bake_mode_ = false;
   bool use_manifest_ = false;
+#ifndef OCTARINE_SHIPPED
+  int dev_listen_port_ = 0;
+  bool dev_listen_all_ = false;
+#endif
   int bake_validation_failures_ = 0;
   Uint64 milliseconds_previous_frame_ = 0;
   // Asset ids acquired for the currently loaded scene. StopScene releases these; LoadScene

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -13,6 +13,8 @@ int main(const int argc, char* argv[]) {
   std::string gamePath;
   std::string startupMode;
   bool useManifest = false;
+  int devListenPort = 0;      // 0 = disabled; >0 = bind on that TCP port
+  bool devListenAll = false;  // false = 127.0.0.1; true = 0.0.0.0 (LAN-exposed)
 
   // Parse command-line arguments
   for (int i = 1; i < argc; ++i) {
@@ -31,6 +33,35 @@ int main(const int argc, char* argv[]) {
       // uses it unconditionally). Lets the asset_manifest.lua path be exercised without packaging.
       useManifest = true;
       Logger::Info("Asset manifest loading forced ON (--use-manifest).");
+    } else if (currentArg == "--dev-listen") {
+#ifdef OCTARINE_SHIPPED
+      Logger::Warn("--dev-listen is stripped from shipped builds; ignoring.");
+      if (i + 1 < argc) ++i;  // consume the port argument so it does not parse as gamePath
+#else
+      if (i + 1 < argc) {
+        try {
+          devListenPort = std::stoi(argv[++i]);
+        } catch (const std::exception&) {
+          Logger::Error("Error: --dev-listen requires an integer port (got '" + std::string(argv[i]) + "').");
+          return 1;
+        }
+        if (devListenPort <= 0 || devListenPort > 65535) {
+          Logger::Error("Error: --dev-listen port out of range (got " + std::to_string(devListenPort) + ").");
+          return 1;
+        }
+        Logger::Info("Dev-listen requested on port " + std::to_string(devListenPort) + ".");
+      } else {
+        Logger::Error("Error: --dev-listen flag requires a port argument.");
+        return 1;
+      }
+#endif
+    } else if (currentArg == "--dev-listen-all") {
+#ifdef OCTARINE_SHIPPED
+      Logger::Warn("--dev-listen-all is stripped from shipped builds; ignoring.");
+#else
+      devListenAll = true;
+      Logger::Warn("--dev-listen-all set; will bind 0.0.0.0 instead of 127.0.0.1.");
+#endif
     } else if (currentArg.starts_with("-")) {
       Logger::Warn("Unknown command-line argument: " + currentArg);
     } else {
@@ -48,6 +79,12 @@ int main(const int argc, char* argv[]) {
   Game game{};
   game.SetStartupMode(startupMode);
   game.SetUseManifest(useManifest);
+#ifndef OCTARINE_SHIPPED
+  game.SetDevListen(devListenPort, devListenAll);
+#else
+  (void)devListenPort;
+  (void)devListenAll;
+#endif
 
   if (game.Initialize(gamePath)) {
     game.Run();

--- a/tests/DevListenServerTest.cpp
+++ b/tests/DevListenServerTest.cpp
@@ -1,0 +1,177 @@
+// Smoke checks for the DevListenServer (Stage 6 PR-A). gtest-free; failed-check count is the
+// exit code. Mirrors the style of ProcessTest / ProjectIniTest.
+//
+// Server is OCTARINE_SHIPPED-gated; this test target builds only when the engine target also
+// builds it. Test spawns the server on an ephemeral port, dials in over loopback, and validates
+// the hello + ping ops round-trip.
+
+#include "Dev/DevListenServer.h"
+
+#ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <winsock2.h>
+#include <ws2tcpip.h>
+using socket_t = SOCKET;
+using io_size_t = int;
+using io_ssize_t = int;
+constexpr socket_t kInvalidSocket = INVALID_SOCKET;
+#else
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+using socket_t = int;
+using io_size_t = std::size_t;
+using io_ssize_t = ssize_t;
+constexpr socket_t kInvalidSocket = -1;
+#endif
+
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <thread>
+
+namespace {
+int g_failures = 0;
+
+void Check(const bool cond, const std::string& what) {
+  if (cond) {
+    std::cout << "  ok   " << what << "\n";
+  } else {
+    std::cerr << "  FAIL " << what << "\n";
+    ++g_failures;
+  }
+}
+
+void CloseSock(socket_t s) {
+#ifdef _WIN32
+  ::closesocket(s);
+#else
+  ::close(s);
+#endif
+}
+
+bool WriteAll(socket_t s, const void* in, std::size_t n) {
+  const auto* p = static_cast<const char*>(in);
+  while (n > 0) {
+    const io_ssize_t sent = ::send(s, p, static_cast<io_size_t>(n), 0);
+    if (sent <= 0) return false;
+    p += sent;
+    n -= static_cast<std::size_t>(sent);
+  }
+  return true;
+}
+
+bool ReadAll(socket_t s, void* out, std::size_t n) {
+  auto* p = static_cast<char*>(out);
+  while (n > 0) {
+    const io_ssize_t got = ::recv(s, p, static_cast<io_size_t>(n), 0);
+    if (got <= 0) return false;
+    p += got;
+    n -= static_cast<std::size_t>(got);
+  }
+  return true;
+}
+
+// Sends `op` + body, reads back `op` + body. Returns the reply body (excluding the 4-byte op
+// header). Empty on failure (g_failures bumped via Check).
+std::string RoundTrip(std::uint16_t port, std::uint32_t op, const std::string& body) {
+  socket_t s = ::socket(AF_INET, SOCK_STREAM, 0);
+  if (s == kInvalidSocket) {
+    Check(false, "RoundTrip: socket()");
+    return {};
+  }
+  sockaddr_in addr{};
+  addr.sin_family = AF_INET;
+  addr.sin_port = htons(port);
+  addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+
+  if (::connect(s, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0) {
+    Check(false, "RoundTrip: connect()");
+    CloseSock(s);
+    return {};
+  }
+
+  const std::uint32_t length = 4 + static_cast<std::uint32_t>(body.size());
+  if (!WriteAll(s, &length, sizeof(length)) || !WriteAll(s, &op, sizeof(op)) ||
+      (body.size() > 0 && !WriteAll(s, body.data(), body.size()))) {
+    Check(false, "RoundTrip: WriteAll(request)");
+    CloseSock(s);
+    return {};
+  }
+
+  std::uint32_t reply_len = 0;
+  if (!ReadAll(s, &reply_len, sizeof(reply_len))) {
+    Check(false, "RoundTrip: ReadAll(reply_len)");
+    CloseSock(s);
+    return {};
+  }
+  std::uint32_t reply_op = 0;
+  if (!ReadAll(s, &reply_op, sizeof(reply_op))) {
+    Check(false, "RoundTrip: ReadAll(reply_op)");
+    CloseSock(s);
+    return {};
+  }
+  if (reply_op != op) {
+    Check(false, "RoundTrip: reply op echoes request");
+    CloseSock(s);
+    return {};
+  }
+  const std::uint32_t reply_body_len = reply_len - 4;
+  std::string out(reply_body_len, '\0');
+  if (reply_body_len > 0 && !ReadAll(s, out.data(), reply_body_len)) {
+    Check(false, "RoundTrip: ReadAll(reply_body)");
+    CloseSock(s);
+    return {};
+  }
+  CloseSock(s);
+  return out;
+}
+}  // namespace
+
+int main() {
+#ifdef _WIN32
+  WSADATA wsadata{};
+  ::WSAStartup(MAKEWORD(2, 2), &wsadata);
+#endif
+
+  using namespace octarine::dev;
+  DevListenServer server;
+  ServerOptions opts;
+  opts.port = 0;            // ephemeral
+  opts.listen_all = false;  // loopback only
+
+  Check(server.Start(opts), "Start() on ephemeral port succeeds");
+  const std::uint16_t port = server.BoundPort();
+  Check(port != 0, "BoundPort() resolves a real port");
+  Check(server.IsRunning(), "IsRunning() true after Start");
+
+  {
+    const std::string banner = RoundTrip(port, static_cast<std::uint32_t>(OpCode::Hello), {});
+    Check(banner == std::string(kHelloBanner), "Hello returns the engine banner");
+  }
+
+  {
+    // 8-byte nonce echoed back unchanged.
+    const std::string nonce = "OCTARINE";
+    const std::string echo = RoundTrip(port, static_cast<std::uint32_t>(OpCode::Ping), nonce);
+    Check(echo == nonce, "Ping echoes the client nonce");
+  }
+
+  server.Stop();
+  Check(!server.IsRunning(), "IsRunning() false after Stop");
+
+  // Restart on a fresh port to confirm Stop+Start cycle is clean.
+  Check(server.Start(opts), "Start() after Stop succeeds again");
+  server.Stop();
+
+#ifdef _WIN32
+  ::WSACleanup();
+#endif
+
+  return g_failures;
+}


### PR DESCRIPTION
## Summary

Stage 6 PR-A of `ai/EditorBuildAndDeployPlan.md` — foundation for the dev-iterate loop. TCP listener the editor (and other tooling) will dial into for asset / script push and Lua eval. This PR ships the socket + thread infrastructure and the `hello` + `ping` ops; PR-B will land `eval_lua` / `reload_scene` / `push_script` / `push_asset`.

- New `src/Dev/DevListenServer.{h,cpp}` — Registry singleton, listener thread bound to `127.0.0.1:<port>` (or `0.0.0.0` with `--dev-listen-all`). Compile-stripped from ship builds via `#ifndef OCTARINE_SHIPPED` on header / .cpp / CMake / Game / Main.
- Wire v1: little-endian `u32 length | u32 op | body[length-4]`.
  - **Hello** returns a versioned banner string so clients can gate on protocol version.
  - **Ping** echoes the client's nonce body back.
  - Reserved op ids for PR-B (`10 EvalLua`, `11 ReloadScene`, `12 PushScript`, `13 PushAsset`) noted in code so we don't reuse them.
- BSD sockets on POSIX, Winsock on Windows (`ws2_32` linked, `WSAStartup` refcounted so tests + engine share one init).
- CLI: `--dev-listen <port>` opts in; `--dev-listen-all` flips the bind to `0.0.0.0` with a loud `Logger::Warn`. Both flags log a "stripped by shipped build" warning when seen in a shipped binary and parse no-op so they cannot eat a CLI slot.
- `Pump()` runs on the main thread per frame; PR-A has nothing to drain through it. PR-B will SPSC the not-thread-safe ops (Lua eval, scene reload, asset writes) through it.

Out of scope (PR-B + later):
- Real ops (`eval_lua` / `reload_scene` / `push_script` / `push_asset`)
- JSON dep (PR-A wire stays binary; PR-B can pull `nlohmann-json` if metadata needs it)
- Editor-side client (Devices panel from Stage 8)

## Test plan

- [x] `cmake --preset editor-debug -DOCTARINE_ENABLE_TESTS=ON && cmake --build build/editor-debug --target OctarineDevListenServerTest` — clean compile on Windows. ws2_32 links.
- [x] `ctest -R DevListenServerTest` — green locally (0.01s). Asserts: Start on ephemeral port, Hello banner roundtrip, Ping echoes nonce, Stop joins thread cleanly, Stop+Start cycle clean.
- [x] Editor-debug + ship-release symbol surface: shipped build does not link `ws2_32` (CMake guard) and does not compile the .cpp (SRC_FILES guard).
- [ ] Manual: launch editor with `--dev-listen 9001`, dial in with `python -c "import socket,struct; s=socket.create_connection(('127.0.0.1',9001)); s.send(struct.pack('<II',4,1)); print(s.recv(256))"`, observe banner.
- [ ] CI: cross-platform legs prove POSIX-socket path compiles on Linux + macOS and the test runs on each.