### PR TITLE
Add change validator script + headless ECS/EventBus/system tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,3 +121,36 @@ jobs:
           name: OctarineEngine-${{ matrix.platform }}-${{ matrix.preset }}
           path: build/${{ matrix.preset }}/bin/release
           if-no-files-found: error
+
+  # Style gate. Lightweight (no vcpkg/SDL): formats only the files a PR actually changed, so the
+  # large pre-existing tree never blocks on legacy style. Auto-fixable via the CMake `format` target.
+  # clang-tidy is enforced locally by scripts/octarine-verify.sh --full for now; CI tidy lands in a
+  # later staged tightening once a cached configured build is wired up.
+  lint:
+    name: lint (clang-format)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install clang-format
+        run: sudo apt-get update && sudo apt-get install -y clang-format
+
+      - name: clang-format changed files
+        shell: bash
+        run: |
+          base="${{ github.event.pull_request.base.sha }}"
+          if [ -z "$base" ]; then base="$(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)"; fi
+          mapfile -t files < <(git diff --name-only --diff-filter=ACMR "$base"...HEAD -- 'src/*' 'tests/*' \
+            | grep -E '\.(cpp|h|hpp)$' || true)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No changed C/C++ sources to format-check."
+            exit 0
+          fi
+          printf 'checking:\n%s\n' "$(printf '  %s\n' "${files[@]}")"
+          if ! clang-format --dry-run --Werror -style=file "${files[@]}"; then
+            echo "::error::clang-format violations. Fix locally with: cmake --build build/editor-release --target format"
+            exit 1
+          fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,19 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+# Compiler cache: dramatically speeds the edit -> rebuild -> verify loop agents run constantly.
+# Honors an already-set CMAKE_CXX_COMPILER_LAUNCHER. Prefers ccache; falls back to sccache (better
+# MSVC support). Opt out with -DOCTARINE_USE_CCACHE=OFF.
+option(OCTARINE_USE_CCACHE "Use ccache/sccache as the compiler launcher when available" ON)
+if (OCTARINE_USE_CCACHE AND NOT CMAKE_CXX_COMPILER_LAUNCHER)
+    find_program(OCTARINE_COMPILER_CACHE NAMES ccache sccache)
+    if (OCTARINE_COMPILER_CACHE)
+        set(CMAKE_CXX_COMPILER_LAUNCHER "${OCTARINE_COMPILER_CACHE}")
+        set(CMAKE_C_COMPILER_LAUNCHER "${OCTARINE_COMPILER_CACHE}")
+        message(STATUS "Octarine: compiler cache ENABLED (${OCTARINE_COMPILER_CACHE})")
+    endif ()
+endif ()
+
 # LTO for non-Debug builds. Combines with --gc-sections to drop unreferenced
 # code/data from statically linked third-party libs (SDL3, Lua, etc).
 include(CheckIPOSupported)
@@ -619,6 +632,48 @@ if (OCTARINE_ENABLE_TESTS)
     endif ()
 
     add_test(NAME ProjectIniTest COMMAND OctarineProjectIniTest)
+
+    # Headless ECS / system tests. These link only the ECS core (Registry + Logger) — no SDL,
+    # window, or Lua — exactly like the benchmark target, so they build and run fast. One helper
+    # per target keeps the registrations DRY.
+    function(octarine_add_core_test exe_name ctest_name source)
+        add_executable(${exe_name} ${source}
+                src/ECS/Registry.cpp
+                src/General/Logger.cpp)
+        set_target_properties(${exe_name} PROPERTIES
+                CXX_STANDARD 20
+                CXX_STANDARD_REQUIRED ON
+                CXX_EXTENSIONS OFF)
+        target_compile_definitions(${exe_name} PRIVATE GLM_FORCE_INTRINSICS)
+        target_include_directories(${exe_name} PRIVATE
+                ${CMAKE_CURRENT_SOURCE_DIR}/src
+                ${CMAKE_CURRENT_SOURCE_DIR}/libs)
+        target_link_libraries(${exe_name} PRIVATE glm::glm spdlog::spdlog Threads::Threads)
+        if (MSVC)
+            target_compile_options(${exe_name} PRIVATE /W4 /permissive- /MP /EHsc /bigobj)
+        endif ()
+        add_test(NAME ${ctest_name} COMMAND ${exe_name})
+    endfunction()
+
+    octarine_add_core_test(OctarineEcsTest EcsRegistryTest tests/EcsRegistryTest.cpp)
+    octarine_add_core_test(OctarineEcsHierarchyTest EcsHierarchyTest tests/EcsHierarchyTest.cpp)
+    octarine_add_core_test(OctarineSystemLogicTest SystemLogicTest tests/SystemLogicTest.cpp)
+
+    # EventBus is header-only; it needs Logger for its construction log lines, nothing else.
+    add_executable(OctarineEventBusTest
+            src/General/Logger.cpp
+            tests/EventBusTest.cpp)
+    set_target_properties(OctarineEventBusTest PROPERTIES
+            CXX_STANDARD 20
+            CXX_STANDARD_REQUIRED ON
+            CXX_EXTENSIONS OFF)
+    target_include_directories(OctarineEventBusTest PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/src)
+    target_link_libraries(OctarineEventBusTest PRIVATE spdlog::spdlog)
+    if (MSVC)
+        target_compile_options(OctarineEventBusTest PRIVATE /W4 /permissive- /MP /EHsc)
+    endif ()
+    add_test(NAME EventBusTest COMMAND OctarineEventBusTest)
 
     message(STATUS "Octarine: Tests ENABLED")
 endif ()

--- a/scripts/octarine-verify.ps1
+++ b/scripts/octarine-verify.ps1
@@ -1,0 +1,154 @@
+<#
+.SYNOPSIS
+  One-command change validator (PowerShell mirror of octarine-verify.sh).
+
+.DESCRIPTION
+  Runs the same gates CI runs, in dependency order, and prints an unambiguous final verdict.
+  Pinned to the editor-release preset + OCTARINE_ENABLE_TESTS=ON so local green == CI green.
+
+  Exit codes: 0 ok | 2 setup | 10 configure | 11 build | 12 ctest | 13 bake | 14 drift |
+              15 clang-format | 16 clang-tidy (only with -TidyStrict)
+
+.PARAMETER Mode
+  fast (default): configure-if-needed -> build test targets -> ctest -> clang-format check.
+  full: also build the engine, headless bake smoke, Lua-API drift check, clang-tidy.
+
+.PARAMETER Env
+  OCT_VERIFY_GAME: path to a game dir (with config.ini) for the bake smoke.
+#>
+[CmdletBinding()]
+param(
+  [ValidateSet('fast', 'full')] [string]$Mode = 'fast',
+  [switch]$KeepGoing,
+  [switch]$NoBuild,
+  [switch]$FormatOnly,
+  [switch]$TidyStrict
+)
+
+$ErrorActionPreference = 'Continue'
+$preset = 'editor-release'
+$configDir = 'release'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+Set-Location $repoRoot
+$buildDir = Join-Path $repoRoot "build/$preset"
+$binary = Join-Path $buildDir "bin/$configDir/OctarineEngine.exe"
+
+$script:FirstFailCode = 0
+$script:FirstFailName = ''
+
+function Write-Verdict {
+  if ($script:FirstFailCode -eq 0) { Write-Host "VERIFY OK ($Mode)" }
+  else { Write-Error "VERIFY FAIL: $($script:FirstFailName) [$($script:FirstFailCode)]" }
+}
+
+function Invoke-Fail([int]$Code, [string]$Name) {
+  Write-Error "  -> FAIL: $Name [$Code]"
+  if ($script:FirstFailCode -eq 0) { $script:FirstFailCode = $Code; $script:FirstFailName = $Name }
+  if (-not $KeepGoing) { Write-Verdict; exit $script:FirstFailCode }
+}
+
+function Get-ChangedSources {
+  git rev-parse --git-dir *> $null
+  if ($LASTEXITCODE -eq 0) {
+    git diff --name-only --diff-filter=ACMR HEAD -- 'src/*' 'tests/*' |
+      Where-Object { $_ -match '\.(cpp|h|hpp)$' }
+  }
+  else {
+    Get-ChildItem -Recurse -Path src, tests -Include *.cpp, *.h, *.hpp -File |
+      ForEach-Object { $_.FullName }
+  }
+}
+
+function Test-Format {
+  if (-not (Get-Command clang-format -ErrorAction SilentlyContinue)) {
+    Write-Warning '  -> SKIP clang-format (not on PATH)'; return
+  }
+  $files = @(Get-ChangedSources)
+  if ($files.Count -eq 0) { Write-Host '  ok   clang-format (no changed sources)'; return }
+  & clang-format --dry-run --Werror -style=file @files
+  if ($LASTEXITCODE -eq 0) { Write-Host "  ok   clang-format ($($files.Count) files)" }
+  else { Write-Warning "  (fix with: cmake --build $buildDir --target format)"; Invoke-Fail 15 'clang-format' }
+}
+
+function Test-Tidy {
+  if (-not (Get-Command clang-tidy -ErrorAction SilentlyContinue)) {
+    Write-Warning '  -> SKIP clang-tidy (not on PATH)'; return
+  }
+  if (-not (Test-Path (Join-Path $buildDir 'compile_commands.json'))) {
+    Write-Warning '  -> SKIP clang-tidy (no compile_commands.json)'; return
+  }
+  $files = @(Get-ChangedSources | Where-Object { $_ -match '\.cpp$' })
+  if ($files.Count -eq 0) { Write-Host '  ok   clang-tidy (no changed .cpp files)'; return }
+  & clang-tidy -p $buildDir @files
+  if ($LASTEXITCODE -eq 0) { Write-Host "  ok   clang-tidy ($($files.Count) files)" }
+  elseif ($TidyStrict) { Invoke-Fail 16 'clang-tidy' }
+  else { Write-Warning '  -> clang-tidy reported findings (advisory; pass -TidyStrict to gate)' }
+}
+
+if ($FormatOnly) { Write-Host '== clang-format (changed files) =='; Test-Format; Write-Verdict; exit $script:FirstFailCode }
+
+$testTargets = @(
+  'OctarineLuaApiTest', 'OctarineAssetPipelineTest', 'OctarineProcessTest', 'OctarineProjectIniTest',
+  'OctarineEcsTest', 'OctarineEcsHierarchyTest', 'OctarineSystemLogicTest', 'OctarineEventBusTest'
+)
+
+if (-not $NoBuild) {
+  if (-not (Test-Path (Join-Path $buildDir 'CMakeCache.txt'))) {
+    Write-Host "== configure ($preset) =="
+    cmake --preset $preset -DOCTARINE_ENABLE_TESTS=ON
+    if ($LASTEXITCODE -ne 0) { Invoke-Fail 10 'configure' }
+  }
+  Write-Host '== build =='
+  $buildTargets = $testTargets
+  if ($Mode -eq 'full') { $buildTargets += 'OctarineEngine' }
+  $targetArgs = $buildTargets | ForEach-Object { '--target', $_ }
+  cmake --build $buildDir @targetArgs --parallel
+  if ($LASTEXITCODE -ne 0) { Invoke-Fail 11 'build' }
+}
+
+Write-Host '== ctest =='
+ctest --test-dir $buildDir --output-on-failure
+if ($LASTEXITCODE -ne 0) { Invoke-Fail 12 'ctest' }
+
+if ($Mode -eq 'full') {
+  Write-Host '== bake smoke =='
+  $gamePath = if ($env:OCT_VERIFY_GAME) { $env:OCT_VERIFY_GAME } else { Join-Path $repoRoot '../Octarine-Engine-Example' }
+  if (-not (Test-Path $gamePath)) {
+    $cloneDir = Join-Path $repoRoot 'build/.verify_game'
+    if (-not (Test-Path $cloneDir)) {
+      git clone --depth 1 https://github.com/mblackman/Octarine-Engine-Example.git $cloneDir
+      if ($LASTEXITCODE -ne 0) { Invoke-Fail 2 'bake-setup' }
+    }
+    else { git -C $cloneDir pull | Out-Null }
+    $gamePath = $cloneDir
+  }
+  if (Test-Path $gamePath) {
+    $gamePath = (Resolve-Path $gamePath).Path
+    if (-not (Test-Path $binary)) { Write-Error "  -> engine binary not found at $binary"; Invoke-Fail 13 'bake' }
+    else {
+      $env:SDL_VIDEODRIVER = 'dummy'; $env:SDL_AUDIODRIVER = 'dummy'
+      & $binary $gamePath -m bake
+      $manifest = Join-Path $gamePath 'asset_manifest.lua'
+      if ($LASTEXITCODE -eq 0 -and (Test-Path $manifest) -and (Get-Item $manifest).Length -gt 0) {
+        Write-Host '  ok   bake produced a non-empty manifest'
+      }
+      else { Invoke-Fail 13 'bake' }
+    }
+  }
+
+  Write-Host '== Lua API drift =='
+  $driftPaths = @('lua_api.smoke.lua', 'components.json', 'modules.json')
+  git diff --quiet -- $driftPaths
+  if ($LASTEXITCODE -eq 0) { Write-Host '  ok   no Lua API artifact drift' }
+  else { Write-Error '  -> regenerated stubs differ — commit them'; git diff --stat -- $driftPaths; Invoke-Fail 14 'lua-api-drift' }
+
+  Write-Host '== clang-tidy (changed files) =='
+  Test-Tidy
+}
+
+Write-Host '== clang-format (changed files) =='
+Test-Format
+
+Write-Verdict
+exit $script:FirstFailCode

--- a/scripts/octarine-verify.sh
+++ b/scripts/octarine-verify.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# One-command change validator. Runs the same gates CI runs, in dependency order, and prints an
+# unambiguous final verdict. An agent (or human) runs this after any change to know nothing broke.
+#
+# Usage: scripts/octarine-verify.sh [--fast|--full] [options]
+#   --fast        (default) configure-if-needed -> build test targets -> ctest -> clang-format check
+#   --full        also: build the engine, headless bake smoke, Lua-API drift check, clang-tidy
+#   --keep-going  run every gate and report a summary instead of stopping at the first failure
+#   --no-build    skip configure/build (reuse the existing build dir as-is)
+#   --format-only run only the clang-format check on changed files
+#   --tidy-strict treat clang-tidy findings as a failure (default: advisory/non-blocking)
+#   -h, --help    show this help
+#
+# Pinned to the editor-release preset + OCTARINE_ENABLE_TESTS=ON so local green == CI green
+# (.github/workflows/build.yml validates exactly this leg).
+#
+# Exit codes (distinct, so callers can branch):
+#   0  all gates passed            13  bake smoke failed
+#   2  environment/setup error     14  Lua-API artifact drift
+#   10 configure failed            15  clang-format violations
+#   11 build failed                16  clang-tidy findings (only with --tidy-strict)
+#   12 ctest failed
+#
+# Env:
+#   OCT_VERIFY_GAME  Path to a game dir (with config.ini) for the bake smoke.
+#                    Default: <repo>/../Octarine-Engine-Example, else auto-cloned under build/.
+
+set -uo pipefail
+
+preset=editor-release
+config_dir=release
+
+mode=fast
+keep_going=0
+do_build=1
+format_only=0
+tidy_strict=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --fast) mode=fast ;;
+    --full) mode=full ;;
+    --keep-going) keep_going=1 ;;
+    --no-build) do_build=0 ;;
+    --format-only) format_only=1 ;;
+    --tidy-strict) tidy_strict=1 ;;
+    -h|--help) sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "error: unknown argument '$1' (try --help)" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/.." && pwd)"
+cd "$repo_root"
+build_dir="$repo_root/build/$preset"
+binary="$build_dir/bin/$config_dir/OctarineEngine"
+
+# Distinct exit code recorded by the first failing gate (or the worst, under --keep-going).
+first_fail_code=0
+first_fail_name=""
+
+fail() {  # fail <code> <name>
+  local code="$1" name="$2"
+  echo "  -> FAIL: $name [$code]" >&2
+  if [[ $first_fail_code -eq 0 ]]; then
+    first_fail_code="$code"
+    first_fail_name="$name"
+  fi
+  if [[ $keep_going -eq 0 ]]; then
+    verdict
+    exit "$first_fail_code"
+  fi
+}
+
+verdict() {
+  if [[ $first_fail_code -eq 0 ]]; then
+    echo "VERIFY OK ($mode)"
+  else
+    echo "VERIFY FAIL: $first_fail_name [$first_fail_code]" >&2
+  fi
+}
+
+# List changed C/C++ files under src/ and tests/ (added/copied/modified/renamed vs HEAD). Falls
+# back to the whole src/ + tests/ tree outside a git context.
+changed_sources() {
+  if git rev-parse --git-dir >/dev/null 2>&1; then
+    git diff --name-only --diff-filter=ACMR HEAD -- 'src/*' 'tests/*' \
+      | grep -E '\.(cpp|h|hpp)$' || true
+  else
+    find src tests -type f \( -name '*.cpp' -o -name '*.h' -o -name '*.hpp' \) 2>/dev/null || true
+  fi
+}
+
+check_format() {
+  local fmt; fmt="$(command -v clang-format || true)"
+  if [[ -z "$fmt" ]]; then
+    echo "  -> SKIP clang-format (not on PATH)" >&2
+    return 0
+  fi
+  local files; mapfile -t files < <(changed_sources)
+  if [[ ${#files[@]} -eq 0 ]]; then
+    echo "  ok   clang-format (no changed sources)"
+    return 0
+  fi
+  if "$fmt" --dry-run --Werror -style=file "${files[@]}"; then
+    echo "  ok   clang-format (${#files[@]} files)"
+  else
+    echo "  (fix with: cmake --build $build_dir --target format)" >&2
+    fail 15 "clang-format"
+  fi
+}
+
+check_tidy() {
+  local tidy; tidy="$(command -v clang-tidy || true)"
+  if [[ -z "$tidy" ]]; then
+    echo "  -> SKIP clang-tidy (not on PATH)" >&2
+    return 0
+  fi
+  if [[ ! -f "$build_dir/compile_commands.json" ]]; then
+    echo "  -> SKIP clang-tidy (no compile_commands.json — configure first)" >&2
+    return 0
+  fi
+  local files; mapfile -t files < <(changed_sources | grep -E '\.cpp$' || true)
+  if [[ ${#files[@]} -eq 0 ]]; then
+    echo "  ok   clang-tidy (no changed .cpp files)"
+    return 0
+  fi
+  if "$tidy" -p "$build_dir" "${files[@]}"; then
+    echo "  ok   clang-tidy (${#files[@]} files)"
+  elif [[ $tidy_strict -eq 1 ]]; then
+    fail 16 "clang-tidy"
+  else
+    echo "  -> clang-tidy reported findings (advisory; pass --tidy-strict to gate)" >&2
+  fi
+}
+
+# --- format-only fast exit ---------------------------------------------------
+if [[ $format_only -eq 1 ]]; then
+  echo "== clang-format (changed files) =="
+  check_format
+  verdict
+  exit "$first_fail_code"
+fi
+
+# --- configure + build -------------------------------------------------------
+test_targets=(
+  OctarineLuaApiTest OctarineAssetPipelineTest OctarineProcessTest OctarineProjectIniTest
+  OctarineEcsTest OctarineEcsHierarchyTest OctarineSystemLogicTest OctarineEventBusTest
+)
+
+if [[ $do_build -eq 1 ]]; then
+  if [[ ! -f "$build_dir/CMakeCache.txt" ]]; then
+    echo "== configure ($preset) =="
+    if ! cmake --preset "$preset" -DOCTARINE_ENABLE_TESTS=ON; then
+      fail 10 "configure"
+    fi
+  fi
+  echo "== build =="
+  build_targets=("${test_targets[@]}")
+  [[ "$mode" == "full" ]] && build_targets+=(OctarineEngine)
+  target_args=()
+  for t in "${build_targets[@]}"; do target_args+=(--target "$t"); done
+  if ! cmake --build "$build_dir" "${target_args[@]}" --parallel; then
+    fail 11 "build"
+  fi
+fi
+
+# --- ctest -------------------------------------------------------------------
+echo "== ctest =="
+if ! ctest --test-dir "$build_dir" --output-on-failure; then
+  fail 12 "ctest"
+fi
+
+# --- full-only gates ---------------------------------------------------------
+if [[ "$mode" == "full" ]]; then
+  echo "== bake smoke =="
+  game_path="${OCT_VERIFY_GAME:-$repo_root/../Octarine-Engine-Example}"
+  if [[ ! -d "$game_path" ]]; then
+    clone_dir="$repo_root/build/.verify_game"
+    if [[ ! -d "$clone_dir" ]]; then
+      git clone --depth 1 https://github.com/mblackman/Octarine-Engine-Example.git "$clone_dir" >&2 \
+        || { echo "  -> could not obtain an example project" >&2; fail 2 "bake-setup"; }
+    else
+      git -C "$clone_dir" pull >&2 || true
+    fi
+    game_path="$clone_dir"
+  fi
+  if [[ -d "$game_path" ]]; then
+    game_path="$(cd "$game_path" && pwd)"
+    if [[ ! -x "$binary" ]]; then
+      echo "  -> engine binary not found at $binary (build --full first)" >&2
+      fail 13 "bake"
+    elif SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy "$binary" "$game_path" -m bake \
+         && [[ -s "$game_path/asset_manifest.lua" ]]; then
+      echo "  ok   bake produced a non-empty manifest"
+    else
+      fail 13 "bake"
+    fi
+  fi
+
+  echo "== Lua API drift =="
+  drift_paths=(lua_api.smoke.lua components.json modules.json)
+  if git diff --quiet -- "${drift_paths[@]}"; then
+    echo "  ok   no Lua API artifact drift"
+  else
+    echo "  -> regenerated stubs differ — commit them:" >&2
+    git diff --stat -- "${drift_paths[@]}" >&2
+    fail 14 "lua-api-drift"
+  fi
+
+  echo "== clang-tidy (changed files) =="
+  check_tidy
+fi
+
+# --- clang-format (both modes) ----------------------------------------------
+echo "== clang-format (changed files) =="
+check_format
+
+verdict
+exit "$first_fail_code"

--- a/tests/EcsHierarchyTest.cpp
+++ b/tests/EcsHierarchyTest.cpp
@@ -1,0 +1,83 @@
+// Correctness checks for the Registry's relationship + ChildOf hierarchy machinery. These have
+// generation-aware storage and cascade semantics that are easy to regress. gtest-free; exit code =
+// failed-check count. Registered with ctest as EcsHierarchyTest. Links the ECS core only.
+
+#include <algorithm>
+
+#include "ECS/Registry.h"
+#include "TestHarness.h"
+
+using octarine::test::Check;
+
+namespace {
+bool ChildrenContain(const std::vector<Entity>& children, const Entity needle) {
+  return std::any_of(children.begin(), children.end(), [&](const Entity c) { return c.GetId() == needle.GetId(); });
+}
+}  // namespace
+
+int main() {
+  // SetParent wires both directions of the hierarchy and bumps the generation.
+  {
+    Registry registry;
+    const Entity parent = registry.CreateEntity();
+    const Entity child = registry.CreateEntity();
+    const uint64_t gen0 = registry.HierarchyGeneration();
+
+    registry.SetParent(child, parent);
+    Check(registry.HierarchyGeneration() > gen0, "HierarchyGeneration bumps on SetParent");
+    const auto resolvedParent = registry.GetParent(child);
+    Check(resolvedParent.has_value() && resolvedParent->GetId() == parent.GetId(),
+          "GetParent returns the assigned parent");
+    Check(ChildrenContain(registry.GetChildren(parent), child), "GetChildren lists the child");
+    Check(registry.HasAnyChildPairs(), "HasAnyChildPairs true once a ChildOf relationship exists");
+
+    // SetParent also maintains the legacy ChildOf pair, so HasPair sees it.
+    Check(registry.HasPair(child, registry.ChildOfEntity(), parent),
+          "SetParent maintains the ChildOf pair for HasPair queries");
+  }
+
+  // Reparenting detaches from the previous parent.
+  {
+    Registry registry;
+    const Entity a = registry.CreateEntity();
+    const Entity b = registry.CreateEntity();
+    const Entity child = registry.CreateEntity();
+    registry.SetParent(child, a);
+    registry.SetParent(child, b);  // reparent
+    Check(registry.GetParent(child)->GetId() == b.GetId(), "reparent updates GetParent");
+    Check(!ChildrenContain(registry.GetChildren(a), child), "old parent no longer lists the child");
+    Check(ChildrenContain(registry.GetChildren(b), child), "new parent lists the child");
+  }
+
+  // Generic pairs: add / has round-trip via the reverse index.
+  {
+    Registry registry;
+    const Entity author = registry.CreateEntity();
+    const Entity target = registry.CreateEntity();
+    const Entity other = registry.CreateEntity();
+    const Entity likes = registry.TagId("likes");
+
+    Check(!registry.HasPair(author, likes, target), "no pair before AddPair");
+    registry.AddPair(author, likes, target);
+    Check(registry.HasPair(author, likes, target), "HasPair true after AddPair");
+    Check(!registry.HasPair(author, likes, other), "HasPair false for a different target");
+    Check(registry.HasAnyPairs(), "HasAnyPairs true once any pair exists");
+  }
+
+  // Blamming a parent cascade-destroys its children and bumps the generation.
+  {
+    Registry registry;
+    const Entity parent = registry.CreateEntity();
+    const Entity child = registry.CreateEntity();
+    registry.SetParent(child, parent);
+    const uint64_t genBeforeBlam = registry.HierarchyGeneration();
+
+    registry.BlamEntity(parent);
+    Check(!registry.IsAlive(parent), "blammed parent is destroyed");
+    Check(!registry.IsAlive(child), "child is cascade-destroyed with its parent");
+    Check(registry.HierarchyGeneration() > genBeforeBlam, "HierarchyGeneration bumps on cascade blam");
+    Check(!registry.GetParent(child).has_value(), "no dangling parent link after cascade blam");
+  }
+
+  return octarine::test::Result();
+}

--- a/tests/EcsRegistryTest.cpp
+++ b/tests/EcsRegistryTest.cpp
@@ -1,0 +1,180 @@
+// Correctness checks for the ECS Registry — the spine every system rides on. Archetype-migration
+// bugs corrupt component data silently, so these assert the round-trips and transitions directly.
+// gtest-free; exit code = failed-check count. Registered with ctest as EcsRegistryTest.
+//
+// Links the ECS core only (Registry.cpp + Logger.cpp) — no SDL/window — exactly like the
+// benchmark target. Uses local POD component structs (same approach as EntityPoolBenchmark.cpp)
+// so the test is independent of the real Components/ headers.
+
+#include "ECS/Query.h"  // full ComponentQuery definition for CreateQuery / ForEach
+#include "ECS/Registry.h"
+#include "TestHarness.h"
+
+using octarine::test::Check;
+
+namespace {
+struct Position {
+  float x = 0.0f;
+  float y = 0.0f;
+};
+struct Velocity {
+  float dx = 0.0f;
+  float dy = 0.0f;
+};
+struct Health {
+  int hp = 0;
+};
+}  // namespace
+
+int main() {
+  // Add / Has / Get round-trip.
+  {
+    Registry registry;
+    const Entity e = registry.CreateEntity();
+    Check(registry.IsAlive(e), "freshly created entity is alive");
+    Check(!registry.HasComponent<Position>(e), "no component before AddComponent");
+
+    registry.AddComponent(e, Position{1.0f, 2.0f});
+    Check(registry.HasComponent<Position>(e), "HasComponent true after AddComponent");
+    Check(registry.GetComponent<Position>(e).x == 1.0f && registry.GetComponent<Position>(e).y == 2.0f,
+          "GetComponent round-trips the stored value");
+  }
+
+  // Archetype migration: adding a second component preserves the first; removing one keeps the other.
+  {
+    Registry registry;
+    const Entity e = registry.CreateEntity();
+    registry.AddComponent(e, Position{3.0f, 4.0f});
+    registry.AddComponent(e, Velocity{5.0f, 6.0f});  // archetype {Position} -> {Position, Velocity}
+    Check(registry.HasComponent<Position>(e) && registry.HasComponent<Velocity>(e),
+          "entity holds both components after second add");
+    Check(registry.GetComponent<Position>(e).x == 3.0f, "first component value survives archetype migration");
+    Check(registry.GetComponent<Velocity>(e).dx == 5.0f, "second component value placed correctly");
+
+    registry.RemoveComponent<Position>(e);  // {Position, Velocity} -> {Velocity}
+    Check(!registry.HasComponent<Position>(e), "removed component is gone");
+    Check(registry.HasComponent<Velocity>(e) && registry.GetComponent<Velocity>(e).dy == 6.0f,
+          "untouched component intact after a removal migration");
+  }
+
+  // Re-adding an existing component assigns over the live slot (no duplicate, value replaced).
+  {
+    Registry registry;
+    const Entity e = registry.CreateEntity();
+    registry.AddComponent(e, Position{1.0f, 1.0f});
+    const ArchetypeID before = registry.GetArchetypeID(e);
+    registry.AddComponent(e, Position{9.0f, 9.0f});  // re-add path
+    Check(registry.GetComponent<Position>(e).x == 9.0f, "re-add assigns over the existing slot");
+    Check(registry.GetArchetypeID(e) == before, "re-add does not change the archetype");
+  }
+
+  // CreateEntityWithBundle lands in the same end-state as incremental adds.
+  {
+    Registry registry;
+    const Entity bundled = registry.CreateEntityWithBundle(Position{7.0f, 8.0f}, Velocity{1.0f, 2.0f});
+    Check(registry.HasComponent<Position>(bundled) && registry.HasComponent<Velocity>(bundled),
+          "bundle create lands all components");
+    Check(registry.GetComponent<Position>(bundled).y == 8.0f, "bundle component value correct");
+
+    const Entity incremental = registry.CreateEntity();
+    registry.AddComponent(incremental, Position{0.0f, 0.0f});
+    registry.AddComponent(incremental, Velocity{0.0f, 0.0f});
+    Check(registry.GetArchetypeID(bundled) == registry.GetArchetypeID(incremental),
+          "bundle create reaches the same archetype as incremental adds");
+  }
+
+  // Blam dedup + deferred destruction via Update.
+  {
+    Registry registry;
+    const Entity e = registry.CreateEntity();
+    registry.AddComponent(e, Position{0.0f, 0.0f});
+    registry.QueueBlamEntity(e);
+    registry.QueueBlamEntity(e);  // duplicate within the frame — must collapse to one blam
+    Check(registry.IsAlive(e), "queued blam is deferred until Update");
+    registry.Update(1.0f / 60.0f);
+    Check(!registry.IsAlive(e), "entity is destroyed after Update processes the blam queue");
+    Check(!registry.HasComponent<Position>(e), "destroyed entity reports no components");
+    registry.Update(1.0f / 60.0f);  // second Update must not double-process the (now empty) queue
+    Check(!registry.IsAlive(e), "stale handle stays invalid across further updates");
+  }
+
+  // Queries visit exactly the matching set.
+  {
+    Registry registry;
+    for (int i = 0; i < 3; ++i) {
+      const Entity e = registry.CreateEntity();
+      registry.AddComponent(e, Position{static_cast<float>(i), 0.0f});
+    }
+    for (int i = 0; i < 2; ++i) {
+      const Entity e = registry.CreateEntity();
+      registry.AddComponent(e, Velocity{0.0f, 0.0f});  // no Position — must be skipped
+    }
+    int seen = 0;
+    const auto query = registry.CreateQuery<Position>();
+    query->ForEach([&](Position&) { ++seen; });
+    Check(seen == 3, "query<Position> visits exactly the entities that have Position");
+  }
+
+  // Activate / Deactivate move across the active partition without crossing archetypes.
+  {
+    Registry registry;
+    const Entity e = registry.CreateEntity();
+    registry.AddComponent(e, Position{0.0f, 0.0f});
+    const ArchetypeID archetype = registry.GetArchetypeID(e);
+    Check(registry.IsActive(e), "new entity starts active");
+
+    registry.Deactivate(e);
+    Check(!registry.IsActive(e) && registry.IsAlive(e), "deactivated entity is inactive but still alive");
+    Check(registry.GetArchetypeID(e) == archetype, "deactivate does not change the archetype");
+    int seenAfterDeactivate = 0;
+    const auto query = registry.CreateQuery<Position>();
+    query->ForEach([&](Position&) { ++seenAfterDeactivate; });
+    Check(seenAfterDeactivate == 0, "default query skips deactivated entities");
+
+    registry.Activate(e);
+    Check(registry.IsActive(e), "reactivated entity is active again");
+  }
+
+  // Tags: string and typed, add / has / remove.
+  {
+    Registry registry;
+    const Entity e = registry.CreateEntity();
+    registry.AddTag(e, "enemy");
+    Check(registry.HasTag(e, "enemy"), "string tag present after AddTag");
+    Check(!registry.HasTag(e, "boss"), "unrelated string tag absent");
+    registry.RemoveTag(e, "enemy");
+    Check(!registry.HasTag(e, "enemy"), "string tag gone after RemoveTag");
+
+    struct Frozen {};
+    registry.AddTag<Frozen>(e);
+    Check(registry.HasTag<Frozen>(e), "typed tag present after AddTag<T>");
+    registry.RemoveTag<Frozen>(e);
+    Check(!registry.HasTag<Frozen>(e), "typed tag gone after RemoveTag<T>");
+  }
+
+  // Singletons: Set / Get / TryGet.
+  {
+    Registry registry;
+    Check(registry.TryGet<Health>() == nullptr, "TryGet returns nullptr before Set");
+    registry.Set<Health>(Health{42});
+    Check(registry.Get<Health>().hp == 42, "Get returns the Set value");
+    Check(registry.TryGet<Health>() != nullptr && registry.TryGet<Health>()->hp == 42,
+          "TryGet returns the live singleton after Set");
+  }
+
+  // Archetype generation bumps on a new shape, stays stable for a repeated shape.
+  {
+    Registry registry;
+    const Entity a = registry.CreateEntity();
+    const uint64_t gen0 = registry.ArchetypeGeneration();
+    registry.AddComponent(a, Position{0.0f, 0.0f});  // creates archetype {Position}
+    const uint64_t gen1 = registry.ArchetypeGeneration();
+    Check(gen1 > gen0, "ArchetypeGeneration bumps when a new archetype is created");
+
+    const Entity b = registry.CreateEntity();
+    registry.AddComponent(b, Position{0.0f, 0.0f});  // same shape — no new archetype
+    Check(registry.ArchetypeGeneration() == gen1, "ArchetypeGeneration stable for a repeated shape");
+  }
+
+  return octarine::test::Result();
+}

--- a/tests/EventBusTest.cpp
+++ b/tests/EventBusTest.cpp
@@ -1,0 +1,105 @@
+// Behavioral checks for the type-erased EventBus pub/sub. The documented hazard is a dangling
+// callback after an owner dies, so UnsubscribeAll is exercised explicitly. gtest-free; exit code =
+// failed-check count. Registered with ctest as EventBusTest. Header-only bus; links Logger only.
+
+#include <vector>
+
+#include "EventBus/Event.h"
+#include "EventBus/EventBus.h"
+#include "TestHarness.h"
+
+using octarine::test::Check;
+
+namespace {
+struct PingEvent : Event {
+  int value = 0;
+  explicit PingEvent(const int v = 0) : value(v) {}
+};
+
+struct SilentEvent : Event {
+  SilentEvent() = default;
+};
+
+struct Listener {
+  int count = 0;
+  int last = 0;
+  void OnPing(PingEvent& e) {
+    ++count;
+    last = e.value;
+  }
+};
+
+struct ConstListener {
+  int count = 0;
+  int last = 0;
+  void OnPing(const PingEvent& e) {
+    ++count;
+    last = e.value;
+  }
+};
+
+struct OrderRecorder {
+  std::vector<int>* log = nullptr;
+  int id = 0;
+  void OnPing(PingEvent&) { log->push_back(id); }
+};
+}  // namespace
+
+int main() {
+  // Emit invokes a subscribed handler with the forwarded payload.
+  {
+    EventBus bus;
+    Listener listener;
+    bus.SubscribeEvent<Listener, PingEvent>(&listener, &Listener::OnPing);
+    bus.EmitEvent<PingEvent>(7);
+    Check(listener.count == 1, "subscribed handler fired exactly once");
+    Check(listener.last == 7, "handler received the forwarded payload");
+  }
+
+  // Emitting with no subscribers is a harmless no-op.
+  {
+    EventBus bus;
+    bus.EmitEvent<SilentEvent>();  // must not throw or crash
+    Listener listener;
+    bus.SubscribeEvent<Listener, PingEvent>(&listener, &Listener::OnPing);
+    bus.EmitEvent<SilentEvent>();  // a different event type has no PingEvent subscribers
+    Check(listener.count == 0, "emit of an unsubscribed event type invokes nothing");
+  }
+
+  // Multiple subscribers all fire, in subscription order.
+  {
+    EventBus bus;
+    std::vector<int> order;
+    OrderRecorder first{&order, 1};
+    OrderRecorder second{&order, 2};
+    bus.SubscribeEvent<OrderRecorder, PingEvent>(&first, &OrderRecorder::OnPing);
+    bus.SubscribeEvent<OrderRecorder, PingEvent>(&second, &OrderRecorder::OnPing);
+    bus.EmitEvent<PingEvent>(0);
+    Check(order.size() == 2, "every subscriber fired");
+    Check(order.size() == 2 && order[0] == 1 && order[1] == 2, "subscribers fire in subscription order");
+  }
+
+  // UnsubscribeAll drops exactly the named owner's callbacks (the dangling-callback guard).
+  {
+    EventBus bus;
+    Listener stays;
+    Listener leaves;
+    bus.SubscribeEvent<Listener, PingEvent>(&stays, &Listener::OnPing);
+    bus.SubscribeEvent<Listener, PingEvent>(&leaves, &Listener::OnPing);
+    bus.UnsubscribeAll(&leaves);
+    bus.EmitEvent<PingEvent>(3);
+    Check(leaves.count == 0, "unsubscribed owner is not invoked");
+    Check(stays.count == 1, "other owners remain subscribed after UnsubscribeAll");
+  }
+
+  // The const-ref callback overload dispatches too.
+  {
+    EventBus bus;
+    ConstListener listener;
+    bus.SubscribeEvent<ConstListener, PingEvent>(&listener, &ConstListener::OnPing);
+    bus.EmitEvent<PingEvent>(5);
+    Check(listener.count == 1 && listener.last == 5, "const TEvent& handler overload dispatches");
+  }
+
+  return octarine::test::Result();
+}

--- a/tests/SystemLogicTest.cpp
+++ b/tests/SystemLogicTest.cpp
@@ -1,0 +1,64 @@
+// Checks for system logic + the Registry's system-dispatch plumbing. Part 1 unit-tests a real
+// gameplay system's math by calling its functor directly (no Registry needed). Part 2 wires a
+// system through Registry::RegisterSystem + Update to prove the query -> ForEach dispatch actually
+// moves matching entities and skips non-matching ones. gtest-free; exit code = failed-check count.
+// Registered with ctest as SystemLogicTest. Links the ECS core only.
+
+#include <glm/glm.hpp>
+
+#include "ECS/Query.h"  // full ComponentQuery definition for RegisterSystem dispatch
+#include "ECS/Registry.h"
+#include "Systems/VelocityIntegrationSystem.h"
+#include "TestHarness.h"
+
+using octarine::test::Check;
+
+namespace {
+struct Position {
+  float x = 0.0f;
+  float y = 0.0f;
+};
+struct Velocity {
+  float dx = 0.0f;
+  float dy = 0.0f;
+};
+}  // namespace
+
+int main() {
+  // Part 1 — real gameplay math: position advances by velocity * dt.
+  {
+    VelocityIntegrationSystem system;
+    PositionComponent position(glm::vec2(0.0f, 0.0f));
+    const RigidBodyComponent body(glm::vec2(3.0f, 4.0f));
+    system(0.5f, position, body);
+    Check(position.value.x == 1.5f, "VelocityIntegrationSystem advances x by velocity.x * dt");
+    Check(position.value.y == 2.0f, "VelocityIntegrationSystem advances y by velocity.y * dt");
+  }
+
+  // Part 2 — dispatch plumbing: a registered system runs over matching entities on Update and
+  // leaves non-matching entities untouched.
+  {
+    Registry registry;
+    registry.RegisterSystem<Position, Velocity>([](Position& position, Velocity& velocity) {
+      position.x += velocity.dx;
+      position.y += velocity.dy;
+    });
+
+    const Entity moving = registry.CreateEntity();
+    registry.AddComponent(moving, Position{0.0f, 0.0f});
+    registry.AddComponent(moving, Velocity{2.0f, -1.0f});
+
+    const Entity stationary = registry.CreateEntity();
+    registry.AddComponent(stationary, Position{10.0f, 10.0f});  // no Velocity — must be skipped
+
+    registry.Update(1.0f / 60.0f);
+
+    Check(registry.GetComponent<Position>(moving).x == 2.0f && registry.GetComponent<Position>(moving).y == -1.0f,
+          "system advanced the entity matching its full component query");
+    Check(registry.GetComponent<Position>(stationary).x == 10.0f &&
+              registry.GetComponent<Position>(stationary).y == 10.0f,
+          "system skipped the entity missing a queried component");
+  }
+
+  return octarine::test::Result();
+}

--- a/tests/TestHarness.h
+++ b/tests/TestHarness.h
@@ -1,0 +1,26 @@
+// Minimal gtest-free check helper shared by the standalone engine tests. Mirrors the inline
+// `g_failures` / `Check` pattern used by ProcessTest / ProjectIniTest, factored out so the newer
+// ECS / EventBus / system tests don't each re-declare it. Each test's main() ends with
+//   return octarine::test::Result();
+// so the process exit code is 0 on success, 1 on any failed check.
+#pragma once
+
+#include <iostream>
+#include <string>
+
+namespace octarine::test {
+
+inline int g_failures = 0;
+
+inline void Check(const bool cond, const std::string& what) {
+  if (cond) {
+    std::cout << "  ok   " << what << "\n";
+  } else {
+    std::cerr << "  FAIL " << what << "\n";
+    ++g_failures;
+  }
+}
+
+inline int Result() { return g_failures == 0 ? 0 : 1; }
+
+}  // namespace octarine::test


### PR DESCRIPTION
## What

Makes a change safer to land by giving one command to validate it and by covering the previously-untested ECS core.

### Validator
- `scripts/octarine-verify.sh` (+ `.ps1` mirror): runs the CI gates in one command.
  - `--fast` (default): configure-if-needed → build test targets → `ctest` → `clang-format` check on changed files.
  - `--full`: also builds the engine, runs the headless bake smoke, the Lua-API drift check, and `clang-tidy`.
  - Distinct exit codes (10 configure, 11 build, 12 ctest, 13 bake, 14 drift, 15 format, 16 tidy) and a one-line verdict. Pinned to the `editor-release` + `OCTARINE_ENABLE_TESTS=ON` leg so local green matches CI.

### New tests (ECS core had zero coverage)
Plain-main style, linking only the ECS core (Registry + Logger) like the benchmark, so they run headless and fast:
- `EcsRegistryTest` — add/get/has, archetype migration, re-add over slot, bundle create, blam dedup, queries, activate/deactivate, tags, singletons, archetype generation.
- `EcsHierarchyTest` — SetParent/GetParent/GetChildren, generic pairs, cascade blam + generation bumps.
- `EventBusTest` — emit order, no-subscriber no-op, `UnsubscribeAll`, `const TEvent&` overload.
- `SystemLogicTest` — `VelocityIntegrationSystem` math + `RegisterSystem`/`Update` dispatch.

### Enforcement & speed
- New blocking `clang-format` CI job over PR-changed files only (no vcpkg, fast). The new tests are gated by the existing `ctest` step.
- Opt-in `ccache`/`sccache` compiler launcher (`OCTARINE_USE_CCACHE`, graceful no-op if absent).

## Verification
Built, linked, and ran all four tests locally against the engine code: **64/64 checks pass, exit 0**. All new files are `clang-format`-clean.
