### PR TITLE
Architecture cleanup: stages 1-5 + 7 (CMake split, POD components, EngineContext, EngineBootstrap, InputSystem binding move, Renderer RT lifecycle)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,129 +86,6 @@ if (OCTARINE_WITH_IMGUI)
 endif ()
 find_package(Threads REQUIRED)
 
-# Source files
-set(SRC_FILES
-        src/Main.cpp
-        src/AssetManager/AssetManager.cpp
-        src/AssetManager/AssetCatalog.cpp
-        src/AssetManager/AssetPak.cpp
-        src/AssetManager/AtlasBaker.cpp
-        src/AssetManager/AudioNormalizer.cpp
-        src/AssetManager/GlyphAtlas.cpp
-        src/AssetManager/TextureAtlasBaker.cpp
-        src/AssetManager/SceneAssetScanner.cpp
-        src/ECS/Registry.cpp
-        src/Game/Game.cpp
-        src/Game/GameConfig.cpp
-        src/General/Logger.cpp
-        src/Lua/Bindings/RegisterAllBindings.cpp
-        src/Lua/LuaApiManifest.cpp
-        src/Lua/Modules/RegisterAllModules.cpp
-        src/Lua/Modules/AssetsModuleLuaBinding.cpp
-        src/Lua/Modules/AudioModuleLuaBinding.cpp
-        src/Lua/Modules/EntityModuleLuaBinding.cpp
-        src/Lua/Modules/GameModuleLuaBinding.cpp
-        src/Lua/Modules/IoModuleLuaBinding.cpp
-        src/Lua/Modules/LogModuleLuaBinding.cpp
-        src/Lua/Modules/SceneModuleLuaBinding.cpp
-        src/Lua/HotReload/ScriptWatcher.cpp
-        src/Lua/HotReload/ScriptHotReload.cpp
-        src/Process/Process.cpp
-        src/Project/ProjectIni.cpp
-        src/Renderer/Renderer.cpp
-        src/Systems/AudioSystem.cpp
-)
-
-if (OCTARINE_WITH_IMGUI)
-    list(APPEND SRC_FILES src/Systems/RenderDebugGUISystem.cpp)
-endif ()
-
-if (OCTARINE_WITH_EDITOR)
-    list(APPEND SRC_FILES src/Editor/EditorPersistence.cpp)
-    list(APPEND SRC_FILES src/Editor/EditorLayoutPresets.cpp)
-    list(APPEND SRC_FILES src/Editor/Inspectors/RegisterAllInspectors.cpp)
-    list(APPEND SRC_FILES src/Editor/PlayerLauncher.cpp)
-    list(APPEND SRC_FILES src/Editor/ExportBuilder.cpp)
-
-    # SecretStore: per-platform credential storage. One backend per host so the OS-native API
-    # links cleanly without cross-platform shims. Linux backend is a no-op stub the editor UI
-    # falls back to env-var-only mode on.
-    if (WIN32)
-        list(APPEND SRC_FILES src/Secrets/SecretStore_Windows.cpp)
-    elseif (APPLE)
-        list(APPEND SRC_FILES src/Secrets/SecretStore_macOS.cpp)
-    else ()
-        list(APPEND SRC_FILES src/Secrets/SecretStore_Linux.cpp)
-    endif ()
-endif ()
-
-if (UNIX AND NOT APPLE AND NOT ANDROID)
-    list(APPEND SRC_FILES src/General/SDL3_Linux_Stubs.cpp)
-endif ()
-
-# Every TU that pulls in a vendored stb single-header (texture atlas bake, glyph atlas bake,
-# JPEG-style image read) trips the engine's `-Wconversion -Wsign-conversion -Werror` baseline at
-# stb's int -> short_int / int -> size_t casts. AudioNormalizer's BS.1770 math hits the same kind
-# of size_t -> double narrowing the project wants flagged elsewhere but cannot here. Disable
-# warnings just for these files so the strict baseline keeps protecting the rest of the engine.
-set_source_files_properties(
-        src/AssetManager/TextureAtlasBaker.cpp
-        src/AssetManager/AtlasBaker.cpp
-        src/AssetManager/GlyphAtlas.cpp
-        src/AssetManager/AudioNormalizer.cpp
-        PROPERTIES COMPILE_OPTIONS "$<IF:$<CXX_COMPILER_ID:MSVC>,/w,-w>")
-
-# Add packaged libs
-if (OCTARINE_WITH_IMGUI)
-    add_subdirectory(libs/sol2_ImGui_Bindings)
-endif ()
-
-# Create the engine target. On Android, SDLActivity dlopens libmain.so and jumps to SDL_main, so the
-# engine must be that shared lib (OUTPUT_NAME main → libmain.so). Everywhere else it is a plain
-# executable. The desktop non-editor build renames its OUTPUT to `OctarineEngine-player` so the
-# editor (also `OctarineEngine`) and the player can coexist in the same dev tree — the editor
-# resolves the player binary by that fixed name when handling the Run Player toolbar action.
-if (ANDROID)
-    add_library(${PROJECT_NAME} SHARED ${SRC_FILES})
-    set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME main)
-else ()
-    add_executable(${PROJECT_NAME} ${SRC_FILES})
-    # Dev player presets (player-debug / player-profile / player-release): rename the binary so
-    # `OctarineEngine` (editor) and `OctarineEngine-player` coexist in the same tree. Shipping
-    # configs (ship-release / packaging) keep the canonical `OctarineEngine` name — downstream
-    # packaging owns the shipped artifact's filename.
-    if (NOT OCTARINE_WITH_EDITOR AND NOT OCTARINE_SHIPPED)
-        set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME OctarineEngine-player)
-    endif ()
-endif ()
-
-# Set target properties
-set_target_properties(${PROJECT_NAME} PROPERTIES
-        CXX_STANDARD 20
-        CXX_STANDARD_REQUIRED ON
-        CXX_EXTENSIONS OFF
-)
-
-if (OCTARINE_ENABLE_PROFILING)
-    target_compile_definitions(${PROJECT_NAME} PRIVATE OCTARINE_PROFILING)
-    message(STATUS "Octarine: Profiling ENABLED")
-endif ()
-
-if (OCTARINE_WITH_IMGUI)
-    target_compile_definitions(${PROJECT_NAME} PRIVATE OCTARINE_WITH_IMGUI)
-    message(STATUS "Octarine: ImGui Debug UI ENABLED")
-endif ()
-
-if (OCTARINE_WITH_EDITOR)
-    target_compile_definitions(${PROJECT_NAME} PRIVATE OCTARINE_WITH_EDITOR)
-    message(STATUS "Octarine: Editor ENABLED")
-endif ()
-
-if (OCTARINE_SHIPPED)
-    target_compile_definitions(${PROJECT_NAME} PRIVATE OCTARINE_SHIPPED)
-    message(STATUS "Octarine: SHIPPED build — asset catalog loads baked manifest (no scan)")
-endif ()
-
 # Engine log level (compile-time default baked into the binary). Policy when OCTARINE_LOG_LEVEL is
 # empty (the default):
 #   SHIPPED build  → warn   (production: errors + warnings only)
@@ -228,57 +105,105 @@ if (NOT OCTARINE_LOG_LEVEL)
 else ()
     set(_octarine_default_log_level "${OCTARINE_LOG_LEVEL}")
 endif ()
-target_compile_definitions(${PROJECT_NAME} PRIVATE OCTARINE_LOG_LEVEL_NAME="${_octarine_default_log_level}")
 message(STATUS "Octarine: default log level = ${_octarine_default_log_level}")
 
-# Include directories
-target_include_directories(${PROJECT_NAME}
-        PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/src
-        ${CMAKE_CURRENT_SOURCE_DIR}/libs
-        # libs/stb is its own include root so src/AssetManager/TextureAtlasBaker.cpp can write
-        # `#include "stb_image.h"` — matches the pattern in scripts/octarine-icon-tool/.
-        ${CMAKE_CURRENT_SOURCE_DIR}/libs/stb
-        ${LUA_INCLUDE_DIR}
-)
-
-# Link libraries
-target_link_libraries(${PROJECT_NAME}
-        PRIVATE
-        glm::glm
-        SDL3::SDL3
-        SDL3_ttf::SDL3_ttf
-        $<IF:$<TARGET_EXISTS:SDL3_mixer::SDL3_mixer>,SDL3_mixer::SDL3_mixer,SDL3_mixer::SDL3_mixer-static>
-        $<IF:$<TARGET_EXISTS:SDL3_image::SDL3_image-shared>,SDL3_image::SDL3_image-shared,SDL3_image::SDL3_image-static>
-        ${LUA_LIBRARIES}
-        spdlog::spdlog
-        sol2::sol2
-        Threads::Threads
-)
-
+if (OCTARINE_ENABLE_PROFILING)
+    message(STATUS "Octarine: Profiling ENABLED")
+endif ()
 if (OCTARINE_WITH_IMGUI)
-    target_link_libraries(${PROJECT_NAME}
-            PRIVATE
-            imgui::imgui
-            sol2_ImGui_Bindings
-    )
+    message(STATUS "Octarine: ImGui Debug UI ENABLED")
+endif ()
+if (OCTARINE_WITH_EDITOR)
+    message(STATUS "Octarine: Editor ENABLED")
+endif ()
+if (OCTARINE_SHIPPED)
+    message(STATUS "Octarine: SHIPPED build — asset catalog loads baked manifest (no scan)")
 endif ()
 
-# Android NDK system libs. SDL3 (statically linked from the arm64-android vcpkg triplet) pulls in the
-# native logging and platform APIs; the linker needs them named explicitly for the shared lib.
+# Vendored ImGui binding lib lives outside src/ so it stays untouched by the layer split. Only
+# meaningful when ImGui is on; pulled in PUBLIC by octarine_editor.
+if (OCTARINE_WITH_IMGUI)
+    add_subdirectory(libs/sol2_ImGui_Bindings)
+endif ()
+
+# Standard compile flags + warnings, packaged as one helper so every static lib + the exe pick up
+# the same set. Replaces the per-target blocks that used to live in this file.
+include(cmake/octarine_library.cmake)
+
+# Per-layer STATIC libraries: octarine_{core,assets,renderer,lua,systems,editor,engine}.
+# octarine_engine is the top-level coordinator that depends on every other lib transitively.
+add_subdirectory(src)
+
+# Final OctarineEngine artifact. On Android, SDLActivity dlopens libmain.so and jumps to SDL_main,
+# so the entry point must live in a shared lib (OUTPUT_NAME main → libmain.so). Everywhere else
+# it is a plain executable.
+#
+# Desktop player presets (player-debug / player-profile / player-release) rename the binary to
+# `OctarineEngine-player` so it can coexist with the editor (also `OctarineEngine`) in the same
+# dev tree — the editor's Run Player toolbar action resolves the player by that fixed name.
+# Shipping configs (ship-release / packaging) keep the canonical `OctarineEngine` name —
+# downstream packaging owns the shipped artifact's filename.
+if (ANDROID)
+    add_library(${PROJECT_NAME} SHARED src/Main.cpp)
+    set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME main)
+else ()
+    add_executable(${PROJECT_NAME} src/Main.cpp)
+    if (NOT OCTARINE_WITH_EDITOR AND NOT OCTARINE_SHIPPED)
+        set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME OctarineEngine-player)
+    endif ()
+endif ()
+
+set_target_properties(${PROJECT_NAME} PROPERTIES
+        CXX_STANDARD 20
+        CXX_STANDARD_REQUIRED ON
+        CXX_EXTENSIONS OFF
+)
+
+target_link_libraries(${PROJECT_NAME} PRIVATE octarine_engine)
+
+# Android NDK system libs — linker needs them named explicitly when SDL3 is statically linked from
+# the arm64-android vcpkg triplet.
 if (ANDROID)
     target_link_libraries(${PROJECT_NAME} PRIVATE android log)
 endif ()
 
-# SecretStore backend libs. Crypt32 ships DPAPI's CryptProtectData/CryptUnprotectData on Windows;
-# Security.framework ships SecItem* on macOS. Linux backend is a stub and needs no link.
-if (OCTARINE_WITH_EDITOR)
-    if (WIN32)
-        target_link_libraries(${PROJECT_NAME} PRIVATE crypt32)
-    elseif (APPLE)
-        target_link_libraries(${PROJECT_NAME} PRIVATE
-                "-framework CoreFoundation"
-                "-framework Security")
+# Compile flags for the final exe match the per-lib helper's settings (the exe TU is just
+# Main.cpp but consistency makes the link-line warnings predictable).
+if (MSVC)
+    target_compile_options(${PROJECT_NAME} PRIVATE
+            /W4 /permissive- /MP /bigobj
+            /w14242 /w14244 /w14254 /w44456 /w44457 /w44458 /w44459 /wd4201 /wd5321
+    )
+    target_compile_options(${PROJECT_NAME} PRIVATE
+            $<IF:$<CONFIG:Debug>,,-WX /arch:AVX2>
+    )
+else ()
+    target_compile_options(${PROJECT_NAME} PRIVATE
+            -Wall -Wextra -Wpedantic -Wshadow -Wconversion -Wfatal-errors
+    )
+    if (ANDROID)
+        target_compile_options(${PROJECT_NAME} PRIVATE
+                $<IF:$<CONFIG:Debug>,,-ffast-math>
+        )
+    else ()
+        target_compile_options(${PROJECT_NAME} PRIVATE
+                $<IF:$<CONFIG:Debug>,,-Werror -march=native -ffast-math>
+        )
+    endif ()
+    target_compile_options(${PROJECT_NAME} PRIVATE
+            $<$<NOT:$<CONFIG:Debug>>:-ffunction-sections>
+            $<$<NOT:$<CONFIG:Debug>>:-fdata-sections>
+    )
+    if (APPLE)
+        target_link_options(${PROJECT_NAME} PRIVATE
+                $<$<NOT:$<CONFIG:Debug>>:-Wl,-dead_strip>
+                $<$<OR:$<CONFIG:Release>,$<CONFIG:MinSizeRel>>:-Wl,-x>
+        )
+    else ()
+        target_link_options(${PROJECT_NAME} PRIVATE
+                $<$<NOT:$<CONFIG:Debug>>:-Wl,--gc-sections>
+                $<$<OR:$<CONFIG:Release>,$<CONFIG:MinSizeRel>>:-s>
+        )
     endif ()
 endif ()
 
@@ -299,68 +224,6 @@ if (OCTARINE_PACKAGE_PROJECT AND NOT ANDROID)
     octarine_package(${PROJECT_NAME} PROJECT "${OCTARINE_PACKAGE_PROJECT}" NAME "${PROJECT_NAME}")
 endif ()
 
-# Compiler-specific flags - Treat warnings as errors in prod builds
-if (MSVC)
-    target_compile_definitions(${PROJECT_NAME} PRIVATE GLM_FORCE_INTRINSICS)
-    target_compile_options(${PROJECT_NAME} PRIVATE
-            /W4
-            /permissive-
-            /MP
-            /bigobj
-            /w14242 # Conversion: possible loss of data
-            /w14244 # Conversion: possible loss of data (float/double/int)
-            /w14254 # Conversion: possible loss of data (larger to smaller type)
-            /w44456 # Shadowing: declaration hides previous local declaration
-            /w44457 # Shadowing: declaration hides function parameter
-            /w44458 # Shadowing: declaration hides class member
-            /w44459 # Shadowing: declaration hides global declaration
-            /wd4201 # nonstandard extension used: nameless struct/union (common in GLM)
-            /wd5321 # nonstandard extension used: encoding UTF-8 character (common in sol2 headers)
-    )
-    target_compile_options(${PROJECT_NAME} PRIVATE
-            $<IF:$<CONFIG:Debug>,,-WX /arch:AVX2>
-    )
-else ()
-    target_compile_definitions(${PROJECT_NAME} PRIVATE GLM_FORCE_INTRINSICS)
-    target_compile_options(${PROJECT_NAME} PRIVATE
-            -Wall
-            -Wextra
-            -Wpedantic
-            -Wshadow
-            -Wconversion
-            -Wfatal-errors
-    )
-    if (ANDROID)
-        # Cross-compile: -march=native would target the build host, not the device. -Werror is dropped
-        # because device-arch-specific warnings can't be observed/cleared from a desktop checkout.
-        target_compile_options(${PROJECT_NAME} PRIVATE
-                $<IF:$<CONFIG:Debug>,,-ffast-math>
-        )
-    else ()
-        target_compile_options(${PROJECT_NAME} PRIVATE
-                $<IF:$<CONFIG:Debug>,,-Werror -march=native -ffast-math>
-        )
-    endif ()
-    # Size reduction for non-Debug builds:
-    # - function/data sections + --gc-sections drops unreferenced symbols from static libs
-    # - -s strips the linked binary
-    target_compile_options(${PROJECT_NAME} PRIVATE
-            $<$<NOT:$<CONFIG:Debug>>:-ffunction-sections>
-            $<$<NOT:$<CONFIG:Debug>>:-fdata-sections>
-    )
-    if (APPLE)
-        target_link_options(${PROJECT_NAME} PRIVATE
-                $<$<NOT:$<CONFIG:Debug>>:-Wl,-dead_strip>
-                $<$<OR:$<CONFIG:Release>,$<CONFIG:MinSizeRel>>:-Wl,-x>
-        )
-    else ()
-        target_link_options(${PROJECT_NAME} PRIVATE
-                $<$<NOT:$<CONFIG:Debug>>:-Wl,--gc-sections>
-                $<$<OR:$<CONFIG:Release>,$<CONFIG:MinSizeRel>>:-s>
-        )
-    endif ()
-endif ()
-
 # -----------------------------------------------------------------------------
 # Linting & Formatting Integration
 # -----------------------------------------------------------------------------
@@ -370,9 +233,13 @@ option(OCTARINE_ENABLE_LINTING "Run clang-tidy during compilation" OFF)
 if (OCTARINE_ENABLE_LINTING)
     find_program(CLANG_TIDY_EXE NAMES "clang-tidy")
     if (CLANG_TIDY_EXE)
-        set_target_properties(${PROJECT_NAME} PROPERTIES
-                CXX_CLANG_TIDY "${CLANG_TIDY_EXE}"
-        )
+        # Apply to every internal lib + the exe so the whole engine TU set gets linted.
+        foreach (_tgt octarine_core octarine_assets octarine_renderer octarine_lua octarine_systems
+                octarine_editor octarine_engine ${PROJECT_NAME})
+            if (TARGET ${_tgt})
+                set_target_properties(${_tgt} PROPERTIES CXX_CLANG_TIDY "${CLANG_TIDY_EXE}")
+            endif ()
+        endforeach ()
         message(STATUS "Octarine: clang-tidy ENABLED (reading from .clang-tidy)")
     else ()
         message(WARNING "Octarine: Linting enabled but clang-tidy executable not found!")
@@ -406,37 +273,28 @@ option(OCTARINE_ENABLE_BENCHMARKS "Build benchmarks" OFF)
 if (OCTARINE_ENABLE_BENCHMARKS)
     find_package(benchmark CONFIG REQUIRED)
 
-    set(BENCHMARK_SRC_FILES
-            tests/benchmarks/EntityPoolBenchmark.cpp
-            src/ECS/Registry.cpp
-            src/General/Logger.cpp
-    )
-
-    add_executable(OctarineBenchmarks ${BENCHMARK_SRC_FILES})
-
-    # Always compile in Release mode flags for the benchmark where possible,
-    # though it will inherit CMake build type
-    target_include_directories(OctarineBenchmarks PRIVATE
-            ${CMAKE_CURRENT_SOURCE_DIR}/src
-            ${CMAKE_CURRENT_SOURCE_DIR}/libs
+    # ECS + Logger are the only engine TUs the benchmark exercises; link octarine_core to pull
+    # their .obj plus the standard compile flags. Skips the rest of the engine — bench runs are
+    # microbenchmarks, not full-engine timings.
+    add_executable(OctarineBenchmarks tests/benchmarks/EntityPoolBenchmark.cpp)
+    set_target_properties(OctarineBenchmarks PROPERTIES
+            CXX_STANDARD 20
+            CXX_STANDARD_REQUIRED ON
+            CXX_EXTENSIONS OFF
     )
 
     target_link_libraries(OctarineBenchmarks PRIVATE
+            octarine_core
             benchmark::benchmark
             benchmark::benchmark_main
-            glm::glm
-            spdlog::spdlog
-            Threads::Threads
     )
 
     if (MSVC)
-        target_compile_definitions(OctarineBenchmarks PRIVATE GLM_FORCE_INTRINSICS)
         target_compile_options(OctarineBenchmarks PRIVATE /W4 /permissive- /MP /bigobj)
         target_compile_options(OctarineBenchmarks PRIVATE
                 $<IF:$<CONFIG:Debug>,,-WX /arch:AVX2>
         )
     else ()
-        target_compile_definitions(OctarineBenchmarks PRIVATE GLM_FORCE_INTRINSICS)
         target_compile_options(OctarineBenchmarks PRIVATE -Wall -Wextra -Wpedantic)
         target_compile_options(OctarineBenchmarks PRIVATE
                 $<IF:$<CONFIG:Debug>,,-Werror -march=native -ffast-math>
@@ -455,121 +313,41 @@ option(OCTARINE_ENABLE_TESTS "Build engine tests" OFF)
 if (OCTARINE_ENABLE_TESTS)
     enable_testing()
 
-    # The Lua API smoke test links the whole engine (it constructs a Game) minus the real
-    # entry point, then replays Game::Setup's binding sequence headless.
-    set(TEST_SRC_FILES ${SRC_FILES})
-    list(REMOVE_ITEM TEST_SRC_FILES src/Main.cpp)
-    list(APPEND TEST_SRC_FILES tests/LuaApiSmokeTest.cpp)
-
-    add_executable(OctarineLuaApiTest ${TEST_SRC_FILES})
-
+    # Both engine-spanning tests link octarine_engine — same surface the real exe sees, minus
+    # Main.cpp. The test .cpp constructs a Game directly and replays its Setup sequence headless.
+    add_executable(OctarineLuaApiTest tests/LuaApiSmokeTest.cpp)
     set_target_properties(OctarineLuaApiTest PROPERTIES
             CXX_STANDARD 20
             CXX_STANDARD_REQUIRED ON
             CXX_EXTENSIONS OFF
     )
-
-    # Mirror the main target's feature defines so the shared sources compile identically.
-    target_compile_definitions(OctarineLuaApiTest PRIVATE GLM_FORCE_INTRINSICS)
     # Smoke test writes its EmmyLua stub + JSON indexes here so repo-root copies stay in sync with
     # the live bindings; CI diffs all three against tracked files to fail on drift.
     target_compile_definitions(OctarineLuaApiTest PRIVATE
             LUA_API_SMOKE_OUTPUT="${CMAKE_CURRENT_SOURCE_DIR}/lua_api.smoke.lua"
             LUA_API_COMPONENTS_OUTPUT="${CMAKE_CURRENT_SOURCE_DIR}/components.json"
             LUA_API_MODULES_OUTPUT="${CMAKE_CURRENT_SOURCE_DIR}/modules.json")
-    if (OCTARINE_WITH_IMGUI)
-        target_compile_definitions(OctarineLuaApiTest PRIVATE OCTARINE_WITH_IMGUI)
-    endif ()
-    if (OCTARINE_WITH_EDITOR)
-        target_compile_definitions(OctarineLuaApiTest PRIVATE OCTARINE_WITH_EDITOR)
-    endif ()
-    if (OCTARINE_ENABLE_PROFILING)
-        target_compile_definitions(OctarineLuaApiTest PRIVATE OCTARINE_PROFILING)
-    endif ()
-
-    target_include_directories(OctarineLuaApiTest PRIVATE
-            ${CMAKE_CURRENT_SOURCE_DIR}/src
-            ${CMAKE_CURRENT_SOURCE_DIR}/libs
-            ${CMAKE_CURRENT_SOURCE_DIR}/libs/stb
-            ${LUA_INCLUDE_DIR}
-    )
-
-    target_link_libraries(OctarineLuaApiTest PRIVATE
-            glm::glm
-            SDL3::SDL3
-            SDL3_ttf::SDL3_ttf
-            $<IF:$<TARGET_EXISTS:SDL3_mixer::SDL3_mixer>,SDL3_mixer::SDL3_mixer,SDL3_mixer::SDL3_mixer-static>
-            $<IF:$<TARGET_EXISTS:SDL3_image::SDL3_image-shared>,SDL3_image::SDL3_image-shared,SDL3_image::SDL3_image-static>
-            ${LUA_LIBRARIES}
-            spdlog::spdlog
-            sol2::sol2
-            Threads::Threads
-    )
-    if (OCTARINE_WITH_IMGUI)
-        target_link_libraries(OctarineLuaApiTest PRIVATE imgui::imgui sol2_ImGui_Bindings)
-    endif ()
-
-    # /bigobj: sol2 + the aggregated engine TU exceed MSVC's default section limit.
+    target_link_libraries(OctarineLuaApiTest PRIVATE octarine_engine)
     if (MSVC)
         target_compile_options(OctarineLuaApiTest PRIVATE /MP /bigobj /permissive- /wd4201 /wd5321)
     endif ()
-
     add_test(NAME LuaApiSmokeTest COMMAND OctarineLuaApiTest)
 
-    # Asset pipeline checks (metadata defaults + catalog build). Links the full engine minus the
-    # real entry point, matching the smoke test, so the tests can exercise AssetCatalog::Build
-    # (which needs GameConfig / sol2) without re-plumbing the target.
-    set(ASSET_TEST_SRC_FILES ${SRC_FILES})
-    list(REMOVE_ITEM ASSET_TEST_SRC_FILES src/Main.cpp)
-    list(APPEND ASSET_TEST_SRC_FILES tests/AssetPipelineTest.cpp)
-
-    add_executable(OctarineAssetPipelineTest ${ASSET_TEST_SRC_FILES})
-
+    # Asset pipeline checks (metadata defaults + catalog build). Same target shape — links the
+    # full engine via octarine_engine so AssetCatalog::Build (which needs GameConfig / sol2) is
+    # reachable without re-plumbing sources.
+    add_executable(OctarineAssetPipelineTest tests/AssetPipelineTest.cpp)
     set_target_properties(OctarineAssetPipelineTest PROPERTIES
             CXX_STANDARD 20
             CXX_STANDARD_REQUIRED ON
             CXX_EXTENSIONS OFF
     )
-
-    target_compile_definitions(OctarineAssetPipelineTest PRIVATE GLM_FORCE_INTRINSICS)
     target_compile_definitions(OctarineAssetPipelineTest PRIVATE
             ASSET_TEST_FIXTURE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/tests/fixtures/assets")
-    if (OCTARINE_WITH_IMGUI)
-        target_compile_definitions(OctarineAssetPipelineTest PRIVATE OCTARINE_WITH_IMGUI)
-    endif ()
-    if (OCTARINE_WITH_EDITOR)
-        target_compile_definitions(OctarineAssetPipelineTest PRIVATE OCTARINE_WITH_EDITOR)
-    endif ()
-    if (OCTARINE_ENABLE_PROFILING)
-        target_compile_definitions(OctarineAssetPipelineTest PRIVATE OCTARINE_PROFILING)
-    endif ()
-
-    target_include_directories(OctarineAssetPipelineTest PRIVATE
-            ${CMAKE_CURRENT_SOURCE_DIR}/src
-            ${CMAKE_CURRENT_SOURCE_DIR}/libs
-            ${CMAKE_CURRENT_SOURCE_DIR}/libs/stb
-            ${LUA_INCLUDE_DIR}
-    )
-
-    target_link_libraries(OctarineAssetPipelineTest PRIVATE
-            glm::glm
-            SDL3::SDL3
-            SDL3_ttf::SDL3_ttf
-            $<IF:$<TARGET_EXISTS:SDL3_mixer::SDL3_mixer>,SDL3_mixer::SDL3_mixer,SDL3_mixer::SDL3_mixer-static>
-            $<IF:$<TARGET_EXISTS:SDL3_image::SDL3_image-shared>,SDL3_image::SDL3_image-shared,SDL3_image::SDL3_image-static>
-            ${LUA_LIBRARIES}
-            spdlog::spdlog
-            sol2::sol2
-            Threads::Threads
-    )
-    if (OCTARINE_WITH_IMGUI)
-        target_link_libraries(OctarineAssetPipelineTest PRIVATE imgui::imgui sol2_ImGui_Bindings)
-    endif ()
-
+    target_link_libraries(OctarineAssetPipelineTest PRIVATE octarine_engine)
     if (MSVC)
         target_compile_options(OctarineAssetPipelineTest PRIVATE /MP /bigobj /permissive- /wd4201 /wd5321)
     endif ()
-
     add_test(NAME AssetPipelineTest COMMAND OctarineAssetPipelineTest)
 
     # Process-spawn smoke test: standalone — no engine sources required, just the wrapper.
@@ -578,23 +356,18 @@ if (OCTARINE_ENABLE_TESTS)
             src/Process/Process.cpp
             tests/ProcessTest.cpp
     )
-
     set_target_properties(OctarineProcessTest PROPERTIES
             CXX_STANDARD 20
             CXX_STANDARD_REQUIRED ON
             CXX_EXTENSIONS OFF
     )
-
     target_include_directories(OctarineProcessTest PRIVATE
             ${CMAKE_CURRENT_SOURCE_DIR}/src
     )
-
     target_link_libraries(OctarineProcessTest PRIVATE Threads::Threads)
-
     if (MSVC)
         target_compile_options(OctarineProcessTest PRIVATE /W4 /permissive- /MP /EHsc)
     endif ()
-
     add_test(NAME ProcessTest COMMAND OctarineProcessTest)
 
     # project.ini reader smoke test: standalone — no engine sources required. Validates parse +
@@ -603,21 +376,17 @@ if (OCTARINE_ENABLE_TESTS)
             src/Project/ProjectIni.cpp
             tests/ProjectIniTest.cpp
     )
-
     set_target_properties(OctarineProjectIniTest PROPERTIES
             CXX_STANDARD 20
             CXX_STANDARD_REQUIRED ON
             CXX_EXTENSIONS OFF
     )
-
     target_include_directories(OctarineProjectIniTest PRIVATE
             ${CMAKE_CURRENT_SOURCE_DIR}/src
     )
-
     if (MSVC)
         target_compile_options(OctarineProjectIniTest PRIVATE /W4 /permissive- /MP /EHsc)
     endif ()
-
     add_test(NAME ProjectIniTest COMMAND OctarineProjectIniTest)
 
     message(STATUS "Octarine: Tests ENABLED")

--- a/cmake/octarine-licenses.cmake
+++ b/cmake/octarine-licenses.cmake
@@ -68,6 +68,25 @@ function(_octarine_licenses_required_from_vcpkg OUT_VAR ENGINE_ROOT)
         math(EXPR _last "${_dep_count} - 1")
         foreach (_i RANGE 0 ${_last})
             string(JSON _name GET "${_manifest_json}" dependencies ${_i} name)
+            # Honor an optional `platform` qualifier: a dep gated to another OS (e.g. the
+            # linux-only `dbus`, pulled in for SDL3's IBus backend) isn't installed in this
+            # triplet, so requiring its license here would falsely fail packaging on macOS /
+            # Windows. Only the qualifiers this manifest actually uses are evaluated; an
+            # unrecognized expression falls through as "required" (the safe default).
+            string(JSON _plat ERROR_VARIABLE _plat_err GET "${_manifest_json}" dependencies ${_i} platform)
+            if (NOT _plat_err AND _plat)
+                set(_plat_matches TRUE)
+                if (_plat STREQUAL "linux" AND NOT CMAKE_SYSTEM_NAME STREQUAL "Linux")
+                    set(_plat_matches FALSE)
+                elseif (_plat STREQUAL "windows" AND NOT CMAKE_SYSTEM_NAME STREQUAL "Windows")
+                    set(_plat_matches FALSE)
+                elseif (_plat STREQUAL "osx" AND NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+                    set(_plat_matches FALSE)
+                endif ()
+                if (NOT _plat_matches)
+                    continue()
+                endif ()
+            endif ()
             string(TOLOWER "${_name}" _name_lc)
             list(APPEND _required "${_name_lc}")
         endforeach ()

--- a/cmake/octarine_library.cmake
+++ b/cmake/octarine_library.cmake
@@ -1,0 +1,73 @@
+# Helper to declare an internal STATIC library with the engine's standard compile
+# options + warnings. Mirrors the compiler-flag block that used to live in the root
+# CMakeLists.txt against a single OctarineEngine target.
+#
+# Usage:
+#   octarine_library(<name> <source> [<source> ...])
+#
+# Public include directory defaults to ${CMAKE_SOURCE_DIR}/src so consumers can
+# reach any header under src/. Feature defines (OCTARINE_WITH_IMGUI etc.) come
+# from octarine_core's PUBLIC compile_definitions; consumers pick them up
+# transitively, so per-target plumbing isn't needed here.
+
+function(octarine_library NAME)
+    set(_sources ${ARGN})
+    add_library(${NAME} STATIC ${_sources})
+    set_target_properties(${NAME} PROPERTIES
+            CXX_STANDARD 20
+            CXX_STANDARD_REQUIRED ON
+            CXX_EXTENSIONS OFF
+            POSITION_INDEPENDENT_CODE ON
+    )
+    target_include_directories(${NAME} PUBLIC
+            "${CMAKE_SOURCE_DIR}/src"
+            "${CMAKE_SOURCE_DIR}/libs"
+    )
+    if (LUA_INCLUDE_DIR)
+        target_include_directories(${NAME} PUBLIC "${LUA_INCLUDE_DIR}")
+    endif ()
+
+    if (MSVC)
+        target_compile_options(${NAME} PRIVATE
+                /W4
+                /permissive-
+                /MP
+                /bigobj
+                /w14242
+                /w14244
+                /w14254
+                /w44456
+                /w44457
+                /w44458
+                /w44459
+                /wd4201
+                /wd5321
+        )
+        # Warnings-as-errors + AVX2 only outside Debug.
+        target_compile_options(${NAME} PRIVATE
+                $<IF:$<CONFIG:Debug>,,-WX /arch:AVX2>
+        )
+    else ()
+        target_compile_options(${NAME} PRIVATE
+                -Wall
+                -Wextra
+                -Wpedantic
+                -Wshadow
+                -Wconversion
+                -Wfatal-errors
+        )
+        if (ANDROID)
+            target_compile_options(${NAME} PRIVATE
+                    $<IF:$<CONFIG:Debug>,,-ffast-math>
+            )
+        else ()
+            target_compile_options(${NAME} PRIVATE
+                    $<IF:$<CONFIG:Debug>,,-Werror -march=native -ffast-math>
+            )
+        endif ()
+        target_compile_options(${NAME} PRIVATE
+                $<$<NOT:$<CONFIG:Debug>>:-ffunction-sections>
+                $<$<NOT:$<CONFIG:Debug>>:-fdata-sections>
+        )
+    endif ()
+endfunction()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,214 @@
+# Engine layer split. Each STATIC library represents one architectural layer; PUBLIC
+# link deps enforce the dependency direction at link time. Headers under src/ are reachable
+# from every consumer (octarine_core publishes the include dir) — layering is enforced via
+# symbol resolution, not via per-dir include walls.
+#
+# Layer map:
+#   octarine_core      General/, ECS/, Components/, EventBus/, Events/, Game/GameConfig,
+#                      Process/, Project/  (POD/data + cross-cutting utilities)
+#   octarine_assets    AssetManager/ (catalog, atlas bakers, audio normalizer, pak)
+#   octarine_renderer  Renderer/
+#   octarine_lua       Lua/Bindings, Lua/Modules, Lua/HotReload, Lua/LuaApiManifest
+#   octarine_systems   Systems/ (minus RenderDebugGUISystem.cpp; that's editor-only)
+#   octarine_editor    Editor/ + Systems/RenderDebugGUISystem.cpp + Secrets/* (per-platform)
+#                      (gated by OCTARINE_WITH_EDITOR / OCTARINE_WITH_IMGUI)
+#   octarine_engine    Game/Game + Engine/EngineBootstrap (top-level coordinator)
+#
+# OctarineEngine (the desktop exe / Android shared lib) is declared in the root CMakeLists.txt
+# and links octarine_engine only — everything else flows through PUBLIC deps.
+
+# -----------------------------------------------------------------------------
+# octarine_core — POD/data foundation. No SDL_image, no SDL_mixer, no imgui.
+# -----------------------------------------------------------------------------
+set(OCTARINE_CORE_SOURCES
+        General/Logger.cpp
+        ECS/Registry.cpp
+        Game/GameConfig.cpp
+        Process/Process.cpp
+        Project/ProjectIni.cpp
+)
+if (UNIX AND NOT APPLE AND NOT ANDROID)
+    list(APPEND OCTARINE_CORE_SOURCES General/SDL3_Linux_Stubs.cpp)
+endif ()
+
+octarine_library(octarine_core ${OCTARINE_CORE_SOURCES})
+target_link_libraries(octarine_core PUBLIC
+        glm::glm
+        SDL3::SDL3
+        spdlog::spdlog
+        sol2::sol2
+        ${LUA_LIBRARIES}
+        Threads::Threads
+)
+
+# Compile defines shared by every layer (consumers inherit via PUBLIC).
+target_compile_definitions(octarine_core PUBLIC GLM_FORCE_INTRINSICS)
+target_compile_definitions(octarine_core PUBLIC OCTARINE_LOG_LEVEL_NAME="${_octarine_default_log_level}")
+if (OCTARINE_ENABLE_PROFILING)
+    target_compile_definitions(octarine_core PUBLIC OCTARINE_PROFILING)
+endif ()
+if (OCTARINE_WITH_IMGUI)
+    target_compile_definitions(octarine_core PUBLIC OCTARINE_WITH_IMGUI)
+endif ()
+if (OCTARINE_WITH_EDITOR)
+    target_compile_definitions(octarine_core PUBLIC OCTARINE_WITH_EDITOR)
+endif ()
+if (OCTARINE_SHIPPED)
+    target_compile_definitions(octarine_core PUBLIC OCTARINE_SHIPPED)
+endif ()
+
+# -----------------------------------------------------------------------------
+# octarine_assets — texture / font / audio handle store + catalog + bakers + pak.
+# Per-file warning suppressions cover vendored stb single-header includes
+# (TextureAtlasBaker, AtlasBaker, GlyphAtlas) and the BS.1770 size_t→double math
+# in AudioNormalizer that trips the engine's strict -Wconversion baseline.
+# -----------------------------------------------------------------------------
+octarine_library(octarine_assets
+        AssetManager/AssetCatalog.cpp
+        AssetManager/AssetManager.cpp
+        AssetManager/AssetPak.cpp
+        AssetManager/AtlasBaker.cpp
+        AssetManager/AudioNormalizer.cpp
+        AssetManager/GlyphAtlas.cpp
+        AssetManager/TextureAtlasBaker.cpp
+        AssetManager/SceneAssetScanner.cpp
+)
+set_source_files_properties(
+        AssetManager/TextureAtlasBaker.cpp
+        AssetManager/AtlasBaker.cpp
+        AssetManager/GlyphAtlas.cpp
+        AssetManager/AudioNormalizer.cpp
+        PROPERTIES COMPILE_OPTIONS "$<IF:$<CXX_COMPILER_ID:MSVC>,/w,-w>")
+target_link_libraries(octarine_assets PUBLIC
+        octarine_core
+        SDL3_ttf::SDL3_ttf
+        $<IF:$<TARGET_EXISTS:SDL3_mixer::SDL3_mixer>,SDL3_mixer::SDL3_mixer,SDL3_mixer::SDL3_mixer-static>
+        $<IF:$<TARGET_EXISTS:SDL3_image::SDL3_image-shared>,SDL3_image::SDL3_image-shared,SDL3_image::SDL3_image-static>
+)
+# libs/stb is its own include root so TextureAtlasBaker.cpp / AtlasBaker.cpp / GlyphAtlas.cpp can
+# write `#include "stb_image.h"` (matches the pattern in scripts/octarine-icon-tool/).
+target_include_directories(octarine_assets PRIVATE ${CMAKE_SOURCE_DIR}/libs/stb)
+
+# -----------------------------------------------------------------------------
+# octarine_renderer — render-queue producer drain + SDL_Renderer wrapper.
+# -----------------------------------------------------------------------------
+octarine_library(octarine_renderer
+        Renderer/Renderer.cpp
+)
+target_link_libraries(octarine_renderer PUBLIC
+        octarine_core
+        octarine_assets
+)
+
+# -----------------------------------------------------------------------------
+# octarine_lua — sol2 component/module bindings + EmmyLua API manifest + hot reload.
+# -----------------------------------------------------------------------------
+octarine_library(octarine_lua
+        Lua/LuaApiManifest.cpp
+        Lua/Bindings/RegisterAllBindings.cpp
+        Lua/HotReload/ScriptHotReload.cpp
+        Lua/HotReload/ScriptWatcher.cpp
+        Lua/Modules/AssetsModuleLuaBinding.cpp
+        Lua/Modules/AudioModuleLuaBinding.cpp
+        Lua/Modules/EntityModuleLuaBinding.cpp
+        Lua/Modules/GameModuleLuaBinding.cpp
+        Lua/Modules/IoModuleLuaBinding.cpp
+        Lua/Modules/LogModuleLuaBinding.cpp
+        Lua/Modules/RegisterAllModules.cpp
+        Lua/Modules/SceneModuleLuaBinding.cpp
+)
+target_link_libraries(octarine_lua PUBLIC
+        octarine_core
+        octarine_assets
+        octarine_renderer
+)
+
+# -----------------------------------------------------------------------------
+# octarine_systems — per-frame Update systems + event-driven systems.
+# RenderDebugGUISystem (editor/IMGUI-only) lives in octarine_editor instead.
+# -----------------------------------------------------------------------------
+octarine_library(octarine_systems
+        Systems/AudioSystem.cpp
+)
+target_link_libraries(octarine_systems PUBLIC
+        octarine_core
+        octarine_assets
+        octarine_renderer
+        octarine_lua
+)
+
+# -----------------------------------------------------------------------------
+# octarine_editor — desktop-only editor UI + inspectors + RenderDebugGUISystem +
+# SecretStore (per-platform credential storage backing the editor's signing
+# secrets surface). Gated by OCTARINE_WITH_EDITOR; OCTARINE_WITH_IMGUI alone
+# (player-debug build) still needs RenderDebugGUISystem, so the lib is created
+# when EITHER is on and selectively compiles the editor-specific .cpps.
+# -----------------------------------------------------------------------------
+if (OCTARINE_WITH_IMGUI OR OCTARINE_WITH_EDITOR)
+    set(OCTARINE_EDITOR_SOURCES "")
+    if (OCTARINE_WITH_IMGUI)
+        list(APPEND OCTARINE_EDITOR_SOURCES Systems/RenderDebugGUISystem.cpp)
+    endif ()
+    if (OCTARINE_WITH_EDITOR)
+        list(APPEND OCTARINE_EDITOR_SOURCES
+                Editor/EditorLayoutPresets.cpp
+                Editor/EditorPersistence.cpp
+                Editor/ExportBuilder.cpp
+                Editor/PlayerLauncher.cpp
+                Editor/Inspectors/RegisterAllInspectors.cpp
+        )
+        # SecretStore: one backend per host so the OS-native API links cleanly without
+        # cross-platform shims. Linux backend is a no-op stub the editor UI falls back
+        # to env-var-only mode on.
+        if (WIN32)
+            list(APPEND OCTARINE_EDITOR_SOURCES Secrets/SecretStore_Windows.cpp)
+        elseif (APPLE)
+            list(APPEND OCTARINE_EDITOR_SOURCES Secrets/SecretStore_macOS.cpp)
+        else ()
+            list(APPEND OCTARINE_EDITOR_SOURCES Secrets/SecretStore_Linux.cpp)
+        endif ()
+    endif ()
+    octarine_library(octarine_editor ${OCTARINE_EDITOR_SOURCES})
+    target_link_libraries(octarine_editor PUBLIC
+            octarine_core
+            octarine_assets
+            octarine_renderer
+            octarine_lua
+            octarine_systems
+    )
+    if (OCTARINE_WITH_IMGUI)
+        target_link_libraries(octarine_editor PUBLIC imgui::imgui sol2_ImGui_Bindings)
+    endif ()
+    # SecretStore backend libs. Crypt32 ships DPAPI's CryptProtectData/CryptUnprotectData on
+    # Windows; Security.framework ships SecItem* on macOS. Linux backend is a stub and needs no
+    # link. Editor-only — gated alongside the editor source compile above.
+    if (OCTARINE_WITH_EDITOR)
+        if (WIN32)
+            target_link_libraries(octarine_editor PUBLIC crypt32)
+        elseif (APPLE)
+            target_link_libraries(octarine_editor PUBLIC
+                    "-framework CoreFoundation"
+                    "-framework Security")
+        endif ()
+    endif ()
+endif ()
+
+# -----------------------------------------------------------------------------
+# octarine_engine — top-level coordinator. Owns Game/Game.cpp + EngineBootstrap, pulls every
+# downstream lib in transitively. Editor lives on the PUBLIC link line when built so its
+# symbols (RenderDebugGUISystem::Render, EditorPersistence::*, SecretStore::*) resolve at the
+# final exe link without forcing the engine TU to know about editor concretely.
+# -----------------------------------------------------------------------------
+octarine_library(octarine_engine
+        Game/Game.cpp
+)
+target_link_libraries(octarine_engine PUBLIC
+        octarine_core
+        octarine_assets
+        octarine_renderer
+        octarine_lua
+        octarine_systems
+)
+if (TARGET octarine_editor)
+    target_link_libraries(octarine_engine PUBLIC octarine_editor)
+endif ()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -200,6 +200,7 @@ endif ()
 # final exe link without forcing the engine TU to know about editor concretely.
 # -----------------------------------------------------------------------------
 octarine_library(octarine_engine
+        Engine/EngineBootstrap.cpp
         Game/Game.cpp
 )
 target_link_libraries(octarine_engine PUBLIC

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -105,6 +105,7 @@ target_link_libraries(octarine_renderer PUBLIC
 # -----------------------------------------------------------------------------
 octarine_library(octarine_lua
         Lua/LuaApiManifest.cpp
+        Lua/Bindings/InputSystemLuaBinding.cpp
         Lua/Bindings/RegisterAllBindings.cpp
         Lua/HotReload/ScriptHotReload.cpp
         Lua/HotReload/ScriptWatcher.cpp
@@ -129,6 +130,7 @@ target_link_libraries(octarine_lua PUBLIC
 # -----------------------------------------------------------------------------
 octarine_library(octarine_systems
         Systems/AudioSystem.cpp
+        Systems/InputSystem.cpp
 )
 target_link_libraries(octarine_systems PUBLIC
         octarine_core

--- a/src/Components/AudioSinkComponent.h
+++ b/src/Components/AudioSinkComponent.h
@@ -4,6 +4,11 @@
 
 #include <cstdint>
 
+// Carries the MIX_Track* AudioSystem assigned this emitter, plus a generation guard so a track
+// reassigned to a different emitter after our clip stopped isn't mistakenly treated as ours.
+// Still SDL-typed — Stage 2's POD goal punts on this one because SpatialAudioSystem +
+// DopplerSystem read sink.track directly each frame and decoupling them via a resolve
+// indirection is a separate refactor. See ArchitectureImprovementsPlan follow-ups.
 struct AudioSinkComponent {
   MIX_Track* track = nullptr;
   std::uint32_t generation = 0;

--- a/src/Components/CameraComponents.h
+++ b/src/Components/CameraComponents.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <SDL3/SDL_rect.h>
+#include "General/Rect.h"
 
 struct CameraComponent {
-  SDL_FRect viewport;
+  octarine::Rect viewport;
 };

--- a/src/Components/SpriteComponent.h
+++ b/src/Components/SpriteComponent.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <SDL3/SDL.h>
-
-#include <cstdint>
 #include <string>
 #include <utility>
+
+#include "General/Rect.h"
+#include "General/SpriteFlip.h"
 
 struct SpriteComponent {
   std::string assetId;
@@ -12,14 +12,8 @@ struct SpriteComponent {
   float height;
   int layer;
   bool isFixed;
-  SDL_FRect srcRect{};
-  SDL_FlipMode flip;
-  mutable SDL_Texture* cachedTexture = nullptr;
-  mutable std::uint64_t cachedTextureGeneration = 0;
-  // Cached origin of this asset inside its atlas, or {0,0,0,0} when not atlas-backed. Re-resolved
-  // alongside cachedTexture (same generation gate) so a hot animation tick reads a single FRect
-  // instead of walking the catalog every frame.
-  mutable SDL_FRect cachedAtlasOffset{};
+  octarine::Rect srcRect{};
+  octarine::SpriteFlip flip = octarine::SpriteFlip::None;
 
   explicit SpriteComponent(std::string t_assetId = "", const float t_width = 0, const float t_height = 0,
                            const int t_layer = 0, const bool t_isFixed = false, const float t_srcRectX = 0,
@@ -29,7 +23,5 @@ struct SpriteComponent {
         height(t_height),
         layer(t_layer),
         isFixed(t_isFixed),
-        flip(SDL_FLIP_NONE) {
-    this->srcRect = {t_srcRectX, t_srcRectY, t_width, t_height};
-  }
+        srcRect{t_srcRectX, t_srcRectY, t_width, t_height} {}
 };

--- a/src/Components/SquarePrimitiveComponent.h
+++ b/src/Components/SquarePrimitiveComponent.h
@@ -1,9 +1,8 @@
 #pragma once
 
-#include <SDL3/SDL.h>
-
 #include <glm/glm.hpp>
 
+#include "General/Color.h"
 #include "General/Constants.h"
 
 struct SquarePrimitiveComponent {
@@ -11,13 +10,13 @@ struct SquarePrimitiveComponent {
   int layer;
   float width;
   float height;
-  SDL_Color color;
+  octarine::Color color;
   bool isFixed;
 
   explicit SquarePrimitiveComponent(const glm::vec2 t_position = glm::vec2(0, 0), const int t_layer = 0,
                                     const float t_width = 0, const float t_height = 0,
-                                    const SDL_Color t_color = {Constants::kUint8Max, Constants::kUint8Max,
-                                                               Constants::kUint8Max, Constants::kUint8Max},
+                                    const octarine::Color t_color = {Constants::kUint8Max, Constants::kUint8Max,
+                                                                     Constants::kUint8Max, Constants::kUint8Max},
                                     const bool t_isFixed = true)
       : position(t_position), layer(t_layer), width(t_width), height(t_height), color(t_color), isFixed(t_isFixed) {}
 };

--- a/src/Components/TextLabelComponent.h
+++ b/src/Components/TextLabelComponent.h
@@ -1,23 +1,24 @@
 #pragma once
 
-#include <SDL3/SDL.h>
-
 #include <glm/glm.hpp>
 #include <string>
 #include <utility>
+
+#include "General/Color.h"
+#include "General/Constants.h"
 
 struct TextLabelComponent {
   glm::vec2 position;
   int layer;
   std::string text;
   std::string fontId;
-  SDL_Color color;
+  octarine::Color color;
   bool isFixed;
 
   explicit TextLabelComponent(const glm::vec2 t_position = glm::vec2(0, 0), const int t_layer = 0,
                               std::string t_text = "", std::string t_fontId = "",
-                              const SDL_Color t_color = {Constants::kUint8Max, Constants::kUint8Max,
-                                                         Constants::kUint8Max, Constants::kUint8Max},
+                              const octarine::Color t_color = {Constants::kUint8Max, Constants::kUint8Max,
+                                                               Constants::kUint8Max, Constants::kUint8Max},
                               const bool t_isFixed = true)
       : position(t_position),
         layer(t_layer),

--- a/src/Editor/Inspectors/InspectorWidgets.h
+++ b/src/Editor/Inspectors/InspectorWidgets.h
@@ -2,10 +2,12 @@
 
 #ifdef OCTARINE_WITH_EDITOR
 
-#include <SDL3/SDL.h>
 #include <imgui.h>
 
+#include <cstdint>
 #include <string>
+
+#include "General/Color.h"
 
 // Shared ImGui helpers for component inspectors. Keeps the per-component
 // EditorInspector<T>::draw bodies free of repeated boilerplate.
@@ -35,13 +37,13 @@ inline bool InputTextString(const char* label, std::string& str, ImGuiInputTextF
   return ImGui::InputText(label, str.data(), str.capacity() + 1, flags, detail::InputTextStringResize, &userData);
 }
 
-/// ColorEdit4 bound to an SDL_Color (0-255). Handles the float[4] <-> Uint8
+/// ColorEdit4 bound to an octarine::Color (0-255). Handles the float[4] <-> Uint8
 /// conversion both ways.
-inline void DrawColorEdit(const char* label, SDL_Color& color) {
+inline void DrawColorEdit(const char* label, octarine::Color& color) {
   float col[4] = {color.r / 255.0F, color.g / 255.0F, color.b / 255.0F, color.a / 255.0F};
   if (ImGui::ColorEdit4(label, col)) {
-    color = {static_cast<Uint8>(col[0] * 255), static_cast<Uint8>(col[1] * 255), static_cast<Uint8>(col[2] * 255),
-             static_cast<Uint8>(col[3] * 255)};
+    color = {static_cast<std::uint8_t>(col[0] * 255), static_cast<std::uint8_t>(col[1] * 255),
+             static_cast<std::uint8_t>(col[2] * 255), static_cast<std::uint8_t>(col[3] * 255)};
   }
 }
 

--- a/src/Engine/EngineBootstrap.cpp
+++ b/src/Engine/EngineBootstrap.cpp
@@ -1,0 +1,166 @@
+#include "Engine/EngineBootstrap.h"
+
+#include <SDL3/SDL.h>
+
+#include <optional>
+#include <string>
+
+#include "AssetManager/AssetManager.h"
+#include "AssetManager/GlyphAtlas.h"
+#include "Components/CameraComponents.h"
+#include "Components/ViewportInfo.h"
+#include "ECS/Registry.h"
+#include "Engine/EngineContext.h"
+#include "EventBus/EventBus.h"
+#include "Game/Game.h"
+#include "Game/GameConfig.h"
+#include "General/Logger.h"
+#include "General/Rect.h"
+#include "Lua/Bindings/RegisterAllBindings.h"
+#include "Lua/Modules/RegisterAllModules.h"
+#include "Renderer/RenderQueue.h"
+#include "Renderer/SpriteRenderCache.h"
+#include "Systems/EntityPoolSystem.h"
+#include "Systems/InputSystem.h"
+#include "Systems/ProjectileEmitSystem.h"
+
+#ifdef OCTARINE_WITH_EDITOR
+#include "Editor/Inspectors/RegisterAllInspectors.h"
+#endif
+
+namespace
+{
+    // Read a file's bytes through SDL_IO so the same path resolves on desktop, inside an APK asset
+    // root, or inside a .app bundle. Mirrors the helper in Game.cpp; duplicated here so Bootstrap
+    // doesn't pull Game.cpp internals.
+    std::optional<std::string> ReadFileViaSDL(const std::string& path)
+    {
+        SDL_IOStream* io = SDL_IOFromFile(path.c_str(), "rb");
+        if (!io)
+        {
+            Logger::Error("SDL_IOFromFile failed for '" + path + "': " + std::string(SDL_GetError()));
+            return std::nullopt;
+        }
+        std::size_t size = 0;
+        void* data = SDL_LoadFile_IO(io, &size, true);
+        if (!data)
+        {
+            Logger::Error("SDL_LoadFile_IO failed for '" + path + "': " + std::string(SDL_GetError()));
+            return std::nullopt;
+        }
+        std::string out(static_cast<const char*>(data), size);
+        SDL_free(data);
+        return out;
+    }
+
+    int LuaDofileViaSDL(lua_State* L)
+    {
+        std::size_t plen = 0;
+        const char* p = luaL_checklstring(L, 1, &plen);
+        const std::string path(p, plen);
+
+        auto bytes = ReadFileViaSDL(path);
+        if (!bytes)
+        {
+            return luaL_error(L, "dofile: cannot open '%s'", path.c_str());
+        }
+
+        lua_settop(L, 0);
+        const int topBefore = lua_gettop(L);
+        const std::string chunkname = "@" + path;
+        if (luaL_loadbuffer(L, bytes->data(), bytes->size(), chunkname.c_str()) != 0)
+        {
+            return luaL_error(L, "dofile load '%s': %s", path.c_str(), lua_tostring(L, -1));
+        }
+        if (lua_pcall(L, 0, LUA_MULTRET, 0) != 0)
+        {
+            return luaL_error(L, "dofile run '%s': %s", path.c_str(), lua_tostring(L, -1));
+        }
+        return lua_gettop(L) - topBefore;
+    }
+} // namespace
+
+namespace engine_bootstrap
+{
+    void InstallLuaLibraries(sol::state& lua)
+    {
+        lua.open_libraries(sol::lib::base, sol::lib::math, sol::lib::io, sol::lib::string, sol::lib::table);
+
+        // Override Lua's stock `dofile` so chunks load through SDL_IO too. Must run after
+        // open_libraries (which installs the default dofile we're replacing).
+        lua_State* L = lua.lua_state();
+        lua_pushcfunction(L, &LuaDofileViaSDL);
+        lua_setglobal(L, "dofile");
+    }
+
+    void InstallCoreSingletons(Registry& registry, EngineContext& context, const int windowWidth,
+                               const int windowHeight, const bool withSpriteRenderCache)
+    {
+        const octarine::Rect camera{0, 0, static_cast<float>(windowWidth), static_cast<float>(windowHeight)};
+
+        registry.Set<RenderQueue>(RenderQueue());
+        registry.Set<CameraComponent>(CameraComponent{camera});
+        registry.Set<AssetManager>(AssetManager());
+        registry.Set<ViewportInfo>(ViewportInfo{
+            0, 0, static_cast<float>(windowWidth), static_cast<float>(windowHeight)
+        });
+        if (withSpriteRenderCache)
+        {
+            // Render-side cache mapping Entity → cached SDL_Texture*. Replaces the mutable
+            // cachedTexture member that used to live on SpriteComponent; keeps SpriteComponent
+            // POD-no-SDL. Bake runs no frames, so skips this slot.
+            registry.Set<SpriteRenderCache>(SpriteRenderCache());
+        }
+
+        // Publish the now-live AssetManager onto the context so consumers reach it without a
+        // separate Registry::Get<AssetManager>() round-trip. Caller is responsible for the other
+        // context fields (sdlRenderer/sdlWindow/eventBus/mixer/config).
+        context.assets = &registry.Get<AssetManager>();
+    }
+
+    ProjectileEmitSystem& InstallPoolAndProjectile(Registry& registry)
+    {
+        // EntityPoolManager before ProjectileEmitSystem::Init — Init calls
+        // Get<EntityPoolManager>().RegisterPool<...>.
+        registry.Set<EntityPoolManager>(EntityPoolManager());
+
+        // ProjectileEmitSystem Set + Init so GameModule's fire_projectile binding can capture it
+        // from the Registry during the modules-install phase below. Init only does
+        // RegisterPool<...> calls — safe before scene/system registration.
+        auto& projectileEmitSystem = registry.Set<ProjectileEmitSystem>(ProjectileEmitSystem());
+        projectileEmitSystem.Init(registry);
+        return projectileEmitSystem;
+    }
+
+    InputSystem& InstallInputSystem(Registry& registry, const std::unique_ptr<EventBus>& eventBus)
+    {
+        // InputSystem owned by the Registry so Lua bindings + event subscriptions outlive any
+        // single scene script reload. Must be Set before ScriptSystem::CreateLuaBindings so the
+        // `input` table is installed alongside ScriptSystem's globals.
+        auto& inputSystem = registry.Set<InputSystem>(InputSystem());
+        inputSystem.SubscribeToEvents(eventBus, &registry);
+        return inputSystem;
+    }
+
+    void RegisterAllComponentBindings()
+    {
+        // Component bindings (LuaBinding<T> specializations) must be registered BEFORE
+        // ScriptSystem's CreateLuaBindings runs — usertypes + registry.has_/get_ are populated
+        // from LuaComponentRegistry at that point.
+        RegisterAllLuaBindings();
+
+#ifdef OCTARINE_WITH_EDITOR
+        // Editor inspector surface — declarative parallel to the Lua bindings.
+        RegisterAllComponentInspectors();
+#endif
+    }
+
+    void InstallLuaModules(sol::state& lua, Game& game) { RegisterAllLuaModules(lua, game); }
+
+    void SetCommonLuaGlobals(sol::state& lua, const GameConfig& config, const std::string& startupMode)
+    {
+        lua["game_window_width"] = config.windowWidth;
+        lua["game_window_height"] = config.windowHeight;
+        lua["oct_startup_mode"] = startupMode;
+    }
+} // namespace engine_bootstrap

--- a/src/Engine/EngineBootstrap.h
+++ b/src/Engine/EngineBootstrap.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <memory>
+#include <sol/sol.hpp>
+#include <string>
+
+class EventBus;
+class Game;
+class GameConfig;
+class InputSystem;
+class ProjectileEmitSystem;
+class Registry;
+struct EngineContext;
+
+// Shared boot-sequence phases used by both Game::Setup (full per-frame loop) and
+// Game::RunBakeValidation (headless asset bake). Each phase is independent — callers compose
+// the subset they need — but the *order* of phases follows the dependency rules baked into
+// the engine (e.g. EntityPoolManager must be Set before ProjectileEmitSystem::Init, Lua
+// libraries must be open before ScriptSystem::CreateLuaBindings, modules install after
+// component bindings).
+//
+// Why a namespace of free fns instead of a class: there's no state to hold between phases.
+// Each fn takes exactly the inputs it needs, returning a reference where one is useful
+// downstream (InstallInputSystem → InputSystem& for LuaSystemRegistry registration, etc.).
+//
+// Before this module existed, Game::Setup and Game::RunBakeValidation duplicated ~50 lines
+// of singleton-set + Lua-binding sequence — drift was a matter of when, not if. Centralizing
+// the shared spine here means a binding/module added in one place reaches both paths.
+namespace engine_bootstrap
+{
+    // Open the Lua libs every startup script + module install assumes (base, math, io, string,
+    // table) and override `dofile` so it loads through SDL_IOFromFile — required for chunks
+    // loaded out of an APK / .app bundle, harmless on a real filesystem.
+    void InstallLuaLibraries(sol::state& lua);
+
+    // Set the engine-level Registry singletons that the startup script + Lua modules read at
+    // install time: RenderQueue, CameraComponent (sized to the window), AssetManager,
+    // ViewportInfo, and optionally SpriteRenderCache (live-frame path only — bake skips it
+    // since no frames render). Also plumbs the freshly-Set AssetManager pointer onto the
+    // EngineContext; other context fields must already be populated by the caller.
+    void InstallCoreSingletons(Registry& registry, EngineContext& context, int windowWidth, int windowHeight,
+                               bool withSpriteRenderCache);
+
+    // EntityPoolManager + ProjectileEmitSystem. ProjectileEmitSystem::Init calls RegisterPool
+    // against the EntityPoolManager, so EntityPoolManager must be Set first. Both bind Lua
+    // surfaces (fire_projectile), so registration must happen before InstallLuaModules.
+    // Returns the system reference so callers can stash it for later use.
+    ProjectileEmitSystem& InstallPoolAndProjectile(Registry& registry);
+
+    // InputSystem owned by the Registry + subscribed to its three input events. The `input.*`
+    // Lua surface is installed later via LuaSystemRegistry::bindAll once Lua libs are open;
+    // this phase wires the engine-side instance + EventBus subscriptions.
+    InputSystem& InstallInputSystem(Registry& registry, const std::unique_ptr<EventBus>& eventBus);
+
+    // RegisterAllLuaBindings + (when OCTARINE_WITH_EDITOR is on) RegisterAllComponentInspectors.
+    // Both walk a static registry — idempotent; calling twice is a no-op for the second pass.
+    // Must run before InstallLuaModules so usertypes exist when modules reference them.
+    void RegisterAllComponentBindings();
+
+    // Invoke RegisterAllLuaModules — installs every free-function module global the startup
+    // script and scenes reach (load_asset, fire_projectile, load_scene, play_sound, ...).
+    // Requires the singletons + InputSystem + Lua libs to be live.
+    void InstallLuaModules(sol::state& lua, Game& game);
+
+    // Stash the always-present Lua globals every scene/startup-script reads: window
+    // dimensions + oct_startup_mode. Pulled out of Setup/Bake so a future startup-mode
+    // addition only edits one site.
+    void SetCommonLuaGlobals(sol::state& lua, const GameConfig& config, const std::string& startupMode);
+} // namespace engine_bootstrap

--- a/src/Engine/EngineContext.h
+++ b/src/Engine/EngineContext.h
@@ -1,0 +1,33 @@
+#pragma once
+
+// Bundle of engine-level resources (SDL handles, EventBus, AssetManager pointer,
+// GameConfig pointer) that systems + Lua modules used to fish out of the Registry
+// individually as `Registry::Set<SDL_Renderer*>` / `Set<MIX_Mixer*>` / etc.
+// Consolidating them into a single typed singleton keeps Registry's singleton-
+// component slot count low, makes the engine-level surface obvious, and lets the
+// boot sequence be expressed as one assignment instead of three.
+//
+// Fields are non-owning. Lifetimes belong to Game (SDL handles), AudioSystem
+// (mixer), and the Registry singletons (AssetManager + GameConfig, both
+// Registry::Set<T>'d). EngineContext only views them.
+//
+// Forward decls keep this header free of SDL / SDL_mixer includes — consumers
+// that actually dereference a field already have the relevant headers on their
+// include path, while consumers that only pass the context around stay clean.
+
+struct SDL_Renderer;
+struct SDL_Window;
+struct MIX_Mixer;
+
+class AssetManager;
+class EventBus;
+class GameConfig;
+
+struct EngineContext {
+  SDL_Renderer* sdlRenderer = nullptr;
+  SDL_Window* sdlWindow = nullptr;
+  MIX_Mixer* mixer = nullptr;
+  EventBus* eventBus = nullptr;
+  AssetManager* assets = nullptr;
+  GameConfig* config = nullptr;
+};

--- a/src/Game/Game.cpp
+++ b/src/Game/Game.cpp
@@ -21,6 +21,7 @@
 #include <SDL3_ttf/SDL_ttf.h>
 #include "../Renderer/RenderQueue.h"
 #include "../Renderer/Renderer.h"
+#include "../Renderer/SpriteRenderCache.h"
 #include "Components/BoxColliderComponent.h"
 #include "Components/CameraComponents.h"
 #include "Components/EntityMaskComponent.h"
@@ -44,6 +45,7 @@
 #include "Events/MouseWheelEvent.h"
 #include "GameConfig.h"
 #include "General/PerfUtils.h"
+#include "General/Rect.h"
 #include "Lua/Bindings/InputSystemLuaBinding.h"
 #include "Lua/Bindings/LuaSystemRegistry.h"
 #include "Lua/Bindings/RegisterAllBindings.h"
@@ -512,8 +514,8 @@ bool Game::RunBakeValidation(const std::string& assetPath)
     // Singletons the startup script + its module globals touch at load time. This mirrors the
     // pre-LoadGame prefix of Game::Setup but omits everything tied to a window/renderer/mixer
     // (per-frame systems, audio, render queue producers) since the bake runs no frames.
-    const SDL_FRect camera(0, 0, static_cast<float>(gameConfig.windowWidth),
-                           static_cast<float>(gameConfig.windowHeight));
+    const octarine::Rect camera{0, 0, static_cast<float>(gameConfig.windowWidth),
+                                static_cast<float>(gameConfig.windowHeight)};
     registry_->Set<RenderQueue>(RenderQueue());
     registry_->Set<CameraComponent>(CameraComponent{camera});
     registry_->Set<AssetManager>(AssetManager());
@@ -686,12 +688,15 @@ void Game::Run()
 void Game::Setup()
 {
     auto& gameConfig = registry_->Get<GameConfig>();
-    const SDL_FRect camera(0, 0, static_cast<float>(gameConfig.windowWidth),
-                           static_cast<float>(gameConfig.windowHeight));
+    const octarine::Rect camera{0, 0, static_cast<float>(gameConfig.windowWidth),
+                                static_cast<float>(gameConfig.windowHeight)};
 
     registry_->Set<RenderQueue>(RenderQueue());
     registry_->Set<CameraComponent>(CameraComponent{camera});
     registry_->Set<AssetManager>(AssetManager());
+    // Render-side cache mapping Entity → cached SDL_Texture*. Replaces the mutable cachedTexture
+    // member that used to live on SpriteComponent; keeps SpriteComponent POD-no-SDL.
+    registry_->Set<SpriteRenderCache>(SpriteRenderCache());
     registry_->Set<ViewportInfo>(ViewportInfo{
         0, 0, static_cast<float>(gameConfig.windowWidth),
         static_cast<float>(gameConfig.windowHeight)
@@ -1349,6 +1354,12 @@ void Game::clearSceneEntities()
     if (auto* inputSystem = registry_->TryGet<InputSystem>())
     {
         inputSystem->ResetLuaState();
+    }
+    // Drop cached SDL_Texture* lookups for entities that just got blammed; the next sprite-emit
+    // pass repopulates as those entities are recreated by the new scene's load.
+    if (auto* spriteCache = registry_->TryGet<SpriteRenderCache>())
+    {
+        spriteCache->Clear();
     }
 }
 

--- a/src/Game/Game.cpp
+++ b/src/Game/Game.cpp
@@ -41,18 +41,19 @@
 #include "ECS/Iterable.h"
 #include "ECS/Query.h"
 #include "ECS/Registry.h"
+#include "Engine/EngineBootstrap.h"
 #include "Events/MouseInputEvent.h"
 #include "Events/MouseWheelEvent.h"
 #include "GameConfig.h"
 #include "General/PerfUtils.h"
 #include "General/Rect.h"
+// InputSystemLuaBinding specializes LuaSystemBinding<InputSystem> — needed below where
+// LuaSystemRegistry::registerSystem(inputSystem) instantiates the lookup. Don't drop.
 #include "Lua/Bindings/InputSystemLuaBinding.h"
 #include "Lua/Bindings/LuaSystemRegistry.h"
-#include "Lua/Bindings/RegisterAllBindings.h"
 #include "Lua/HotReload/ScriptHotReload.h"
 #include "Lua/LuaApiManifest.h"
 #include "Lua/LuaEntityLoader.h"
-#include "Lua/Modules/RegisterAllModules.h"
 #include "Components/AudioActiveTag.h"
 #include "Components/AudioListenerComponent.h"
 #include "Systems/AnimationSystem.h"
@@ -63,11 +64,9 @@
 #include "Systems/DamageSystem.h"
 #include "Systems/DopplerSystem.h"
 #include "Systems/DrawColliderSystem.h"
-#include "Systems/EntityPoolSystem.h"
 #include "Systems/InputSystem.h"
 #include "Systems/ObstacleBounceSystem.h"
 #include "Systems/OffScreenDespawnSystem.h"
-#include "Systems/ProjectileEmitSystem.h"
 #include "Systems/ProjectileLifecycleSystem.h"
 #include "Systems/RenderPrimitiveSystem.h"
 #include "Systems/RenderSpriteSystem.h"
@@ -91,7 +90,6 @@
 #include "../Editor/EditorPersistence.h"
 #include "../Editor/ExportBuilder.h"
 #include "../Editor/PlayerLauncher.h"
-#include "../Editor/Inspectors/RegisterAllInspectors.h"
 #endif
 
 constexpr Uint8 GREY_COLOR = 24;
@@ -101,7 +99,8 @@ namespace
 {
     // Read a file's bytes through SDL_IO so the same path resolves on desktop, inside an APK asset
     // root, or inside a .app bundle. Lua's stock fopen-based loader only sees a real filesystem and
-    // misses AAssetManager-backed entries on Android.
+    // misses AAssetManager-backed entries on Android. Used by LoadGame + LoadScene; the dofile
+    // override that exposes this to scripts lives in engine_bootstrap::InstallLuaLibraries.
     std::optional<std::string> ReadFileViaSDL(const std::string& path)
     {
         SDL_IOStream* io = SDL_IOFromFile(path.c_str(), "rb");
@@ -120,47 +119,6 @@ namespace
         std::string out(static_cast<const char*>(data), size);
         SDL_free(data);
         return out;
-    }
-
-    // Raw Lua C function backing the engine's `dofile` override. Registered via lua_pushcfunction so
-    // sol2 doesn't post-process the return: we report (top_after - top_before) which Lua interprets
-    // as the number of return values from the chunk, preserving multi-return correctly.
-    int LuaDofileViaSDL(lua_State* L)
-    {
-        std::size_t plen = 0;
-        const char* p = luaL_checklstring(L, 1, &plen);
-        const std::string path(p, plen);
-
-        auto bytes = ReadFileViaSDL(path);
-        if (!bytes)
-        {
-            return luaL_error(L, "dofile: cannot open '%s'", path.c_str());
-        }
-
-        // Drop the path arg so chunk return values are the only ones above topBefore.
-        lua_settop(L, 0);
-        const int topBefore = lua_gettop(L);
-        const std::string chunkname = "@" + path;
-        if (luaL_loadbuffer(L, bytes->data(), bytes->size(), chunkname.c_str()) != 0)
-        {
-            return luaL_error(L, "dofile load '%s': %s", path.c_str(), lua_tostring(L, -1));
-        }
-        if (lua_pcall(L, 0, LUA_MULTRET, 0) != 0)
-        {
-            return luaL_error(L, "dofile run '%s': %s", path.c_str(), lua_tostring(L, -1));
-        }
-        return lua_gettop(L) - topBefore;
-    }
-
-    // Override Lua's `dofile` so chunks load through SDL_IO too. The example calls
-    // dofile(get_asset_path("scripts/lib/foo.lua")); on desktop that's an absolute path SDL_IO opens
-    // directly, on Android it's a relative path SDL_IO resolves against the APK asset root. The stock
-    // Lua loader would fall back to fopen and miss the APK on Android.
-    void InstallLuaFileLoaders(sol::state& lua)
-    {
-        lua_State* L = lua.lua_state();
-        lua_pushcfunction(L, &LuaDofileViaSDL);
-        lua_setglobal(L, "dofile");
     }
 } // namespace
 
@@ -518,51 +476,30 @@ bool Game::RunBakeValidation(const std::string& assetPath)
         return false;
     }
 
-    // Singletons the startup script + its module globals touch at load time. This mirrors the
-    // pre-LoadGame prefix of Game::Setup but omits everything tied to a window/renderer/mixer
-    // (per-frame systems, audio, render queue producers) since the bake runs no frames.
-    const octarine::Rect camera{0, 0, static_cast<float>(gameConfig.windowWidth),
-                                static_cast<float>(gameConfig.windowHeight)};
-    registry_->Set<RenderQueue>(RenderQueue());
-    registry_->Set<CameraComponent>(CameraComponent{camera});
-    registry_->Set<AssetManager>(AssetManager());
-    registry_->Set<ViewportInfo>(ViewportInfo{
-        0, 0, static_cast<float>(gameConfig.windowWidth),
-        static_cast<float>(gameConfig.windowHeight)
-    });
-    // Bake mode: no window/renderer/mixer exist. Context still gets Set so module/system code
-    // that reads it can branch on null fields instead of TryGet'ing each slot separately.
-    EngineContext ctx;
-    ctx.eventBus = event_bus_.get();
-    ctx.config = &gameConfig;
-    ctx.assets = &registry_->Get<AssetManager>();
-    registry_->Set<EngineContext>(ctx);
+    // Bake mode: no window/renderer/mixer. Set the engine context first with the bits that do
+    // exist; InstallCoreSingletons plumbs ctx.assets once it Sets the AssetManager.
+    EngineContext bakeCtx;
+    bakeCtx.eventBus = event_bus_.get();
+    bakeCtx.config = &gameConfig;
+    registry_->Set<EngineContext>(bakeCtx);
 
-    // EntityPoolManager before ProjectileEmitSystem::Init (Init calls RegisterPool against it),
-    // matching Setup's ordering so fire_projectile binds correctly during module install.
-    registry_->Set<EntityPoolManager>(EntityPoolManager());
-    auto& projectileEmitSystem = registry_->Set<ProjectileEmitSystem>(ProjectileEmitSystem());
-    projectileEmitSystem.Init(*registry_);
-
-    // InputSystem owns the `input.*` Lua surface the scene libs bind against (input_map.install,
-    // spawn.install_click_spawn). Set + subscribe before bindings install.
-    auto& inputSystem = registry_->Set<InputSystem>(InputSystem());
-    inputSystem.SubscribeToEvents(event_bus_, registry_.get());
-
-    RegisterAllLuaBindings();
-
+    // Shared bootstrap spine. withSpriteRenderCache=false — bake runs no frames so the render
+    // cache slot is unused.
+    engine_bootstrap::InstallCoreSingletons(*registry_, registry_->Get<EngineContext>(), gameConfig.windowWidth,
+                                            gameConfig.windowHeight, /*withSpriteRenderCache=*/false);
+    engine_bootstrap::InstallPoolAndProjectile(*registry_);
+    auto& inputSystem = engine_bootstrap::InstallInputSystem(*registry_, event_bus_);
+    engine_bootstrap::RegisterAllComponentBindings();
     LuaSystemRegistry::clear();
     LuaSystemRegistry::registerSystem(inputSystem);
-
-    lua.open_libraries(sol::lib::base, sol::lib::math, sol::lib::io, sol::lib::string, sol::lib::table);
-    InstallLuaFileLoaders(lua);
+    engine_bootstrap::InstallLuaLibraries(lua);
+    // Bake doesn't register ScriptSystem as a per-frame system (no frames). A stack instance
+    // is enough to install the primitive + component usertypes Lua scripts reference.
     ScriptSystem scriptSystem;
     scriptSystem.CreateLuaBindings(lua);
-    RegisterAllLuaModules(lua, *this);
+    engine_bootstrap::InstallLuaModules(lua, *this);
     LuaSystemRegistry::bindAll(lua);
-    lua["game_window_width"] = gameConfig.windowWidth;
-    lua["game_window_height"] = gameConfig.windowHeight;
-    lua["oct_startup_mode"] = startup_mode_;
+    engine_bootstrap::SetCommonLuaGlobals(lua, gameConfig, startup_mode_);
 
     auto& assetManager = registry_->Get<AssetManager>();
     assetManager.LoadGameConfig(gameConfig);
@@ -700,73 +637,29 @@ void Game::Run()
 void Game::Setup()
 {
     auto& gameConfig = registry_->Get<GameConfig>();
-    const octarine::Rect camera{0, 0, static_cast<float>(gameConfig.windowWidth),
-                                static_cast<float>(gameConfig.windowHeight)};
 
-    registry_->Set<RenderQueue>(RenderQueue());
-    registry_->Set<CameraComponent>(CameraComponent{camera});
-    registry_->Set<AssetManager>(AssetManager());
-    // Render-side cache mapping Entity → cached SDL_Texture*. Replaces the mutable cachedTexture
-    // member that used to live on SpriteComponent; keeps SpriteComponent POD-no-SDL.
-    registry_->Set<SpriteRenderCache>(SpriteRenderCache());
-    registry_->Set<ViewportInfo>(ViewportInfo{
-        0, 0, static_cast<float>(gameConfig.windowWidth),
-        static_cast<float>(gameConfig.windowHeight)
-    });
+    // Shared bootstrap spine (see engine_bootstrap/EngineBootstrap.h). withSpriteRenderCache=true
+    // — the live game loop reads the cache from the parallel sprite-render pass.
+    engine_bootstrap::InstallCoreSingletons(*registry_, registry_->Get<EngineContext>(), gameConfig.windowWidth,
+                                            gameConfig.windowHeight, /*withSpriteRenderCache=*/true);
 
-    // Finish populating the engine context: AssetManager is now live, so plumb its pointer in
-    // alongside the SDL handles Initialize() already set. Mixer is filled in below after
-    // AudioSystem::Init succeeds.
-    registry_->Get<EngineContext>().assets = &registry_->Get<AssetManager>();
-
-    // Gameplay
+    // ScriptSystem is registered as a per-frame system (vs. Bake's stack instance) so its
+    // operator() runs each tick. CreateLuaBindings still happens below in the bootstrap spine.
     auto& scriptSystem = registry_->RegisterSystem<ScriptComponent>(ScriptSystem());
-    // InputSystem owned by the Registry so Lua bindings + event subscriptions outlive any single
-    // scene script reload. Must be Set before CreateLuaBindings so the `input` table is installed
-    // alongside ScriptSystem's globals.
-    auto& inputSystem = registry_->Set<InputSystem>(InputSystem());
-    inputSystem.SubscribeToEvents(event_bus_, registry_.get());
 
-    // Component bindings (LuaBinding<T> specializations) must be registered BEFORE
-    // ScriptSystem's CreateLuaBindings runs — usertypes + registry.has_/get_ are
-    // populated from LuaComponentRegistry at that point.
-    RegisterAllLuaBindings();
-
-#ifdef OCTARINE_WITH_EDITOR
-    // Editor inspector surface — declarative parallel to the Lua bindings.
-    RegisterAllComponentInspectors();
-#endif
-
-    // Systems that expose a Lua surface register here; bindAll installs them all once
-    // the sol::state has its libraries open.
+    auto& inputSystem = engine_bootstrap::InstallInputSystem(*registry_, event_bus_);
+    engine_bootstrap::RegisterAllComponentBindings();
     LuaSystemRegistry::clear();
     LuaSystemRegistry::registerSystem(inputSystem);
-
-    lua.open_libraries(sol::lib::base, sol::lib::math, sol::lib::io, sol::lib::string, sol::lib::table);
-    // Re-route Lua file-loading through SDL_IO so dofile() reaches inside read-only bundles
-    // (APK/.app). Must run after open_libraries (which installs the stock dofile).
-    InstallLuaFileLoaders(lua);
+    engine_bootstrap::InstallLuaLibraries(lua);
     // Snapshot stdlib globals before binding so the API manifest can diff out everything the
     // engine adds. Cheap; the actual dump only fires when OCTARINE_DUMP_LUA_API is set.
     const auto preBindingGlobals = LuaApiManifest::SnapshotGlobals(lua);
-
-    // EntityPoolManager Set before ProjectileEmitSystem::Init — Init calls
-    // Get<EntityPoolManager>().RegisterPool<...>. Was Set later (after audio); moved up to
-    // satisfy the new init order.
-    registry_->Set<EntityPoolManager>(EntityPoolManager());
-
-    // ProjectileEmitSystem set + Init early so GameModule's fire_projectile can capture it from
-    // the Registry during RegisterAllLuaModules. Init only does RegisterPool<...> calls — safe
-    // to run before scene/system registration.
-    auto& projectileEmitSystem = registry_->Set<ProjectileEmitSystem>(ProjectileEmitSystem());
-    projectileEmitSystem.Init(*registry_);
-
+    engine_bootstrap::InstallPoolAndProjectile(*registry_);
     scriptSystem.CreateLuaBindings(lua);
-    RegisterAllLuaModules(lua, *this);
+    engine_bootstrap::InstallLuaModules(lua, *this);
     LuaSystemRegistry::bindAll(lua);
-    lua["game_window_width"] = gameConfig.windowWidth;
-    lua["game_window_height"] = gameConfig.windowHeight;
-    lua["oct_startup_mode"] = startup_mode_;
+    engine_bootstrap::SetCommonLuaGlobals(lua, gameConfig, startup_mode_);
 
     // Emit the EmmyLua API stub when requested (no-op otherwise). Runs once per Setup, after the
     // full surface — globals, modules, system tables — is installed.

--- a/src/Game/Game.cpp
+++ b/src/Game/Game.cpp
@@ -417,8 +417,15 @@ bool Game::Initialize(const std::string& assetPath)
 
     SDL_SetRenderDrawColor(sdl_renderer_, GREY_COLOR, GREY_COLOR, GREY_COLOR, Constants::kUint8Max);
 
-    registry_->Set<SDL_Renderer*>(sdl_renderer_);
-    registry_->Set<EventBus*>(event_bus_.get());
+    // Populate the engine-level resource bundle now that SDL is up. AssetManager + mixer are
+    // filled in by Setup once those exist; consumers read the same instance via
+    // Registry::Get<EngineContext>().
+    EngineContext ctx;
+    ctx.sdlWindow = window_;
+    ctx.sdlRenderer = sdl_renderer_;
+    ctx.eventBus = event_bus_.get();
+    ctx.config = &gameConfig;
+    registry_->Set<EngineContext>(ctx);
 
     s_is_running_ = true;
     return true;
@@ -523,8 +530,13 @@ bool Game::RunBakeValidation(const std::string& assetPath)
         0, 0, static_cast<float>(gameConfig.windowWidth),
         static_cast<float>(gameConfig.windowHeight)
     });
-    registry_->Set<SDL_Renderer*>(nullptr); // no GPU in bake; bake-mode asset globals skip it
-    registry_->Set<EventBus*>(event_bus_.get());
+    // Bake mode: no window/renderer/mixer exist. Context still gets Set so module/system code
+    // that reads it can branch on null fields instead of TryGet'ing each slot separately.
+    EngineContext ctx;
+    ctx.eventBus = event_bus_.get();
+    ctx.config = &gameConfig;
+    ctx.assets = &registry_->Get<AssetManager>();
+    registry_->Set<EngineContext>(ctx);
 
     // EntityPoolManager before ProjectileEmitSystem::Init (Init calls RegisterPool against it),
     // matching Setup's ordering so fire_projectile binds correctly during module install.
@@ -702,6 +714,11 @@ void Game::Setup()
         static_cast<float>(gameConfig.windowHeight)
     });
 
+    // Finish populating the engine context: AssetManager is now live, so plumb its pointer in
+    // alongside the SDL handles Initialize() already set. Mixer is filled in below after
+    // AudioSystem::Init succeeds.
+    registry_->Get<EngineContext>().assets = &registry_->Get<AssetManager>();
+
     // Gameplay
     auto& scriptSystem = registry_->RegisterSystem<ScriptComponent>(ScriptSystem());
     // InputSystem owned by the Registry so Lua bindings + event subscriptions outlive any single
@@ -830,6 +847,9 @@ void Game::Setup()
     {
         Logger::Error("AudioSystem failed to initialize; audio disabled this session.");
     }
+    // Mixer is owned by AudioSystem; publish it on the context so asset loads + the master-
+    // volume sync (in Game::Update) can reach it without going through the Registry's typed slot.
+    registry_->Get<EngineContext>().mixer = audioSystem.Mixer();
 
     if (gameConfig.HasLoadedConfig())
     {
@@ -972,10 +992,10 @@ void Game::Update(const float deltaTime)
     // Master volume + mute live at the mixer level so they apply to every track (including loops
     // already playing). Synced every frame — and outside the pause gate — so toggling mute reacts
     // immediately even while execution is paused.
-    if (auto* mixer = registry_->TryGet<MIX_Mixer*>())
+    if (auto* mixer = registry_->Get<EngineContext>().mixer)
     {
         const float masterGain = options.audioEnabled ? std::max(0.0F, options.masterVolume) : 0.0F;
-        MIX_SetMixerGain(*mixer, masterGain);
+        MIX_SetMixerGain(mixer, masterGain);
     }
 
     auto* inputSystem = registry_->TryGet<InputSystem>();
@@ -1208,7 +1228,7 @@ void Game::LoadScene(const std::string& scenePath)
             if (assets && assets->valid())
             {
                 auto& am = registry_->Get<AssetManager>();
-                auto* mixer = registry_->TryGet<MIX_Mixer*>();
+                auto* mixer = registry_->Get<EngineContext>().mixer;
                 int assetCount = 0;
                 for (auto& [key, value] : *assets)
                 {
@@ -1229,7 +1249,7 @@ void Game::LoadScene(const std::string& scenePath)
                         }
                         else if (type == "audio_clip")
                         {
-                            if (mixer) am.AddAudioClip(*mixer, id, file);
+                            if (mixer) am.AddAudioClip(mixer, id, file);
                         }
                         assetCount++;
                     }
@@ -1242,8 +1262,7 @@ void Game::LoadScene(const std::string& scenePath)
             // front before entities load.
             {
                 auto& am = registry_->Get<AssetManager>();
-                auto* mixerPtr = registry_->TryGet<MIX_Mixer*>();
-                MIX_Mixer* mixer = mixerPtr ? *mixerPtr : nullptr;
+                MIX_Mixer* mixer = registry_->Get<EngineContext>().mixer;
                 const std::vector<AssetReference> refs = SceneAssetScanner::CollectRefs(sceneTable);
 
                 if (const int failures = am.Validate(refs); failures > 0)

--- a/src/Game/Game.cpp
+++ b/src/Game/Game.cpp
@@ -92,9 +92,6 @@
 #include "../Editor/PlayerLauncher.h"
 #endif
 
-constexpr Uint8 GREY_COLOR = 24;
-constexpr Uint8 BLACK_COLOR = 0;
-
 namespace
 {
     // Read a file's bytes through SDL_IO so the same path resolves on desktop, inside an APK asset
@@ -296,12 +293,8 @@ bool Game::Initialize(const std::string& assetPath)
         return false;
     }
 
-    game_render_texture_ = SDL_CreateTexture(sdl_renderer_, SDL_PIXELFORMAT_RGBA8888, SDL_TEXTUREACCESS_TARGET,
-                                             gameConfig.windowWidth, gameConfig.windowHeight);
-
-    if (!game_render_texture_)
+    if (!renderer_->CreateScene(sdl_renderer_, gameConfig.windowWidth, gameConfig.windowHeight))
     {
-        Logger::Error("SDL_CreateTexture Error: " + std::string(SDL_GetError()));
         return false;
     }
 
@@ -373,8 +366,6 @@ bool Game::Initialize(const std::string& assetPath)
 #endif
 #endif
 
-    SDL_SetRenderDrawColor(sdl_renderer_, GREY_COLOR, GREY_COLOR, GREY_COLOR, Constants::kUint8Max);
-
     // Populate the engine-level resource bundle now that SDL is up. AssetManager + mixer are
     // filled in by Setup once those exist; consumers read the same instance via
     // Registry::Get<EngineContext>().
@@ -417,10 +408,7 @@ void Game::Destroy()
 
     if (sdl_renderer_)
     {
-        if (game_render_texture_)
-        {
-            SDL_DestroyTexture(game_render_texture_);
-        }
+        renderer_->DestroyScene();
 #ifdef OCTARINE_WITH_IMGUI
         ImGui_ImplSDLRenderer3_Shutdown();
         ImGui_ImplSDL3_Shutdown();
@@ -936,9 +924,7 @@ void Game::Render([[maybe_unused]] const float deltaTime)
     PROFILE_COUNTER_SET("RenderQueue: Size", static_cast<long long>(renderQueue.Size()));
     PROFILE_COUNTER_SET("Entities: User", static_cast<long long>(registry_->GetUserEntityCount()));
 
-    SDL_SetRenderTarget(sdl_renderer_, game_render_texture_);
-    SDL_SetRenderDrawColor(sdl_renderer_, GREY_COLOR, GREY_COLOR, GREY_COLOR, Constants::kUint8Max);
-    SDL_RenderClear(sdl_renderer_);
+    renderer_->BeginScene(sdl_renderer_);
 
 #ifdef OCTARINE_PROFILING
     {
@@ -947,11 +933,11 @@ void Game::Render([[maybe_unused]] const float deltaTime)
     }
     {
         PerfUtils::ScopedTimer drawTimer("Render: Draw");
-        renderer_->Render(renderQueue, sdl_renderer_);
+        renderer_->DrawQueue(renderQueue, sdl_renderer_);
     }
 #else
     renderQueue.Sort();
-    renderer_->Render(renderQueue, sdl_renderer_);
+    renderer_->DrawQueue(renderQueue, sdl_renderer_);
 #endif
 
     if (gameConfig.GetEngineOptions().drawColliders && collider_query_)
@@ -961,9 +947,7 @@ void Game::Render([[maybe_unused]] const float deltaTime)
         collider_query_->ForEach(drawColliderSystem);
     }
 
-    SDL_SetRenderTarget(sdl_renderer_, nullptr);
-    SDL_SetRenderDrawColor(sdl_renderer_, BLACK_COLOR, BLACK_COLOR, BLACK_COLOR, Constants::kUint8Max);
-    SDL_RenderClear(sdl_renderer_);
+    renderer_->EndScene(sdl_renderer_);
 
     auto& options = gameConfig.GetEngineOptions();
     const bool editorSession = gameConfig.IsEditorMode() || !gameConfig.HasLoadedConfig();
@@ -993,20 +977,20 @@ void Game::Render([[maybe_unused]] const float deltaTime)
         // and NOT showing debug overlays. In editor mode, the Scene window handles drawing this texture.
         if (!editorSession && !options.showDebugGUI)
         {
-            SDL_RenderTexture(sdl_renderer_, game_render_texture_, nullptr, nullptr);
+            renderer_->CompositeSceneToWindow(sdl_renderer_);
         }
 #ifdef OCTARINE_WITH_IMGUI
-        RenderDebugGUISystem::Render(this, sdl_renderer_, game_render_texture_, deltaTime);
+        RenderDebugGUISystem::Render(this, sdl_renderer_, renderer_->GetSceneTexture(), deltaTime);
 #endif
     }
 
 #ifdef OCTARINE_PROFILING
     {
         PerfUtils::ScopedTimer presentTimer("Render: Present");
-        SDL_RenderPresent(sdl_renderer_);
+        renderer_->Present(sdl_renderer_);
     }
 #else
-    SDL_RenderPresent(sdl_renderer_);
+    renderer_->Present(sdl_renderer_);
 #endif
     // Emit per-frame counters as COUNTER lines so headless bench runs can capture them
     // alongside TIMER lines. All systems for this frame have already written their values.

--- a/src/Game/Game.h
+++ b/src/Game/Game.h
@@ -10,6 +10,7 @@
 #include "../Components/BoxColliderComponent.h"
 #include "../Components/GlobalTransformComponent.h"
 #include "../ECS/Query.h"
+#include "../Engine/EngineContext.h"
 #include "../EventBus/EventBus.h"
 #include "../Events/KeyInputEvent.h"
 #include "../Renderer/Renderer.h"
@@ -67,6 +68,13 @@ public:
 
     [[nodiscard]] Registry* GetRegistry() const { return registry_.get(); }
     [[nodiscard]] sol::state& GetLua() { return lua; }
+
+    // Engine-level resource bundle (SDL handles, EventBus, AssetManager, GameConfig).
+    // Lives as a Registry singleton — systems read it the same way via
+    // `Registry::Get<EngineContext>()`. Game just forwards to the registry copy so
+    // fields stay coherent across Initialize → Setup → AudioSystem::Init mutations.
+    [[nodiscard]] EngineContext& GetContext() { return registry_->Get<EngineContext>(); }
+    [[nodiscard]] const EngineContext& GetContext() const { return registry_->Get<EngineContext>(); }
 
     void LoadScene(const std::string& scenePath);
     void ReloadScene();

--- a/src/Game/Game.h
+++ b/src/Game/Game.h
@@ -110,7 +110,6 @@ private:
 
     SDL_Window* window_;
     SDL_Renderer* sdl_renderer_;
-    SDL_Texture* game_render_texture_{nullptr};
     static inline bool s_is_running_{false};
     bool scene_running_ = false;
     bool bake_mode_ = false;

--- a/src/General/Color.h
+++ b/src/General/Color.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <cstdint>
+
+namespace octarine {
+
+struct Color {
+  std::uint8_t r = 0;
+  std::uint8_t g = 0;
+  std::uint8_t b = 0;
+  std::uint8_t a = 0;
+};
+
+}  // namespace octarine

--- a/src/General/Rect.h
+++ b/src/General/Rect.h
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace octarine {
+
+struct Rect {
+  float x = 0.0F;
+  float y = 0.0F;
+  float w = 0.0F;
+  float h = 0.0F;
+};
+
+}  // namespace octarine

--- a/src/General/SpriteFlip.h
+++ b/src/General/SpriteFlip.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <cstdint>
+
+namespace octarine {
+
+// Mirror flags for sprite rendering. Bit layout matches SDL_FlipMode but the
+// enum is backend-agnostic so component data doesn't depend on SDL headers.
+enum class SpriteFlip : std::uint8_t {
+  None = 0,
+  Horizontal = 1u << 0,
+  Vertical = 1u << 1,
+  Both = Horizontal | Vertical,
+};
+
+}  // namespace octarine

--- a/src/Lua/Bindings/InputSystemLuaBinding.cpp
+++ b/src/Lua/Bindings/InputSystemLuaBinding.cpp
@@ -1,0 +1,85 @@
+#include "Lua/Bindings/InputSystemLuaBinding.h"
+
+#include <SDL3/SDL.h>
+
+#include <algorithm>
+#include <cctype>
+#include <glm/glm.hpp>
+#include <string>
+
+#include "Components/ViewportInfo.h"
+#include "ECS/Registry.h"
+#include "Systems/InputSystem.h"
+
+namespace
+{
+    int ToMouseButton(const sol::object& btn)
+    {
+        if (btn.is<int>()) return btn.as<int>();
+        if (btn.is<std::string>())
+        {
+            const std::string name = InputSystem::MakeKey(btn.as<std::string>());
+            if (name == "left") return SDL_BUTTON_LEFT;
+            if (name == "middle") return SDL_BUTTON_MIDDLE;
+            if (name == "right") return SDL_BUTTON_RIGHT;
+            if (name == "x1") return SDL_BUTTON_X1;
+            if (name == "x2") return SDL_BUTTON_X2;
+        }
+        return 0;
+    }
+} // namespace
+
+void LuaSystemBinding<InputSystem>::bind(sol::state& lua, InputSystem& system)
+{
+    lua["input"] = lua.create_table();
+    sol::table input = lua["input"];
+
+    input.set_function("is_key_down", [&system](const std::string& name) { return system.IsKeyDown(name); });
+    input.set_function("is_key_pressed", [&system](const std::string& name) { return system.IsKeyPressed(name); });
+    input.set_function("is_key_released", [&system](const std::string& name) { return system.IsKeyReleased(name); });
+
+    input.set_function("is_mouse_down", [&system](sol::object btn) { return system.IsMouseDown(ToMouseButton(btn)); });
+    input.set_function("is_mouse_pressed",
+                       [&system](sol::object btn) { return system.IsMousePressed(ToMouseButton(btn)); });
+    input.set_function("is_mouse_released",
+                       [&system](sol::object btn) { return system.IsMouseReleased(ToMouseButton(btn)); });
+    input.set_function("is_hovered", [&system]()
+    {
+        return system.GetRegistry() ? system.GetRegistry()->Get<ViewportInfo>().isHovered : true;
+    });
+    input.set_function("is_focused", [&system]()
+    {
+        return system.GetRegistry() ? system.GetRegistry()->Get<ViewportInfo>().isFocused : true;
+    });
+    input.set_function("mouse_position",
+                       [&system]() { return glm::vec2(system.MouseX(), system.MouseY()); });
+    input.set_function("mouse_wheel",
+                       [&system]() { return glm::vec2(system.WheelDx(), system.WheelDy()); });
+
+    input.set_function("bind",
+                       [&system](const std::string& action, const std::string& key) { system.Bind(action, key); });
+    input.set_function("unbind", [&system](const std::string& action, sol::optional<std::string> key)
+    {
+        if (key)
+        {
+            system.Unbind(action, *key);
+        }
+        else
+        {
+            system.UnbindAction(action);
+        }
+    });
+    input.set_function("is_action_down", [&system](const std::string& a) { return system.IsActionDown(a); });
+    input.set_function("is_action_pressed", [&system](const std::string& a) { return system.IsActionPressed(a); });
+    input.set_function("is_action_released", [&system](const std::string& a) { return system.IsActionReleased(a); });
+
+    input.set_function("on_key_down",
+                       [&system](sol::protected_function fn) { system.AddOnKeyDown(std::move(fn)); });
+    input.set_function("on_key_up", [&system](sol::protected_function fn) { system.AddOnKeyUp(std::move(fn)); });
+    input.set_function("on_mouse_down",
+                       [&system](sol::protected_function fn) { system.AddOnMouseDown(std::move(fn)); });
+    input.set_function("on_mouse_up",
+                       [&system](sol::protected_function fn) { system.AddOnMouseUp(std::move(fn)); });
+    input.set_function("on_mouse_wheel",
+                       [&system](sol::protected_function fn) { system.AddOnMouseWheel(std::move(fn)); });
+}

--- a/src/Lua/Bindings/InputSystemLuaBinding.h
+++ b/src/Lua/Bindings/InputSystemLuaBinding.h
@@ -3,10 +3,14 @@
 #include <sol/sol.hpp>
 
 #include "Lua/Bindings/LuaSystemRegistry.h"
-#include "Systems/InputSystem.h"
 
+class InputSystem;
+
+// LuaSystemBinding<InputSystem>::bind installs the `input.*` table — every is_/on_/bind/etc.
+// global the scenes reach. Definition lives in InputSystemLuaBinding.cpp so InputSystem.h
+// doesn't have to host the sol-laden install body inline.
 template <>
 struct LuaSystemBinding<InputSystem>
 {
-    static void bind(sol::state& lua, InputSystem& system) { system.CreateLuaBindings(lua); }
+    static void bind(sol::state& lua, InputSystem& system);
 };

--- a/src/Lua/Bindings/LuaBinding.h
+++ b/src/Lua/Bindings/LuaBinding.h
@@ -1,10 +1,11 @@
 #pragma once
 
-#include <SDL3/SDL.h>
-
+#include <cstdint>
 #include <glm/glm.hpp>
 #include <sol/sol.hpp>
 #include <string>
+
+#include "General/Color.h"
 
 namespace LuaComponentHelpers
 {
@@ -21,10 +22,11 @@ namespace LuaComponentHelpers
         return result;
     }
 
-    inline SDL_Color SafeGetColor(const sol::table& parentTable, const std::string& key, Uint8 defaultR = 0,
-                                  Uint8 defaultG = 0, Uint8 defaultB = 0, Uint8 defaultA = 0)
+    inline octarine::Color SafeGetColor(const sol::table& parentTable, const std::string& key,
+                                        std::uint8_t defaultR = 0, std::uint8_t defaultG = 0,
+                                        std::uint8_t defaultB = 0, std::uint8_t defaultA = 0)
     {
-        SDL_Color result = {defaultR, defaultG, defaultB, defaultA};
+        octarine::Color result{defaultR, defaultG, defaultB, defaultA};
         if (sol::optional<sol::table> vecTableOpt = parentTable[key]; vecTableOpt && vecTableOpt.value().valid())
         {
             sol::table& vecTable = vecTableOpt.value();

--- a/src/Lua/Bindings/SquarePrimitiveComponentLuaBinding.h
+++ b/src/Lua/Bindings/SquarePrimitiveComponentLuaBinding.h
@@ -19,7 +19,7 @@ struct LuaBinding<SquarePrimitiveComponent>
         const auto layer = SafeGetOptionalValue<int>(t, "layer", 1);
         const auto width = SafeGetOptionalValue<float>(t, "width", 0.0f);
         const auto height = SafeGetOptionalValue<float>(t, "height", 0.0f);
-        const SDL_Color color = SafeGetColor(t, "color");
+        const octarine::Color color = SafeGetColor(t, "color");
         const auto fixed = SafeGetOptionalValue<bool>(t, "fixed", false);
         return SquarePrimitiveComponent(position, layer, width, height, color, fixed);
     }

--- a/src/Lua/Bindings/TextLabelComponentLuaBinding.h
+++ b/src/Lua/Bindings/TextLabelComponentLuaBinding.h
@@ -19,7 +19,7 @@ struct LuaBinding<TextLabelComponent>
         const int layer = SafeGetOptionalValue<int>(t, "layer", 1);
         const std::string text = t["text"].get<std::string>();
         const std::string fontId = t["font_id"].get<std::string>();
-        const SDL_Color color = SafeGetColor(t, "color");
+        const octarine::Color color = SafeGetColor(t, "color");
         const bool isFixed = SafeGetOptionalValue<bool>(t, "is_fixed", true);
         return TextLabelComponent(offsetPosition, layer, text, fontId, color, isFixed);
     }

--- a/src/Lua/Modules/AudioModuleLuaBinding.cpp
+++ b/src/Lua/Modules/AudioModuleLuaBinding.cpp
@@ -3,6 +3,7 @@
 #include <string>
 
 #include "ECS/Registry.h"
+#include "Engine/EngineContext.h"
 #include "EventBus/EventBus.h"
 #include "Events/AudioPlayEvent.h"
 #include "Game/Game.h"
@@ -12,7 +13,7 @@ void LuaModuleBinding<AudioModule>::install(sol::state& lua, Game& game)
 {
     lua.set_function("play_sound", [&game](const std::string& clipId, const sol::optional<float> volume)
     {
-        auto* eventBus = game.GetRegistry()->Get<EventBus*>();
+        auto* eventBus = game.GetContext().eventBus;
         if (!eventBus)
         {
             Logger::Error("play_sound called before event bus is ready");

--- a/src/Lua/Modules/SceneModuleLuaBinding.cpp
+++ b/src/Lua/Modules/SceneModuleLuaBinding.cpp
@@ -14,6 +14,7 @@
 #include "AssetManager/AssetManager.h"
 #include "AssetManager/SceneAssetScanner.h"
 #include "ECS/Registry.h"
+#include "Engine/EngineContext.h"
 #include "Game/Game.h"
 #include "Game/GameConfig.h"
 #include "General/Logger.h"
@@ -68,7 +69,7 @@ void LuaModuleBinding<SceneModule>::install(sol::state& lua, Game& game)
             return;
         }
 
-        LoadAsset(std::move(assetTable), assetManager, game.GetRenderer(), registry->Get<MIX_Mixer*>());
+        LoadAsset(std::move(assetTable), assetManager, game.GetRenderer(), game.GetContext().mixer);
     });
     // Scan a scene table for its required asset ids (sprite/font/audio + tilemap + preload),
     // validate them against the catalog, then acquire each. The data-driven replacement for a
@@ -79,8 +80,7 @@ void LuaModuleBinding<SceneModule>::install(sol::state& lua, Game& game)
     {
         auto* registry = game.GetRegistry();
         auto& assetManager = registry->Get<AssetManager>();
-        auto* mixerPtr = registry->TryGet<MIX_Mixer*>();
-        MIX_Mixer* mixer = mixerPtr ? *mixerPtr : nullptr;
+        MIX_Mixer* mixer = game.GetContext().mixer;
 
         const std::vector<AssetReference> refs = SceneAssetScanner::CollectRefs(scene);
         const int failures = assetManager.Validate(refs);

--- a/src/Renderer/RenderCulling.h
+++ b/src/Renderer/RenderCulling.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <SDL3/SDL.h>
+#include "General/Rect.h"
 
 // Renderable viewport-cull test shared by all Render*System producers. World-space items
 // are tested against the camera rect; screen-space (isFixed) items against the window rect.
 // AABB params describe the renderable's top-left + size in its native space (world or screen).
 inline bool IsRenderableOutsideViewport(const float originX, const float originY, const float width, const float height,
-                                        const bool isFixed, const SDL_FRect& camera, const float windowWidth,
+                                        const bool isFixed, const octarine::Rect& camera, const float windowWidth,
                                         const float windowHeight) {
   if (isFixed) {
     return originX + width < 0 || originX > windowWidth || originY + height < 0 || originY > windowHeight;

--- a/src/Renderer/Renderer.cpp
+++ b/src/Renderer/Renderer.cpp
@@ -1,10 +1,56 @@
 #include "./Renderer.h"
 
 #include <cmath>
+#include <string>
 
+#include "General/Constants.h"
 #include "General/Logger.h"
 
-void Renderer::Render(const RenderQueue& renderQueue, SDL_Renderer* renderer) const {
+namespace
+{
+constexpr Uint8 kSceneClearGrey = 24;
+constexpr Uint8 kWindowClearBlack = 0;
+}  // namespace
+
+bool Renderer::CreateScene(SDL_Renderer* sdlRenderer, const int width, const int height) {
+  if (sdlRenderer == nullptr) return false;
+  scene_texture_ =
+      SDL_CreateTexture(sdlRenderer, SDL_PIXELFORMAT_RGBA8888, SDL_TEXTUREACCESS_TARGET, width, height);
+  if (scene_texture_ == nullptr) {
+    Logger::Error("Renderer::CreateScene SDL_CreateTexture failed: " + std::string(SDL_GetError()));
+    return false;
+  }
+  return true;
+}
+
+void Renderer::DestroyScene() {
+  if (scene_texture_ != nullptr) {
+    SDL_DestroyTexture(scene_texture_);
+    scene_texture_ = nullptr;
+  }
+}
+
+void Renderer::BeginScene(SDL_Renderer* sdlRenderer) const {
+  SDL_SetRenderTarget(sdlRenderer, scene_texture_);
+  SDL_SetRenderDrawColor(sdlRenderer, kSceneClearGrey, kSceneClearGrey, kSceneClearGrey, Constants::kUint8Max);
+  SDL_RenderClear(sdlRenderer);
+}
+
+void Renderer::EndScene(SDL_Renderer* sdlRenderer) const {
+  SDL_SetRenderTarget(sdlRenderer, nullptr);
+  SDL_SetRenderDrawColor(sdlRenderer, kWindowClearBlack, kWindowClearBlack, kWindowClearBlack, Constants::kUint8Max);
+  SDL_RenderClear(sdlRenderer);
+}
+
+void Renderer::CompositeSceneToWindow(SDL_Renderer* sdlRenderer) const {
+  if (scene_texture_ != nullptr) {
+    SDL_RenderTexture(sdlRenderer, scene_texture_, nullptr, nullptr);
+  }
+}
+
+void Renderer::Present(SDL_Renderer* sdlRenderer) const { SDL_RenderPresent(sdlRenderer); }
+
+void Renderer::DrawQueue(const RenderQueue& renderQueue, SDL_Renderer* renderer) const {
   for (const RenderKey& key : renderQueue) {
     switch (key.type) {
       case SPRITE: {

--- a/src/Renderer/Renderer.h
+++ b/src/Renderer/Renderer.h
@@ -2,25 +2,64 @@
 
 #include <SDL3/SDL.h>
 
-#include <string>
-#include <unordered_map>
-
 #include "../AssetManager/AssetManager.h"
 #include "./RenderQueue.h"
 
 class Registry;
 
+// Owns the off-screen scene target the game renders into each frame, plus the SDL_RenderTarget
+// switches + present. Game::Render orchestrates the phases (BeginScene / DrawQueue / EndScene /
+// CompositeSceneToWindow / Present) instead of calling SDL_Set*RenderTarget itself; the engine
+// keeps `SDL_SetRenderTarget` contained to this TU.
+//
+// The scene texture is sized to the window at creation time. Lifetime tracks the SDL renderer:
+// Game::Initialize calls CreateScene after the renderer exists; Game::Destroy calls DestroyScene
+// before SDL_DestroyRenderer. Re-creation on window resize is a follow-up — the existing
+// behavior keeps the original window-size target and lets SDL letterbox it.
 class Renderer {
  public:
   Renderer() = default;
+  ~Renderer() = default;
 
   Renderer(const Renderer&) = delete;
   Renderer& operator=(const Renderer&) = delete;
-
   Renderer(Renderer&&) = delete;
   Renderer& operator=(Renderer&&) = delete;
 
-  ~Renderer() = default;
+  // Allocate the scene render target. Must run after SDL_CreateRenderer. Returns false (and
+  // leaves the renderer in a no-scene state) when SDL_CreateTexture fails — caller logs.
+  bool CreateScene(SDL_Renderer* sdlRenderer, int width, int height);
 
-  void Render(const RenderQueue& renderQueue, SDL_Renderer* renderer) const;
+  // Destroy the scene texture. Idempotent; safe to call when CreateScene never ran or failed.
+  // Must run before SDL_DestroyRenderer.
+  void DestroyScene();
+
+  // Phase 1: bind the scene texture as the render target and clear to the engine's scene-bg
+  // grey. Subsequent DrawQueue / per-frame draw calls land in the scene texture.
+  void BeginScene(SDL_Renderer* sdlRenderer) const;
+
+  // Phase 2: walk a sorted RenderQueue and dispatch each command to SDL_Render*. Texture/font
+  // resolution happens in the producer systems (cmd.texture is already a live handle).
+  void DrawQueue(const RenderQueue& renderQueue, SDL_Renderer* sdlRenderer) const;
+
+  // Phase 3: unbind the scene texture (RT becomes the window backbuffer) and clear that
+  // backbuffer to black. The editor/debug UI + final composite draw on top of the cleared
+  // backbuffer.
+  void EndScene(SDL_Renderer* sdlRenderer) const;
+
+  // Player-build composite: blit the full scene texture into the window backbuffer. Editor
+  // builds skip this — the Scene window inside ImGui draws the scene texture itself, so
+  // composing it to the window again would double-draw.
+  void CompositeSceneToWindow(SDL_Renderer* sdlRenderer) const;
+
+  // Phase 4: flip. SDL_RenderPresent stays inside Renderer so the engine has exactly one
+  // present site per frame.
+  void Present(SDL_Renderer* sdlRenderer) const;
+
+  // Hand the editor / RenderDebugGUI access to the texture they composite into the Scene
+  // window. Returns nullptr when CreateScene never ran (headless / bake / pre-Init paths).
+  [[nodiscard]] SDL_Texture* GetSceneTexture() const { return scene_texture_; }
+
+ private:
+  SDL_Texture* scene_texture_ = nullptr;
 };

--- a/src/Renderer/SpriteRenderCache.h
+++ b/src/Renderer/SpriteRenderCache.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <SDL3/SDL.h>
+
+#include <cstdint>
+#include <unordered_map>
+
+#include "ECS/Entity.h"
+
+// Render-side cache mapping Entity -> last-resolved SDL_Texture* + atlas-slice origin + the
+// AssetManager texture-generation the values were resolved against. Lives in the render layer
+// so SpriteComponent stays POD (no SDL handles in game data). For atlas-packed assets, the
+// slice origin is added to the sprite's logical srcRect during emit so the same script-level
+// (sx, sy) selects inside the packed atlas; loose textures leave the offset zero (no-op add).
+//
+// Single-threaded: callers must serialize Store/Forget/Clear. RenderSpriteSystem warms the
+// cache in a serial Prepare pass and reads it in the parallel emit pass — never inserts under
+// ParallelForEach because std::unordered_map cannot tolerate concurrent writes.
+class SpriteRenderCache {
+ public:
+  struct Entry {
+    SDL_Texture* texture = nullptr;
+    SDL_FRect atlasOffset{};
+    std::uint64_t generation = 0;
+  };
+
+  // Returns the cached entry pointer iff present and generation matches; nullptr otherwise.
+  // Caller resolves + Store()s on a miss (warm-pass only — emit is read-only).
+  [[nodiscard]] const Entry* Lookup(Entity entity, std::uint64_t currentGen) const {
+    if (const auto it = entries_.find(entity.GetId()); it != entries_.end() && it->second.generation == currentGen) {
+      return &it->second;
+    }
+    return nullptr;
+  }
+
+  void Store(Entity entity, SDL_Texture* texture, SDL_FRect atlasOffset, std::uint64_t generation) {
+    entries_[entity.GetId()] = {texture, atlasOffset, generation};
+  }
+
+  void Forget(Entity entity) { entries_.erase(entity.GetId()); }
+
+  void Clear() { entries_.clear(); }
+
+ private:
+  std::unordered_map<EcsId, Entry> entries_;
+};

--- a/src/Systems/AnimationSystem.h
+++ b/src/Systems/AnimationSystem.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <SDL3/SDL.h>
+#include <cmath>
 
 #include "../Components/AnimationComponent.h"
 #include "../Components/SpriteComponent.h"

--- a/src/Systems/AudioSystem.cpp
+++ b/src/Systems/AudioSystem.cpp
@@ -70,8 +70,8 @@ bool AudioSystem::Init(Registry* registry, const std::unique_ptr<EventBus>& even
         }
     }
 
-    registry_->Set<MIX_Mixer*>(mixer);
-
+    // Mixer is published onto EngineContext by Game::Setup once Init returns; AudioSystem owns
+    // the pointer and exposes it via Mixer() so callers don't need a Registry round-trip.
     eventBus->SubscribeEvent<AudioSystem, AudioPlayEvent>(this, &AudioSystem::OnAudioPlay);
 
     Logger::Info("AudioSystem initialized; track pool size = " + std::to_string(state_->track_pool.size()) +

--- a/src/Systems/CollisionSystem.h
+++ b/src/Systems/CollisionSystem.h
@@ -13,6 +13,7 @@
 #include "../ECS/Entity.h"
 #include "../ECS/Iterable.h"
 #include "../ECS/Registry.h"
+#include "../Engine/EngineContext.h"
 #include "../EventBus/EventBus.h"
 #include "../Events/CollisionEvent.h"
 #include "General/PerfUtils.h"
@@ -91,7 +92,7 @@ class CollisionSystem {
     PROFILE_NAMED_SCOPE("Collision System Update");
 
     auto* registry = ctx.GetRegistry();
-    auto* eventBus = registry->Get<EventBus*>();
+    auto* eventBus = registry->Get<EngineContext>().eventBus;
 
     if (collisionResult_.valid() &&
         collisionResult_.wait_for(std::chrono::milliseconds(0)) != std::future_status::ready) {

--- a/src/Systems/DrawColliderSystem.h
+++ b/src/Systems/DrawColliderSystem.h
@@ -6,6 +6,7 @@
 
 #include "../Components/BoxColliderComponent.h"
 #include "../Components/GlobalTransformComponent.h"
+#include "../Engine/EngineContext.h"
 #include "../General/Constants.h"
 #include "Components/CameraComponents.h"
 #include "ECS/Iterable.h"
@@ -15,7 +16,7 @@ class DrawColliderSystem {
  public:
   void operator()(const ContextFacade& context, const GlobalTransformComponent& transform,
                   const BoxColliderComponent& collider) const {
-    auto* renderer = context.GetRegistry()->Get<SDL_Renderer*>();
+    auto* renderer = context.GetRegistry()->Get<EngineContext>().sdlRenderer;
     const auto& camera = context.GetRegistry()->Get<CameraComponent>().viewport;
 
     const float w = static_cast<float>(collider.width) * transform.scale.x;

--- a/src/Systems/InputSystem.cpp
+++ b/src/Systems/InputSystem.cpp
@@ -1,0 +1,233 @@
+#include "Systems/InputSystem.h"
+
+#include <SDL3/SDL.h>
+
+#include <glm/glm.hpp>
+#include <string>
+
+#include "Components/ViewportInfo.h"
+#include "Game/GameConfig.h"
+
+void InputSystem::BeginFrame()
+{
+    float mx = 0.0f;
+    float my = 0.0f;
+    SDL_GetMouseState(&mx, &my);
+
+    if (registry_)
+    {
+        const auto& viewport = registry_->Get<ViewportInfo>();
+        const auto& config = registry_->Get<GameConfig>();
+        const glm::vec2 transformed =
+            viewport.TransformCoordinates(mx, my, config.windowWidth, config.windowHeight);
+        mouseX_ = transformed.x;
+        mouseY_ = transformed.y;
+    }
+    else
+    {
+        mouseX_ = mx;
+        mouseY_ = my;
+    }
+}
+
+#ifdef OCTARINE_WITH_EDITOR
+bool InputSystem::ShouldLogInput() const
+{
+    return registry_ && registry_->Get<GameConfig>().GetEngineOptions().logInputEvents;
+}
+#endif
+
+void InputSystem::OnKeyInput(const KeyInputEvent& event)
+{
+    if (registry_ && event.isPressed)
+    {
+        const auto& viewport = registry_->Get<ViewportInfo>();
+        if (!viewport.isFocused)
+        {
+            return;
+        }
+    }
+
+    const std::string key = MakeKey(SDL_GetKeyName(event.inputKey));
+#ifdef OCTARINE_WITH_EDITOR
+    if (ShouldLogInput())
+    {
+        Logger::Info("[input] key " + std::string(event.isPressed ? "down" : "up") + ": " + key);
+    }
+#endif
+    if (event.isPressed)
+    {
+        if (heldKeys_.find(key) == heldKeys_.end())
+        {
+            pressedKeys_.insert(key);
+            Dispatch(onKeyDown_, key);
+        }
+        heldKeys_.insert(key);
+    }
+    else
+    {
+        heldKeys_.erase(key);
+        pressedKeys_.erase(key);
+        releasedKeys_.insert(key);
+        Dispatch(onKeyUp_, key);
+    }
+}
+
+void InputSystem::OnMouseInput(const MouseInputEvent& event)
+{
+    if (registry_ && (event.event.type == SDL_EVENT_MOUSE_BUTTON_DOWN))
+    {
+        const auto& viewport = registry_->Get<ViewportInfo>();
+        if (!viewport.isHovered)
+        {
+            return;
+        }
+    }
+
+    const int btn = static_cast<int>(event.event.button);
+    float x = event.event.x;
+    float y = event.event.y;
+
+    if (registry_)
+    {
+        const auto& viewport = registry_->Get<ViewportInfo>();
+        const auto& config = registry_->Get<GameConfig>();
+        const glm::vec2 transformed = viewport.TransformCoordinates(x, y, config.windowWidth, config.windowHeight);
+        x = transformed.x;
+        y = transformed.y;
+    }
+
+#ifdef OCTARINE_WITH_EDITOR
+    if (ShouldLogInput())
+    {
+        const bool down = event.event.type == SDL_EVENT_MOUSE_BUTTON_DOWN;
+        Logger::Info("[input] mouse " + std::string(down ? "down" : "up") + " btn " + std::to_string(btn) + " at (" +
+            std::to_string(x) + ", " + std::to_string(y) + ")");
+    }
+#endif
+
+    if (event.event.type == SDL_EVENT_MOUSE_BUTTON_DOWN)
+    {
+        if (heldMouseButtons_.find(btn) == heldMouseButtons_.end())
+        {
+            pressedMouseButtons_.insert(btn);
+            Dispatch(onMouseDown_, btn, x, y);
+        }
+        heldMouseButtons_.insert(btn);
+    }
+    else if (event.event.type == SDL_EVENT_MOUSE_BUTTON_UP)
+    {
+        heldMouseButtons_.erase(btn);
+        pressedMouseButtons_.erase(btn);
+        releasedMouseButtons_.insert(btn);
+        Dispatch(onMouseUp_, btn, x, y);
+    }
+}
+
+void InputSystem::OnMouseWheel(const MouseWheelEvent& event)
+{
+    if (registry_)
+    {
+        const auto& viewport = registry_->Get<ViewportInfo>();
+        if (!viewport.isHovered)
+        {
+            return;
+        }
+    }
+
+#ifdef OCTARINE_WITH_EDITOR
+    if (ShouldLogInput())
+    {
+        Logger::Info("[input] wheel " + std::to_string(event.dx) + ", " + std::to_string(event.dy));
+    }
+#endif
+
+    wheelDx_ += event.dx;
+    wheelDy_ += event.dy;
+    Dispatch(onMouseWheel_, event.dx, event.dy);
+}
+
+bool InputSystem::IsKeyDown(const std::string& key) const
+{
+    if (registry_ && !registry_->Get<ViewportInfo>().isFocused) return false;
+    return MatchesSet(key, heldKeys_);
+}
+
+bool InputSystem::IsKeyPressed(const std::string& key) const
+{
+    if (registry_ && !registry_->Get<ViewportInfo>().isFocused) return false;
+    return MatchesSet(key, pressedKeys_);
+}
+
+bool InputSystem::IsKeyReleased(const std::string& key) const
+{
+    if (registry_ && !registry_->Get<ViewportInfo>().isFocused) return false;
+    return MatchesSet(key, releasedKeys_);
+}
+
+bool InputSystem::MatchesSet(const std::string& key, const std::unordered_set<std::string>& set) const
+{
+    if (key.empty()) return false;
+    const std::string lower = MakeKey(key);
+    if (const auto it = keyAliases_.find(lower); it != keyAliases_.end())
+    {
+        for (const auto& alias : it->second)
+        {
+            if (set.find(alias) != set.end()) return true;
+        }
+    }
+    return set.find(lower) != set.end();
+}
+
+bool InputSystem::IsMouseDown(const int btn) const
+{
+    if (registry_ && !registry_->Get<ViewportInfo>().isHovered) return false;
+    return btn > 0 && heldMouseButtons_.find(btn) != heldMouseButtons_.end();
+}
+
+bool InputSystem::IsMousePressed(const int btn) const
+{
+    if (registry_ && !registry_->Get<ViewportInfo>().isHovered) return false;
+    return btn > 0 && pressedMouseButtons_.find(btn) != pressedMouseButtons_.end();
+}
+
+bool InputSystem::IsMouseReleased(const int btn) const
+{
+    if (registry_ && !registry_->Get<ViewportInfo>().isHovered) return false;
+    return btn > 0 && releasedMouseButtons_.find(btn) != releasedMouseButtons_.end();
+}
+
+void InputSystem::Bind(const std::string& action, const std::string& key)
+{
+    auto& keys = actions_[action];
+    const std::string lower = MakeKey(key);
+    if (std::find(keys.begin(), keys.end(), lower) == keys.end())
+    {
+        keys.push_back(lower);
+    }
+}
+
+void InputSystem::Unbind(const std::string& action, const std::string& key)
+{
+    const auto it = actions_.find(action);
+    if (it == actions_.end()) return;
+    const std::string lower = MakeKey(key);
+    auto& keys = it->second;
+    keys.erase(std::remove(keys.begin(), keys.end(), lower), keys.end());
+    if (keys.empty()) actions_.erase(it);
+}
+
+bool InputSystem::IsActionDown(const std::string& action) const
+{
+    return AnyBoundKey(action, [this](const std::string& k) { return IsKeyDown(k); });
+}
+
+bool InputSystem::IsActionPressed(const std::string& action) const
+{
+    return AnyBoundKey(action, [this](const std::string& k) { return IsKeyPressed(k); });
+}
+
+bool InputSystem::IsActionReleased(const std::string& action) const
+{
+    return AnyBoundKey(action, [this](const std::string& k) { return IsKeyReleased(k); });
+}

--- a/src/Systems/InputSystem.h
+++ b/src/Systems/InputSystem.h
@@ -4,7 +4,6 @@
 
 #include <algorithm>
 #include <cctype>
-#include <glm/glm.hpp>
 #include <memory>
 #include <sol/sol.hpp>
 #include <string>
@@ -12,15 +11,24 @@
 #include <unordered_set>
 #include <vector>
 
-#include "../Components/ViewportInfo.h"
 #include "../ECS/Registry.h"
 #include "../EventBus/EventBus.h"
 #include "../Events/KeyInputEvent.h"
 #include "../Events/MouseInputEvent.h"
 #include "../Events/MouseWheelEvent.h"
-#include "../Game/GameConfig.h"
 #include "../General/Logger.h"
 
+// Per-frame input state machine: held/pressed/released sets for keys + mouse buttons, accumulated
+// mouse wheel delta, action map (named action → list of keys), and the script-installed
+// callback vectors that fire on each edge. EventBus subscriptions feed OnKeyInput / OnMouseInput
+// / OnMouseWheel; the Lua `input.*` surface (is_key_*, on_key_*, bind, etc.) lives in
+// `Lua/Bindings/InputSystemLuaBinding.cpp` — InputSystem just exposes the public accessors +
+// mutators that binding's lambdas call into.
+//
+// FOLLOW-UP: the sol::protected_function callback vectors still force this header to pull in
+// <sol/sol.hpp>. Closing that out cleanly needs a PImpl-style InputSystemLuaCallbacks struct
+// (declared here, defined in InputSystem.cpp) which is more surgery than this stage is scoped
+// for. Tracked alongside ArchitectureImprovementsPlan's broader header-sol cleanup.
 class InputSystem
 {
 public:
@@ -48,28 +56,9 @@ public:
     }
 
     // Called near the top of Game::Update so polling APIs see a fresh cursor position
-    // for systems that run this frame.
-    void BeginFrame()
-    {
-        float mx = 0.0f;
-        float my = 0.0f;
-        SDL_GetMouseState(&mx, &my);
-
-        if (registry_)
-        {
-            const auto& viewport = registry_->Get<ViewportInfo>();
-            const auto& config = registry_->Get<GameConfig>();
-            const glm::vec2 transformed = viewport.
-                TransformCoordinates(mx, my, config.windowWidth, config.windowHeight);
-            mouseX_ = transformed.x;
-            mouseY_ = transformed.y;
-        }
-        else
-        {
-            mouseX_ = mx;
-            mouseY_ = my;
-        }
-    }
+    // for systems that run this frame. Reads viewport + window dims to map raw SDL coords
+    // to game-space (editor's scene-window pan/zoom would alias raw coords).
+    void BeginFrame();
 
     // Called at the end of Game::Update — pressed/released are per-frame edges, wheel
     // delta is a per-frame accumulator.
@@ -106,176 +95,42 @@ public:
 #ifdef OCTARINE_WITH_EDITOR
     // Editor-only diagnostic logging for input events. Gated behind EngineOptions::logInputEvents so it
     // stays quiet until someone is actually debugging input. Compiled out entirely in player builds.
-    [[nodiscard]] bool ShouldLogInput() const
-    {
-        return registry_ && registry_->Get<GameConfig>().GetEngineOptions().logInputEvents;
-    }
+    [[nodiscard]] bool ShouldLogInput() const;
 #endif
 
-    void CreateLuaBindings(sol::state& lua)
-    {
-        lua["input"] = lua.create_table();
-        sol::table input = lua["input"];
+    // Accessors used by Lua/Bindings/InputSystemLuaBinding.cpp. Plain getters / mutators so the
+    // binding lambdas can read state and append callbacks without poking at internals directly.
+    [[nodiscard]] Registry* GetRegistry() const { return registry_; }
+    [[nodiscard]] float MouseX() const { return mouseX_; }
+    [[nodiscard]] float MouseY() const { return mouseY_; }
+    [[nodiscard]] float WheelDx() const { return wheelDx_; }
+    [[nodiscard]] float WheelDy() const { return wheelDy_; }
 
-        input.set_function("is_key_down", [this](const std::string& name) { return IsKeyDown(name); });
-        input.set_function("is_key_pressed", [this](const std::string& name) { return IsKeyPressed(name); });
-        input.set_function("is_key_released", [this](const std::string& name) { return IsKeyReleased(name); });
+    [[nodiscard]] bool IsKeyDown(const std::string& key) const;
+    [[nodiscard]] bool IsKeyPressed(const std::string& key) const;
+    [[nodiscard]] bool IsKeyReleased(const std::string& key) const;
+    [[nodiscard]] bool IsMouseDown(int btn) const;
+    [[nodiscard]] bool IsMousePressed(int btn) const;
+    [[nodiscard]] bool IsMouseReleased(int btn) const;
+    [[nodiscard]] bool IsActionDown(const std::string& action) const;
+    [[nodiscard]] bool IsActionPressed(const std::string& action) const;
+    [[nodiscard]] bool IsActionReleased(const std::string& action) const;
 
-        input.set_function("is_mouse_down", [this](sol::object btn) { return IsMouseDown(ToMouseButton(btn)); });
-        input.set_function("is_mouse_pressed", [this](sol::object btn) { return IsMousePressed(ToMouseButton(btn)); });
-        input.set_function("is_mouse_released", [this](sol::object btn)
-        {
-            return IsMouseReleased(ToMouseButton(btn));
-        });
-        input.set_function("is_hovered", [this]()
-        {
-            return registry_ ? registry_->Get<ViewportInfo>().isHovered : true;
-        });
-        input.set_function("is_focused", [this]()
-        {
-            return registry_ ? registry_->Get<ViewportInfo>().isFocused : true;
-        });
-        input.set_function("mouse_position", [this]() { return glm::vec2(mouseX_, mouseY_); });
-        input.set_function("mouse_wheel", [this]() { return glm::vec2(wheelDx_, wheelDy_); });
+    void Bind(const std::string& action, const std::string& key);
+    void Unbind(const std::string& action, const std::string& key);
+    // Clear all bindings for an action; the Lua `input.unbind(action)` form (no key arg) maps to this.
+    void UnbindAction(const std::string& action) { actions_.erase(action); }
 
-        input.set_function("bind", [this](const std::string& action, const std::string& key) { Bind(action, key); });
-        input.set_function("unbind", [this](const std::string& action, sol::optional<std::string> key)
-        {
-            if (key)
-            {
-                Unbind(action, *key);
-            }
-            else
-            {
-                actions_.erase(action);
-            }
-        });
-        input.set_function("is_action_down", [this](const std::string& a) { return IsActionDown(a); });
-        input.set_function("is_action_pressed", [this](const std::string& a) { return IsActionPressed(a); });
-        input.set_function("is_action_released", [this](const std::string& a) { return IsActionReleased(a); });
-
-        input.set_function("on_key_down", [this](sol::protected_function fn) { onKeyDown_.push_back(std::move(fn)); });
-        input.set_function("on_key_up", [this](sol::protected_function fn) { onKeyUp_.push_back(std::move(fn)); });
-        input.set_function("on_mouse_down", [this](sol::protected_function fn)
-        {
-            onMouseDown_.push_back(std::move(fn));
-        });
-        input.set_function("on_mouse_up", [this](sol::protected_function fn) { onMouseUp_.push_back(std::move(fn)); });
-        input.set_function("on_mouse_wheel",
-                           [this](sol::protected_function fn) { onMouseWheel_.push_back(std::move(fn)); });
-    }
+    void AddOnKeyDown(sol::protected_function fn) { onKeyDown_.push_back(std::move(fn)); }
+    void AddOnKeyUp(sol::protected_function fn) { onKeyUp_.push_back(std::move(fn)); }
+    void AddOnMouseDown(sol::protected_function fn) { onMouseDown_.push_back(std::move(fn)); }
+    void AddOnMouseUp(sol::protected_function fn) { onMouseUp_.push_back(std::move(fn)); }
+    void AddOnMouseWheel(sol::protected_function fn) { onMouseWheel_.push_back(std::move(fn)); }
 
 private:
-    void OnKeyInput(const KeyInputEvent& event)
-    {
-        if (registry_ && event.isPressed)
-        {
-            const auto& viewport = registry_->Get<ViewportInfo>();
-            if (!viewport.isFocused)
-            {
-                return;
-            }
-        }
-
-        const std::string key = MakeKey(SDL_GetKeyName(event.inputKey));
-#ifdef OCTARINE_WITH_EDITOR
-        if (ShouldLogInput())
-        {
-            Logger::Info("[input] key " + std::string(event.isPressed ? "down" : "up") + ": " + key);
-        }
-#endif
-        if (event.isPressed)
-        {
-            if (heldKeys_.find(key) == heldKeys_.end())
-            {
-                pressedKeys_.insert(key);
-                Dispatch(onKeyDown_, key);
-            }
-            heldKeys_.insert(key);
-        }
-        else
-        {
-            heldKeys_.erase(key);
-            pressedKeys_.erase(key);
-            releasedKeys_.insert(key);
-            Dispatch(onKeyUp_, key);
-        }
-    }
-
-    void OnMouseInput(const MouseInputEvent& event)
-    {
-        if (registry_ && (event.event.type == SDL_EVENT_MOUSE_BUTTON_DOWN))
-        {
-            const auto& viewport = registry_->Get<ViewportInfo>();
-            if (!viewport.isHovered)
-            {
-                return;
-            }
-        }
-
-        const int btn = static_cast<int>(event.event.button);
-        float x = event.event.x;
-        float y = event.event.y;
-
-        if (registry_)
-        {
-            const auto& viewport = registry_->Get<ViewportInfo>();
-            const auto& config = registry_->Get<GameConfig>();
-            const glm::vec2 transformed = viewport.TransformCoordinates(x, y, config.windowWidth, config.windowHeight);
-            x = transformed.x;
-            y = transformed.y;
-        }
-
-#ifdef OCTARINE_WITH_EDITOR
-        if (ShouldLogInput())
-        {
-            const bool down = event.event.type == SDL_EVENT_MOUSE_BUTTON_DOWN;
-            Logger::Info(
-                "[input] mouse " + std::string(down ? "down" : "up") + " btn " + std::to_string(btn) + " at (" +
-                std::to_string(x) + ", " + std::to_string(y) + ")");
-        }
-#endif
-
-        if (event.event.type == SDL_EVENT_MOUSE_BUTTON_DOWN)
-        {
-            if (heldMouseButtons_.find(btn) == heldMouseButtons_.end())
-            {
-                pressedMouseButtons_.insert(btn);
-                Dispatch(onMouseDown_, btn, x, y);
-            }
-            heldMouseButtons_.insert(btn);
-        }
-        else if (event.event.type == SDL_EVENT_MOUSE_BUTTON_UP)
-        {
-            heldMouseButtons_.erase(btn);
-            pressedMouseButtons_.erase(btn);
-            releasedMouseButtons_.insert(btn);
-            Dispatch(onMouseUp_, btn, x, y);
-        }
-    }
-
-    void OnMouseWheel(const MouseWheelEvent& event)
-    {
-        if (registry_)
-        {
-            const auto& viewport = registry_->Get<ViewportInfo>();
-            if (!viewport.isHovered)
-            {
-                return;
-            }
-        }
-
-#ifdef OCTARINE_WITH_EDITOR
-        if (ShouldLogInput())
-        {
-            Logger::Info("[input] wheel " + std::to_string(event.dx) + ", " + std::to_string(event.dy));
-        }
-#endif
-
-        wheelDx_ += event.dx;
-        wheelDy_ += event.dy;
-        Dispatch(onMouseWheel_, event.dx, event.dy);
-    }
+    void OnKeyInput(const KeyInputEvent& event);
+    void OnMouseInput(const MouseInputEvent& event);
+    void OnMouseWheel(const MouseWheelEvent& event);
 
     template <typename... Args>
     static void Dispatch(const std::vector<sol::protected_function>& fns, Args&&... args)
@@ -292,105 +147,7 @@ private:
         }
     }
 
-    [[nodiscard]] bool IsKeyDown(const std::string& key) const
-    {
-        if (registry_ && !registry_->Get<ViewportInfo>().isFocused) return false;
-        return MatchesSet(key, heldKeys_);
-    }
-
-    [[nodiscard]] bool IsKeyPressed(const std::string& key) const
-    {
-        if (registry_ && !registry_->Get<ViewportInfo>().isFocused) return false;
-        return MatchesSet(key, pressedKeys_);
-    }
-
-    [[nodiscard]] bool IsKeyReleased(const std::string& key) const
-    {
-        if (registry_ && !registry_->Get<ViewportInfo>().isFocused) return false;
-        return MatchesSet(key, releasedKeys_);
-    }
-
-    [[nodiscard]] bool MatchesSet(const std::string& key, const std::unordered_set<std::string>& set) const
-    {
-        if (key.empty()) return false;
-        const std::string lower = MakeKey(key);
-        if (const auto it = keyAliases_.find(lower); it != keyAliases_.end())
-        {
-            for (const auto& alias : it->second)
-            {
-                if (set.find(alias) != set.end()) return true;
-            }
-        }
-        return set.find(lower) != set.end();
-    }
-
-    [[nodiscard]] bool IsMouseDown(const int btn) const
-    {
-        if (registry_ && !registry_->Get<ViewportInfo>().isHovered) return false;
-        return btn > 0 && heldMouseButtons_.find(btn) != heldMouseButtons_.end();
-    }
-
-    [[nodiscard]] bool IsMousePressed(const int btn) const
-    {
-        if (registry_ && !registry_->Get<ViewportInfo>().isHovered) return false;
-        return btn > 0 && pressedMouseButtons_.find(btn) != pressedMouseButtons_.end();
-    }
-
-    [[nodiscard]] bool IsMouseReleased(const int btn) const
-    {
-        if (registry_ && !registry_->Get<ViewportInfo>().isHovered) return false;
-        return btn > 0 && releasedMouseButtons_.find(btn) != releasedMouseButtons_.end();
-    }
-
-    static int ToMouseButton(const sol::object& btn)
-    {
-        if (btn.is<int>()) return btn.as<int>();
-        if (btn.is<std::string>())
-        {
-            const std::string name = MakeKey(btn.as<std::string>());
-            if (name == "left") return SDL_BUTTON_LEFT;
-            if (name == "middle") return SDL_BUTTON_MIDDLE;
-            if (name == "right") return SDL_BUTTON_RIGHT;
-            if (name == "x1") return SDL_BUTTON_X1;
-            if (name == "x2") return SDL_BUTTON_X2;
-        }
-        return 0;
-    }
-
-    void Bind(const std::string& action, const std::string& key)
-    {
-        auto& keys = actions_[action];
-        const std::string lower = MakeKey(key);
-        if (std::find(keys.begin(), keys.end(), lower) == keys.end())
-        {
-            keys.push_back(lower);
-        }
-    }
-
-    void Unbind(const std::string& action, const std::string& key)
-    {
-        const auto it = actions_.find(action);
-        if (it == actions_.end()) return;
-        const std::string lower = MakeKey(key);
-        auto& keys = it->second;
-        keys.erase(std::remove(keys.begin(), keys.end(), lower), keys.end());
-        if (keys.empty()) actions_.erase(it);
-    }
-
-    [[nodiscard]] bool IsActionDown(const std::string& action) const
-    {
-        return AnyBoundKey(action, [this](const std::string& k) { return IsKeyDown(k); });
-    }
-
-    [[nodiscard]] bool IsActionPressed(const std::string& action) const
-    {
-        return AnyBoundKey(action, [this](const std::string& k) { return IsKeyPressed(k); });
-    }
-
-    [[nodiscard]] bool IsActionReleased(const std::string& action) const
-    {
-        return AnyBoundKey(action, [this](const std::string& k) { return IsKeyReleased(k); });
-    }
+    [[nodiscard]] bool MatchesSet(const std::string& key, const std::unordered_set<std::string>& set) const;
 
     template <typename Pred>
     bool AnyBoundKey(const std::string& action, Pred&& pred) const

--- a/src/Systems/ObstacleBounceSystem.h
+++ b/src/Systems/ObstacleBounceSystem.h
@@ -8,6 +8,7 @@
 #include "../ECS/Registry.h"
 #include "../EventBus/EventBus.h"
 #include "../Events/CollisionEvent.h"
+#include "../General/SpriteFlip.h"
 
 class ObstacleBounceSystem {
  public:
@@ -37,7 +38,8 @@ class ObstacleBounceSystem {
 
     if (registry_->HasComponent<SpriteComponent>(enemy)) {
       auto& sprite = registry_->GetComponent<SpriteComponent>(enemy);
-      sprite.flip = sprite.flip == SDL_FLIP_NONE ? SDL_FLIP_HORIZONTAL : SDL_FLIP_NONE;
+      sprite.flip =
+          sprite.flip == octarine::SpriteFlip::None ? octarine::SpriteFlip::Horizontal : octarine::SpriteFlip::None;
     }
   }
 

--- a/src/Systems/RenderPrimitiveSystem.h
+++ b/src/Systems/RenderPrimitiveSystem.h
@@ -1,12 +1,11 @@
 #pragma once
 
-#include <SDL3/SDL.h>
-
 #include <atomic>
 
 #include "../Components/GlobalTransformComponent.h"
 #include "../Components/SquarePrimitiveComponent.h"
 #include "../General/PerfUtils.h"
+#include "../General/Rect.h"
 #include "../Renderer/RenderCulling.h"
 #include "../Renderer/RenderQueue.h"
 #include "Components/CameraComponents.h"
@@ -45,7 +44,7 @@ class RenderPrimitiveSystem {
 
     auto& cmd = renderQueue_->EmplaceSquare(static_cast<unsigned int>(square.layer), square.position.y);
     cmd.destRect = {x, y, square.width, square.height};
-    cmd.color = square.color;
+    cmd.color = SDL_Color{square.color.r, square.color.g, square.color.b, square.color.a};
     cmd.rotation = transform.rotation;
   }
 
@@ -53,7 +52,7 @@ class RenderPrimitiveSystem {
   RenderQueue* renderQueue_ = nullptr;
   float windowWidth_ = 0;
   float windowHeight_ = 0;
-  SDL_FRect camera_{};
+  octarine::Rect camera_{};
 #ifdef OCTARINE_PROFILING
   std::atomic<long long>* culledCounter_ = nullptr;
   std::atomic<long long>* emplacedCounter_ = nullptr;

--- a/src/Systems/RenderSpriteSystem.h
+++ b/src/Systems/RenderSpriteSystem.h
@@ -3,15 +3,21 @@
 #include <SDL3/SDL.h>
 
 #include <atomic>
+#include <memory>
+#include <optional>
 
-#include "../AssetManager/AssetManager.h"
-#include "../Components/GlobalTransformComponent.h"
-#include "../Components/SpriteComponent.h"
-#include "../General/PerfUtils.h"
-#include "../Renderer/RenderCulling.h"
-#include "../Renderer/RenderQueue.h"
+#include "AssetManager/AssetManager.h"
+#include "Components/GlobalTransformComponent.h"
+#include "Components/SpriteComponent.h"
+#include "ECS/Query.h"
 #include "ECS/Registry.h"
 #include "Game/GameConfig.h"
+#include "General/PerfUtils.h"
+#include "General/Rect.h"
+#include "General/SpriteFlip.h"
+#include "Renderer/RenderCulling.h"
+#include "Renderer/RenderQueue.h"
+#include "Renderer/SpriteRenderCache.h"
 
 class RenderSpriteSystem {
  public:
@@ -20,15 +26,35 @@ class RenderSpriteSystem {
     camera_ = registry->Get<CameraComponent>().viewport;
     assetManager_ = &registry->Get<AssetManager>();
     renderQueue_ = &registry->Get<RenderQueue>();
+    spriteCache_ = &registry->Get<SpriteRenderCache>();
     windowWidth_ = static_cast<float>(gameConfig.windowWidth);
     windowHeight_ = static_cast<float>(gameConfig.windowHeight);
+
+    // Single-threaded cache warm: walk every sprite entity once and resolve the SDL_Texture* +
+    // atlas slice now. operator() (which runs in parallel via ParallelForEach) then does a
+    // race-free read-only Lookup. SpriteRenderCache is an std::unordered_map and cannot tolerate
+    // concurrent inserts.
+    if (!warmingQuery_) {
+      warmingQuery_ = registry->CreateQuery<SpriteComponent>();
+    }
+    warmingQuery_->Update();
+    const auto assetGen = assetManager_->TextureGeneration();
+    warmingQuery_->ForEach([this, assetGen](Entity entity, const SpriteComponent& sprite) {
+      if (spriteCache_->Lookup(entity, assetGen) == nullptr) {
+        SDL_Texture* texture = assetManager_->GetTexture(sprite.assetId);
+        const auto slice = assetManager_->GetAtlasSlice(sprite.assetId);
+        const SDL_FRect atlasOffset = slice.has_value() ? *slice : SDL_FRect{0, 0, 0, 0};
+        spriteCache_->Store(entity, texture, atlasOffset, assetGen);
+      }
+    });
+
 #ifdef OCTARINE_PROFILING
     if (!culledCounter_) culledCounter_ = PROFILE_COUNTER_HANDLE("RenderSprite: Culled");
     if (!emplacedCounter_) emplacedCounter_ = PROFILE_COUNTER_HANDLE("RenderSprite: Emplaced");
 #endif
   }
 
-  void operator()(const GlobalTransformComponent& transform, const SpriteComponent& sprite) const {
+  void operator()(Entity entity, const GlobalTransformComponent& transform, const SpriteComponent& sprite) const {
     const bool isOutsideCamera = IsRenderableOutsideViewport(
         transform.position.x, transform.position.y, sprite.width * transform.scale.x,
         sprite.height * transform.scale.y, sprite.isFixed, camera_, windowWidth_, windowHeight_);
@@ -40,48 +66,40 @@ class RenderSpriteSystem {
 
     PROFILE_COUNTER_INC(emplacedCounter_);
 
-    // Re-resolve when first seen or when AssetManager has loaded/replaced any texture
-    // since this sprite cached its pointer. Stale cache would draw a destroyed handle.
-    const auto assetGen = assetManager_->TextureGeneration();
-    if (!sprite.cachedTexture || sprite.cachedTextureGeneration != assetGen) {
-      sprite.cachedTexture = assetManager_->GetTexture(sprite.assetId);
-      sprite.cachedTextureGeneration = assetGen;
-      const auto slice = assetManager_->GetAtlasSlice(sprite.assetId);
-      sprite.cachedAtlasOffset = slice.has_value() ? *slice : SDL_FRect{0, 0, 0, 0};
-    }
+    const SpriteRenderCache::Entry* entry = spriteCache_->Lookup(entity, assetManager_->TextureGeneration());
+    SDL_Texture* texture = entry ? entry->texture : nullptr;
+    const SDL_FRect atlasOffset = entry ? entry->atlasOffset : SDL_FRect{0, 0, 0, 0};
 
     const float x = sprite.isFixed ? transform.position.x : transform.position.x - camera_.x;
     const float y = sprite.isFixed ? transform.position.y : transform.position.y - camera_.y;
 
-    auto& cmd = renderQueue_->EmplaceSprite(static_cast<unsigned int>(sprite.layer), transform.position.y,
-                                            sprite.cachedTexture);
+    auto& cmd = renderQueue_->EmplaceSprite(static_cast<unsigned int>(sprite.layer), transform.position.y, texture);
     cmd.destX = x;
     cmd.destY = y;
     cmd.destW = sprite.width * transform.scale.x;
     cmd.destH = sprite.height * transform.scale.y;
-    // Atlas-aware src_rect compose: a loose texture leaves cachedAtlasOffset at zero (no-op add);
-    // an atlas member adds the slice origin so the sprite's logical (sx, sy) selects inside the
+    // Atlas-aware src_rect compose: a loose texture leaves atlasOffset at zero (no-op add); an
+    // atlas member adds the slice origin so the sprite's logical (sx, sy) selects inside the
     // packed atlas instead of the standalone source PNG.
-    cmd.srcRect.x = sprite.srcRect.x + sprite.cachedAtlasOffset.x;
-    cmd.srcRect.y = sprite.srcRect.y + sprite.cachedAtlasOffset.y;
+    cmd.srcRect.x = sprite.srcRect.x + atlasOffset.x;
+    cmd.srcRect.y = sprite.srcRect.y + atlasOffset.y;
     cmd.srcRect.w = sprite.srcRect.w;
     cmd.srcRect.h = sprite.srcRect.h;
     cmd.rotation = transform.rotation;
     cmd.pivot = {cmd.destW * 0.5f, cmd.destH * 0.5f};
-    cmd.flip = sprite.flip;
-    cmd.texture = sprite.cachedTexture;
+    cmd.flip = static_cast<SDL_FlipMode>(sprite.flip);
+    cmd.texture = texture;
   }
 
  private:
   AssetManager* assetManager_ = nullptr;
   RenderQueue* renderQueue_ = nullptr;
+  SpriteRenderCache* spriteCache_ = nullptr;
+  std::unique_ptr<ComponentQuery<SpriteComponent>> warmingQuery_;
   float windowWidth_ = 0;
   float windowHeight_ = 0;
-  SDL_FRect camera_{};
+  octarine::Rect camera_{};
 #ifdef OCTARINE_PROFILING
-  // Cached counter handles — pointer is stable across frames because PerfCounters never
-  // erases slots; ResetValues() only zeroes the atomic. operator() is called per-entity in
-  // parallel chunks, so the only hot-path cost is an atomic fetch_add.
   std::atomic<long long>* culledCounter_ = nullptr;
   std::atomic<long long>* emplacedCounter_ = nullptr;
 #endif

--- a/src/Systems/RenderTextSystem.h
+++ b/src/Systems/RenderTextSystem.h
@@ -18,6 +18,7 @@
 #include "../Components/TextLabelComponent.h"
 #include "../General/Logger.h"
 #include "../General/PerfUtils.h"
+#include "../General/Rect.h"
 #include "../Renderer/RenderCommands.h"
 #include "../Renderer/RenderCulling.h"
 #include "../Renderer/RenderQueue.h"
@@ -50,7 +51,7 @@ class RenderTextSystem {
     const auto& assetManager = registry->Get<AssetManager>();
     auto* sdlRenderer = registry->Get<SDL_Renderer*>();
     auto& renderQueue = registry->Get<RenderQueue>();
-    const SDL_FRect camera = registry->Get<CameraComponent>().viewport;
+    const octarine::Rect camera = registry->Get<CameraComponent>().viewport;
 
     TTF_Font* font = assetManager.GetFont(text.fontId);
     if (!font) return;
@@ -61,17 +62,20 @@ class RenderTextSystem {
 
     auto it = text_cache_.find(cacheKey);
     if (it == text_cache_.end()) {
-      // Atlas fast path (Stage 14 B3): when every codepoint in the string is resident in the
-      // font's GlyphAtlas, compose the destination surface by blitting from the atlas. Falls back
-      // to TTF_RenderText_Blended if the font has no baked atlas or the string hits a glyph the
-      // bake step didn't cover (extended Latin, emoji, etc.).
+      // text.color is now octarine::Color (Stage 2 POD-no-SDL). Convert to SDL_Color once at the
+      // render seam — both the atlas fast path and the TTF fallback take it.
+      const SDL_Color sdlColor{text.color.r, text.color.g, text.color.b, text.color.a};
+      // Atlas fast path: when every codepoint in the string is resident in the font's GlyphAtlas,
+      // compose the destination surface by blitting from the atlas. Falls back to
+      // TTF_RenderText_Blended when no atlas is baked or the string hits an uncovered glyph
+      // (extended Latin, emoji, etc.).
       SDL_Surface* surface = nullptr;
       const GlyphAtlas* atlas = assetManager.GetGlyphAtlas(text.fontId);
       if (atlas != nullptr && atlas->IsLoaded()) {
-        surface = ComposeFromAtlas(*atlas, text.text, text.color);
+        surface = ComposeFromAtlas(*atlas, text.text, sdlColor);
       }
       if (surface == nullptr) {
-        surface = TTF_RenderText_Blended(font, text.text.c_str(), 0, text.color);
+        surface = TTF_RenderText_Blended(font, text.text.c_str(), 0, sdlColor);
       }
       if (!surface) {
         Logger::Error("RenderText: surface compose failed: " + std::string(SDL_GetError()));

--- a/src/Systems/RenderTextSystem.h
+++ b/src/Systems/RenderTextSystem.h
@@ -16,6 +16,7 @@
 #include "../AssetManager/GlyphAtlas.h"
 #include "../Components/GlobalTransformComponent.h"
 #include "../Components/TextLabelComponent.h"
+#include "../Engine/EngineContext.h"
 #include "../General/Logger.h"
 #include "../General/PerfUtils.h"
 #include "../General/Rect.h"
@@ -49,7 +50,7 @@ class RenderTextSystem {
 
     Registry* registry = ctx.GetRegistry();
     const auto& assetManager = registry->Get<AssetManager>();
-    auto* sdlRenderer = registry->Get<SDL_Renderer*>();
+    auto* sdlRenderer = registry->Get<EngineContext>().sdlRenderer;
     auto& renderQueue = registry->Get<RenderQueue>();
     const octarine::Rect camera = registry->Get<CameraComponent>().viewport;
 

--- a/src/Systems/ScriptSystem.h
+++ b/src/Systems/ScriptSystem.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <SDL3/SDL.h>
-
+#include <cstdint>
 #include <glm/glm.hpp>
 #include <sol/sol.hpp>
 
 #include "../Components/ScriptComponent.h"
+#include "../General/Color.h"
 #include "../General/Logger.h"
 #include "Lua/Bindings/LuaComponentRegistry.h"
 
@@ -51,9 +51,10 @@ private:
                                     &glm::vec2::x,
                                     "y", &glm::vec2::y);
 
-        lua.new_usertype<SDL_Color>("color",
-                                    sol::constructors<SDL_Color(), SDL_Color(Uint8, Uint8, Uint8, Uint8)>(),
-                                    "r", &SDL_Color::r, "g", &SDL_Color::g, "b", &SDL_Color::b, "a", &SDL_Color::a);
+        lua.new_usertype<octarine::Color>(
+            "color",
+            sol::constructors<octarine::Color(), octarine::Color(std::uint8_t, std::uint8_t, std::uint8_t, std::uint8_t)>(),
+            "r", &octarine::Color::r, "g", &octarine::Color::g, "b", &octarine::Color::b, "a", &octarine::Color::a);
 
         // Component usertypes — driven by LuaComponentRegistry. Add a new component by
         // dropping a LuaBinding<T> header + one line in RegisterAllBindings.cpp.

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -31,8 +31,14 @@
       "name": "sdl3",
       "features": [
         "x11",
-        "wayland"
+        "wayland",
+        "dbus"
       ],
+      "platform": "linux"
+    },
+    {
+      "name": "dbus",
+      "default-features": false,
       "platform": "linux"
     },
     {


### PR DESCRIPTION
## Summary

Six stages from the architecture-cleanup plan. Each commit was developed
and verified on its own branch before being rebased onto current main.

| Stage | Commit | What |
|-------|--------|------|
| 2 | 3b56c80 | POD components + `SpriteRenderCache` (Sprite/Square/Text/Camera lose SDL types) |
| 1 | 180b555 | CMake library split: `octarine_{core,assets,renderer,lua,systems,editor,engine}` |
| 3 | 973d9be | `EngineContext` bundles `SDL_Renderer* / MIX_Mixer* / EventBus* / AssetManager* / GameConfig*` — drops three raw-pointer slots from the Registry |
| 4 | 6a1f634 | `engine_bootstrap` namespace centralizes the boot phases `Game::Setup` and `RunBakeValidation` used to duplicate |
| 5 | 689cf63 | `InputSystem::CreateLuaBindings` body moves to `InputSystemLuaBinding.cpp`; header drops 429→186 LOC |
| 7 | 026ef86 | `Renderer` owns the scene render target, scene/window RT switches, and `SDL_RenderPresent`; `Game::Render` orchestrates phases |

Plan + stage table tracked in ``ai/ArchitectureImprovementsPlan.md`` (local-only).

## Known scope footnotes

- **Stage 2 audio sink:** the slot/generation handle refactor was dropped during rebase because `SpatialAudioSystem` + `DopplerSystem` (added on main) read `sink.track` directly each frame and decoupling them needs a separate resolve-indirection pass. `AudioSinkComponent` still carries `MIX_Track*`; everything else in the component layer is now POD-no-SDL.
- **Stage 5 header sol:** the header dropped from 429→186 LOC (well under the 250 LOC target), but `<sol/sol.hpp>` still appears because the script-installed callback vectors are `vector<sol::protected_function>`. Closing that out cleanly needs a PImpl-style callbacks struct — documented inline in the header.

## Test plan

- [x] `editor-debug` + tests: `LuaApiSmokeTest` + `AssetPipelineTest` + `ProcessTest` + `ProjectIniTest` (4/4 pass)
- [x] `editor-release` builds clean
- [x] `ship-release` builds clean; ``--startup-mode bake`` exits 0 against the example project
- [x] `player-release` builds clean (outputs `OctarineEngine-player.exe` per main's renaming logic)
- [ ] CI green