### PR TITLE
Stage 8: Lua modules bind against LuaBindingContext, not Game

### DIFF
--- a/src/Game/Game.h
+++ b/src/Game/Game.h
@@ -13,11 +13,12 @@
 #include "../Engine/EngineContext.h"
 #include "../EventBus/EventBus.h"
 #include "../Events/KeyInputEvent.h"
+#include "../Lua/LuaBindingContext.h"
 #include "../Renderer/Renderer.h"
 
 class Registry;
 
-class Game {
+class Game : public LuaBindingContext {
  public:
   Game();
 
@@ -43,12 +44,15 @@ class Game {
   // True while running under the headless bake (`-m bake`). Asset-loading Lua globals
   // (`acquire_scene_assets`, `load_asset`) consult this to validate-and-count referenced ids
   // instead of uploading to a GPU/mixer that does not exist in this mode.
-  [[nodiscard]] bool IsBakeMode() const { return bake_mode_; }
+  [[nodiscard]] bool IsBakeMode() const override { return bake_mode_; }
 
   // Accumulate unresolved-reference failures found while a scene script runs under bake. Bake
   // sums these across the whole startup run and fails the process if any remain.
-  void RecordBakeValidationFailures(int failures) { bake_validation_failures_ += failures; }
+  void RecordBakeValidationFailures(int failures) override { bake_validation_failures_ += failures; }
   static void Quit() { s_is_running_ = false; }
+
+  // LuaBindingContext shutdown hook (the `quit_game` global) — forwards to the static flag.
+  void RequestQuit() override { Quit(); }
 
   // Optional startup-mode hint exposed to Lua as `oct_startup_mode`. Empty string means
   // "no override" — the startup script can show its normal menu. Set by Main from the
@@ -62,28 +66,28 @@ class Game {
   // In a shipped build (OCTARINE_SHIPPED) the manifest is used unconditionally and this is moot.
   void SetUseManifest(bool useManifest) { use_manifest_ = useManifest; }
 
-  [[nodiscard]] SDL_Renderer* GetRenderer() const { return sdl_renderer_; }
+  [[nodiscard]] SDL_Renderer* GetRenderer() const override { return sdl_renderer_; }
   [[nodiscard]] SDL_Window* GetWindow() const { return window_; }
 
-  [[nodiscard]] Registry* GetRegistry() const { return registry_.get(); }
+  [[nodiscard]] Registry* GetRegistry() const override { return registry_.get(); }
   [[nodiscard]] sol::state& GetLua() { return lua; }
 
   // Engine-level resource bundle (SDL handles, EventBus, AssetManager, GameConfig).
   // Lives as a Registry singleton — systems read it the same way via
   // `Registry::Get<EngineContext>()`. Game just forwards to the registry copy so
   // fields stay coherent across Initialize → Setup → AudioSystem::Init mutations.
-  [[nodiscard]] EngineContext& GetContext() { return registry_->Get<EngineContext>(); }
+  [[nodiscard]] EngineContext& GetContext() override { return registry_->Get<EngineContext>(); }
   [[nodiscard]] const EngineContext& GetContext() const { return registry_->Get<EngineContext>(); }
 
-  void LoadScene(const std::string& scenePath);
-  void ReloadScene();
-  void StopScene();
+  void LoadScene(const std::string& scenePath) override;
+  void ReloadScene() override;
+  void StopScene() override;
 
   // Record asset ids acquired for the current scene so StopScene/the next LoadScene releases
   // them. Deduped against ids already tracked. Called by the C++ scene loader and by the
   // `acquire_scene_assets` Lua global (which serves scenes that load via a side-effect script
   // rather than returning a table). Safe to call repeatedly with overlapping sets.
-  void TrackSceneAssets(const std::vector<std::string>& assetIds);
+  void TrackSceneAssets(const std::vector<std::string>& assetIds) override;
 
   // True between a successful LoadScene/ReloadScene and the next StopScene. The editor toolbar
   // uses this to decide whether Play should resume a paused scene or (re)start a stopped one.

--- a/src/Lua/LuaBindingContext.h
+++ b/src/Lua/LuaBindingContext.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+class Registry;
+struct EngineContext;
+struct SDL_Renderer;
+
+// Narrow host interface the Lua free-function modules (Lua/Modules/*) bind against, instead of
+// closing over the whole Game. Game implements it; module install fns take LuaBindingContext& so
+// the module .cpp files no longer #include "Game/Game.h" — breaking the module -> Game ->
+// (re)registers-modules cycle and letting tests supply a fake host.
+//
+// Surface is intentionally minimal: only what the shipped module bindings actually call. Widen it
+// when a binding needs something new, not preemptively.
+class LuaBindingContext {
+ public:
+  virtual ~LuaBindingContext() = default;
+
+  [[nodiscard]] virtual Registry* GetRegistry() const = 0;
+  [[nodiscard]] virtual SDL_Renderer* GetRenderer() const = 0;
+  [[nodiscard]] virtual EngineContext& GetContext() = 0;
+
+  virtual void LoadScene(const std::string& scenePath) = 0;
+  virtual void ReloadScene() = 0;
+  virtual void StopScene() = 0;
+  virtual void TrackSceneAssets(const std::vector<std::string>& assetIds) = 0;
+
+  [[nodiscard]] virtual bool IsBakeMode() const = 0;
+  virtual void RecordBakeValidationFailures(int failures) = 0;
+
+  // Request engine shutdown (the `quit_game` Lua global). Named distinctly from Game's static
+  // Quit() so the override doesn't collide with the static member.
+  virtual void RequestQuit() = 0;
+};

--- a/src/Lua/Modules/AssetsModuleLuaBinding.cpp
+++ b/src/Lua/Modules/AssetsModuleLuaBinding.cpp
@@ -4,10 +4,10 @@
 
 #include "AssetManager/AssetManager.h"
 #include "ECS/Registry.h"
-#include "Game/Game.h"
+#include "Lua/LuaBindingContext.h"
 
-void LuaModuleBinding<AssetsModule>::install(sol::state& lua, Game& game) {
-  lua.set_function("get_asset_path", [&game](const std::string& relativePath) {
-    return game.GetRegistry()->Get<AssetManager>().GetFullPath(relativePath);
+void LuaModuleBinding<AssetsModule>::install(sol::state& lua, LuaBindingContext& ctx) {
+  lua.set_function("get_asset_path", [&ctx](const std::string& relativePath) {
+    return ctx.GetRegistry()->Get<AssetManager>().GetFullPath(relativePath);
   });
 }

--- a/src/Lua/Modules/AssetsModuleLuaBinding.h
+++ b/src/Lua/Modules/AssetsModuleLuaBinding.h
@@ -6,5 +6,5 @@ struct AssetsModule {};
 
 template <>
 struct LuaModuleBinding<AssetsModule> {
-  static void install(sol::state& lua, Game& game);
+  static void install(sol::state& lua, LuaBindingContext& ctx);
 };

--- a/src/Lua/Modules/AudioModuleLuaBinding.cpp
+++ b/src/Lua/Modules/AudioModuleLuaBinding.cpp
@@ -6,12 +6,12 @@
 #include "Engine/EngineContext.h"
 #include "EventBus/EventBus.h"
 #include "Events/AudioPlayEvent.h"
-#include "Game/Game.h"
 #include "General/Logger.h"
+#include "Lua/LuaBindingContext.h"
 
-void LuaModuleBinding<AudioModule>::install(sol::state& lua, Game& game) {
-  lua.set_function("play_sound", [&game](const std::string& clipId, const sol::optional<float> volume) {
-    auto* eventBus = game.GetContext().eventBus;
+void LuaModuleBinding<AudioModule>::install(sol::state& lua, LuaBindingContext& ctx) {
+  lua.set_function("play_sound", [&ctx](const std::string& clipId, const sol::optional<float> volume) {
+    auto* eventBus = ctx.GetContext().eventBus;
     if (!eventBus) {
       Logger::Error("play_sound called before event bus is ready");
       return;

--- a/src/Lua/Modules/AudioModuleLuaBinding.h
+++ b/src/Lua/Modules/AudioModuleLuaBinding.h
@@ -6,5 +6,5 @@ struct AudioModule {};
 
 template <>
 struct LuaModuleBinding<AudioModule> {
-  static void install(sol::state& lua, Game& game);
+  static void install(sol::state& lua, LuaBindingContext& ctx);
 };

--- a/src/Lua/Modules/EntityModuleLuaBinding.cpp
+++ b/src/Lua/Modules/EntityModuleLuaBinding.cpp
@@ -7,9 +7,9 @@
 #include "Components/PositionComponent.h"
 #include "Components/SpriteComponent.h"
 #include "ECS/Registry.h"
-#include "Game/Game.h"
 #include "General/Logger.h"
 #include "Lua/Bindings/LuaComponentRegistry.h"
+#include "Lua/LuaBindingContext.h"
 
 namespace {
 glm::vec2 GetEntityPosition(Registry* registry, const Entity entity) {
@@ -58,29 +58,29 @@ void SetEntitySpriteSrcRect(Registry* registry, const Entity entity, const float
 }
 }  // namespace
 
-void LuaModuleBinding<EntityModule>::install(sol::state& lua, Game& game) {
-  lua.set_function("blam", [&game](const Entity entity) { game.GetRegistry()->BlamEntity(entity); });
-  lua.set_function("get_name", [&game](const Entity entity) { return GetEntityName(game.GetRegistry(), entity); });
-  lua.set_function("set_name", [&game](const Entity entity, const std::string& name) {
-    SetEntityName(game.GetRegistry(), entity, name);
+void LuaModuleBinding<EntityModule>::install(sol::state& lua, LuaBindingContext& ctx) {
+  lua.set_function("blam", [&ctx](const Entity entity) { ctx.GetRegistry()->BlamEntity(entity); });
+  lua.set_function("get_name", [&ctx](const Entity entity) { return GetEntityName(ctx.GetRegistry(), entity); });
+  lua.set_function("set_name", [&ctx](const Entity entity, const std::string& name) {
+    SetEntityName(ctx.GetRegistry(), entity, name);
   });
-  lua.set_function("find_entity_by_name", [&game](sol::this_state state, const std::string& name) {
-    return FindEntityByName(state, game.GetRegistry(), name);
+  lua.set_function("find_entity_by_name", [&ctx](sol::this_state state, const std::string& name) {
+    return FindEntityByName(state, ctx.GetRegistry(), name);
   });
   lua.set_function("get_position",
-                   [&game](const Entity entity) { return GetEntityPosition(game.GetRegistry(), entity); });
-  lua.set_function("set_position", [&game](const Entity entity, const double x, const double y) {
-    SetEntityPosition(game.GetRegistry(), entity, x, y);
+                   [&ctx](const Entity entity) { return GetEntityPosition(ctx.GetRegistry(), entity); });
+  lua.set_function("set_position", [&ctx](const Entity entity, const double x, const double y) {
+    SetEntityPosition(ctx.GetRegistry(), entity, x, y);
   });
-  lua.set_function("set_sprite_src_rect", [&game](const Entity entity, const float x, const float y) {
-    SetEntitySpriteSrcRect(game.GetRegistry(), entity, x, y);
+  lua.set_function("set_sprite_src_rect", [&ctx](const Entity entity, const float x, const float y) {
+    SetEntitySpriteSrcRect(ctx.GetRegistry(), entity, x, y);
   });
 
   lua["registry"] = lua.create_table();
   sol::table reg = lua["registry"];
 
-  reg.set_function("get_parent", [&game](sol::this_state state, const Entity entity) -> sol::object {
-    const auto parent = game.GetRegistry()->GetParent(entity);
+  reg.set_function("get_parent", [&ctx](sol::this_state state, const Entity entity) -> sol::object {
+    const auto parent = ctx.GetRegistry()->GetParent(entity);
     if (!parent.has_value()) return sol::lua_nil;
     return sol::make_object(state, parent.value());
   });
@@ -88,6 +88,6 @@ void LuaModuleBinding<EntityModule>::install(sol::state& lua, Game& game) {
   // Component has_/get_ accessors — driven by LuaComponentRegistry. Adding a new
   // component automatically exposes `registry.has_<key>` and `registry.get_<key>`.
   for (const auto& entry : LuaComponentRegistry::all()) {
-    entry.bindRegistryAccessors(reg, game.GetRegistry());
+    entry.bindRegistryAccessors(reg, ctx.GetRegistry());
   }
 }

--- a/src/Lua/Modules/EntityModuleLuaBinding.h
+++ b/src/Lua/Modules/EntityModuleLuaBinding.h
@@ -6,5 +6,5 @@ struct EntityModule {};
 
 template <>
 struct LuaModuleBinding<EntityModule> {
-  static void install(sol::state& lua, Game& game);
+  static void install(sol::state& lua, LuaBindingContext& ctx);
 };

--- a/src/Lua/Modules/GameModuleLuaBinding.cpp
+++ b/src/Lua/Modules/GameModuleLuaBinding.cpp
@@ -4,26 +4,26 @@
 
 #include "Components/CameraComponents.h"
 #include "ECS/Registry.h"
-#include "Game/Game.h"
 #include "Game/GameConfig.h"
+#include "Lua/LuaBindingContext.h"
 #include "Systems/ProjectileEmitSystem.h"
 
-void LuaModuleBinding<GameModule>::install(sol::state& lua, Game& game) {
-  lua.set_function("quit_game", &Game::Quit);
+void LuaModuleBinding<GameModule>::install(sol::state& lua, LuaBindingContext& ctx) {
+  lua.set_function("quit_game", [&ctx]() { ctx.RequestQuit(); });
 
-  lua.set_function("set_game_map_dimensions", [&game](const double width, const double height) {
-    auto& gameConfig = game.GetRegistry()->Get<GameConfig>();
+  lua.set_function("set_game_map_dimensions", [&ctx](const double width, const double height) {
+    auto& gameConfig = ctx.GetRegistry()->Get<GameConfig>();
     gameConfig.playableAreaHeight = static_cast<float>(height);
     gameConfig.playableAreaWidth = static_cast<float>(width);
   });
 
-  lua.set_function("get_game_map_dimensions", [&game]() {
-    const auto& gameConfig = game.GetRegistry()->Get<GameConfig>();
+  lua.set_function("get_game_map_dimensions", [&ctx]() {
+    const auto& gameConfig = ctx.GetRegistry()->Get<GameConfig>();
     return glm::vec2(gameConfig.playableAreaWidth, gameConfig.playableAreaHeight);
   });
 
-  lua.set_function("get_camera_position", [&game]() {
-    const auto& camera = game.GetRegistry()->Get<CameraComponent>();
+  lua.set_function("get_camera_position", [&ctx]() {
+    const auto& camera = ctx.GetRegistry()->Get<CameraComponent>();
     return glm::vec2(camera.viewport.x, camera.viewport.y);
   });
 
@@ -31,8 +31,8 @@ void LuaModuleBinding<GameModule>::install(sol::state& lua, Game& game) {
   // via input callbacks. dx/dy is a non-normalized aim vector; 0,0 falls back to the
   // emitter's configured velocity.
   lua.set_function(
-      "fire_projectile", [&game](const Entity emitter, const sol::optional<double> dx, const sol::optional<double> dy) {
-        auto* registry = game.GetRegistry();
+      "fire_projectile", [&ctx](const Entity emitter, const sol::optional<double> dx, const sol::optional<double> dy) {
+        auto* registry = ctx.GetRegistry();
         auto& projectileEmitSystem = registry->Get<ProjectileEmitSystem>();
         projectileEmitSystem.Fire(
             *registry, emitter, glm::vec2(static_cast<float>(dx.value_or(0.0)), static_cast<float>(dy.value_or(0.0))));

--- a/src/Lua/Modules/GameModuleLuaBinding.h
+++ b/src/Lua/Modules/GameModuleLuaBinding.h
@@ -6,5 +6,5 @@ struct GameModule {};
 
 template <>
 struct LuaModuleBinding<GameModule> {
-  static void install(sol::state& lua, Game& game);
+  static void install(sol::state& lua, LuaBindingContext& ctx);
 };

--- a/src/Lua/Modules/IoModuleLuaBinding.cpp
+++ b/src/Lua/Modules/IoModuleLuaBinding.cpp
@@ -31,6 +31,6 @@ std::vector<std::string> ReadFileLines(const std::string& filename) {
 }
 }  // namespace
 
-void LuaModuleBinding<IoModule>::install(sol::state& lua, Game& /*game*/) {
+void LuaModuleBinding<IoModule>::install(sol::state& lua, LuaBindingContext& /*ctx*/) {
   lua.set_function("read_file_lines", &ReadFileLines);
 }

--- a/src/Lua/Modules/IoModuleLuaBinding.h
+++ b/src/Lua/Modules/IoModuleLuaBinding.h
@@ -6,5 +6,5 @@ struct IoModule {};
 
 template <>
 struct LuaModuleBinding<IoModule> {
-  static void install(sol::state& lua, Game& game);
+  static void install(sol::state& lua, LuaBindingContext& ctx);
 };

--- a/src/Lua/Modules/LogModuleLuaBinding.cpp
+++ b/src/Lua/Modules/LogModuleLuaBinding.cpp
@@ -20,7 +20,7 @@ int LuaHandler(lua_State* /*lua_state*/, sol::optional<const std::exception&> ex
 }
 }  // namespace
 
-void LuaModuleBinding<LogModule>::install(sol::state& lua, Game& /*game*/) {
+void LuaModuleBinding<LogModule>::install(sol::state& lua, LuaBindingContext& /*ctx*/) {
   lua.set_function("log", &Logger::LogLua);
   lua.set_function("log_e", &Logger::ErrorLua);
   lua.set_function("log_w", &Logger::WarnLua);

--- a/src/Lua/Modules/LogModuleLuaBinding.h
+++ b/src/Lua/Modules/LogModuleLuaBinding.h
@@ -6,5 +6,5 @@ struct LogModule {};
 
 template <>
 struct LuaModuleBinding<LogModule> {
-  static void install(sol::state& lua, Game& game);
+  static void install(sol::state& lua, LuaBindingContext& ctx);
 };

--- a/src/Lua/Modules/LuaModule.h
+++ b/src/Lua/Modules/LuaModule.h
@@ -2,11 +2,11 @@
 
 #include <sol/sol.hpp>
 
-class Game;
+class LuaBindingContext;
 
 // Specialize for each module to expose a group of free-function globals to Lua.
 // Each specialization MUST provide:
-//   static void install(sol::state& lua, Game& game);
+//   static void install(sol::state& lua, LuaBindingContext& ctx);
 //
 // Modules install during Game::Setup (after CreateLuaBindings types, before
 // LuaSystemRegistry::bindAll). Add a new module by creating a header with a tag

--- a/src/Lua/Modules/RegisterAllModules.cpp
+++ b/src/Lua/Modules/RegisterAllModules.cpp
@@ -16,6 +16,6 @@ const std::vector<LuaModuleDescriptor> kLuaModules = {
     {"Game", &LuaModuleBinding<GameModule>::install},
 };
 
-void RegisterAllLuaModules(sol::state& lua, Game& game) {
-  for (const auto& m : kLuaModules) m.install(lua, game);
+void RegisterAllLuaModules(sol::state& lua, LuaBindingContext& ctx) {
+  for (const auto& m : kLuaModules) m.install(lua, ctx);
 }

--- a/src/Lua/Modules/RegisterAllModules.h
+++ b/src/Lua/Modules/RegisterAllModules.h
@@ -3,17 +3,17 @@
 #include <sol/sol.hpp>
 #include <vector>
 
-class Game;
+class LuaBindingContext;
 
 // Descriptor for a single Lua free-function module. The install function pointer matches
-// LuaModuleBinding<M>::install (sol::state&, Game&); the name is used by the modules.json index.
+// LuaModuleBinding<M>::install (sol::state&, LuaBindingContext&); the name is used by the modules.json index.
 struct LuaModuleDescriptor {
   const char* name;
-  void (*install)(sol::state&, Game&);
+  void (*install)(sol::state&, LuaBindingContext&);
 };
 
 // Authoritative install order. RegisterAllLuaModules iterates this; OctarineLuaApiTest iterates
 // the same list with per-module snapshots to discover which globals each module installs.
 extern const std::vector<LuaModuleDescriptor> kLuaModules;
 
-void RegisterAllLuaModules(sol::state& lua, Game& game);
+void RegisterAllLuaModules(sol::state& lua, LuaBindingContext& ctx);

--- a/src/Lua/Modules/SceneModuleLuaBinding.cpp
+++ b/src/Lua/Modules/SceneModuleLuaBinding.cpp
@@ -14,9 +14,9 @@
 #include "AssetManager/SceneAssetScanner.h"
 #include "ECS/Registry.h"
 #include "Engine/EngineContext.h"
-#include "Game/Game.h"
 #include "Game/GameConfig.h"
 #include "General/Logger.h"
+#include "Lua/LuaBindingContext.h"
 #include "Lua/LuaEntityLoader.h"
 
 namespace {
@@ -34,46 +34,46 @@ void LoadAsset(sol::table assetTable, AssetManager& assetManager, SDL_Renderer* 
 }
 }  // namespace
 
-void LuaModuleBinding<SceneModule>::install(sol::state& lua, Game& game) {
-  lua.set_function("load_asset", [&game](sol::table assetTable) {
-    auto* registry = game.GetRegistry();
+void LuaModuleBinding<SceneModule>::install(sol::state& lua, LuaBindingContext& ctx) {
+  lua.set_function("load_asset", [&ctx](sol::table assetTable) {
+    auto* registry = ctx.GetRegistry();
     auto& assetManager = registry->Get<AssetManager>();
 
     // Under bake there is no renderer/mixer to upload to, so skip the GPU/mixer load. But
     // load_asset is the explicit-file legacy path (it bypasses the catalog), so the bake's
     // catalog-membership check never sees these refs — validate the file on disk here instead so
     // a typo'd path in a direct load_asset call still fails the bake gate. The FS is real at bake.
-    if (game.IsBakeMode()) {
+    if (ctx.IsBakeMode()) {
       const std::string file = assetTable["file"].get_or<std::string>("");
       const std::string id = assetTable["id"].get_or<std::string>("");
       std::error_code ec;
       if (file.empty() || !std::filesystem::exists(assetManager.GetFullPath(file), ec)) {
         Logger::Error("load_asset (bake): id '" + id + "' maps to a missing file: '" +
                       (file.empty() ? "<none>" : assetManager.GetFullPath(file)) + "'");
-        game.RecordBakeValidationFailures(1);
+        ctx.RecordBakeValidationFailures(1);
       }
       return;
     }
 
-    LoadAsset(std::move(assetTable), assetManager, game.GetRenderer(), game.GetContext().mixer);
+    LoadAsset(std::move(assetTable), assetManager, ctx.GetRenderer(), ctx.GetContext().mixer);
   });
   // Scan a scene table for its required asset ids (sprite/font/audio + tilemap + preload),
   // validate them against the catalog, then acquire each. The data-driven replacement for a
   // manual load_asset loop; scripts using a custom loader call this instead of listing assets by
   // hand. Returns the number of assets successfully acquired. Raises a Lua error when validation
   // fails and the assetValidationFatal dev gate is set.
-  lua.set_function("acquire_scene_assets", [&game](const sol::table& scene) -> int {
-    auto* registry = game.GetRegistry();
+  lua.set_function("acquire_scene_assets", [&ctx](const sol::table& scene) -> int {
+    auto* registry = ctx.GetRegistry();
     auto& assetManager = registry->Get<AssetManager>();
-    MIX_Mixer* mixer = game.GetContext().mixer;
+    MIX_Mixer* mixer = ctx.GetContext().mixer;
 
     const std::vector<AssetReference> refs = SceneAssetScanner::CollectRefs(scene);
     const int failures = assetManager.Validate(refs);
 
     // Bake: tally unresolved references across every scene the startup script loads, then keep
     // running (don't throw on the first miss) so one bake run reports them all. No GPU upload.
-    if (game.IsBakeMode()) {
-      game.RecordBakeValidationFailures(failures);
+    if (ctx.IsBakeMode()) {
+      ctx.RecordBakeValidationFailures(failures);
       Logger::Info("acquire_scene_assets (bake): validated " + std::to_string(refs.size()) + " reference(s), " +
                    std::to_string(failures) + " unresolved.");
       return 0;
@@ -84,7 +84,7 @@ void LuaModuleBinding<SceneModule>::install(sol::state& lua, Game& game) {
                                " unresolved asset reference(s); assetValidationFatal is set.");
     }
 
-    const int acquired = assetManager.AcquireAll(refs, game.GetRenderer(), mixer);
+    const int acquired = assetManager.AcquireAll(refs, ctx.GetRenderer(), mixer);
 
     // Record the acquired ids on the Game so the next scene swap / StopScene releases them.
     // Without this, scenes that load via a side-effect script (rather than returning a table
@@ -94,16 +94,16 @@ void LuaModuleBinding<SceneModule>::install(sol::state& lua, Game& game) {
     for (const auto& ref : refs) {
       if (seen.insert(ref.id).second) ids.push_back(ref.id);
     }
-    game.TrackSceneAssets(ids);
+    ctx.TrackSceneAssets(ids);
 
     Logger::Info("acquire_scene_assets: acquired " + std::to_string(acquired) + " asset(s).");
     return acquired;
   });
-  lua.set_function("load_entity", [&game](const sol::table& assetTable) {
-    LuaEntityLoader::LoadEntityFromLua(game.GetRegistry(), assetTable);
+  lua.set_function("load_entity", [&ctx](const sol::table& assetTable) {
+    LuaEntityLoader::LoadEntityFromLua(ctx.GetRegistry(), assetTable);
   });
-  lua.set_function("clear_scene", [&game]() { game.StopScene(); });
-  lua.set_function("load_scene", [&game](const std::string& path) { game.LoadScene(path); });
-  lua.set_function("reload_scene", [&game]() { game.ReloadScene(); });
-  lua.set_function("stop_scene", [&game]() { game.StopScene(); });
+  lua.set_function("clear_scene", [&ctx]() { ctx.StopScene(); });
+  lua.set_function("load_scene", [&ctx](const std::string& path) { ctx.LoadScene(path); });
+  lua.set_function("reload_scene", [&ctx]() { ctx.ReloadScene(); });
+  lua.set_function("stop_scene", [&ctx]() { ctx.StopScene(); });
 }

--- a/src/Lua/Modules/SceneModuleLuaBinding.h
+++ b/src/Lua/Modules/SceneModuleLuaBinding.h
@@ -6,5 +6,5 @@ struct SceneModule {};
 
 template <>
 struct LuaModuleBinding<SceneModule> {
-  static void install(sol::state& lua, Game& game);
+  static void install(sol::state& lua, LuaBindingContext& ctx);
 };


### PR DESCRIPTION
## Summary

Stage 8 of the architecture-improvements plan. Lua free-function module bindings (`Lua/Modules/*`) closed over the whole `Game` and `#include`d `Game/Game.h`, creating a module→`Game` compile dependency on top of the existing `Game`→modules registration call — a cycle that also blocked installing any module against a test double.

New **`src/Lua/LuaBindingContext.h`** is an abstract interface exposing only the surface the shipped module bindings use:

- `GetRegistry()` / `GetRenderer()` / `GetContext()`
- `LoadScene` / `ReloadScene` / `StopScene` / `TrackSceneAssets`
- `IsBakeMode` / `RecordBakeValidationFailures`
- `RequestQuit` (the `quit_game` global — named distinctly from `Game`'s static `Quit()` so the override doesn't collide)

`Game` now `public`-inherits `LuaBindingContext` and marks its existing methods `override` (no new state; signatures already matched). `LuaModuleBinding<M>::install`, the `LuaModuleDescriptor` function pointer, and `RegisterAllLuaModules` take `LuaBindingContext&` instead of `Game&`. The five module `.cpp`s that used `Game` drop `Game/Game.h` for `Lua/LuaBindingContext.h`; `Io`/`Log` only needed the unused-param type swap. Callers (`EngineBootstrap`, `LuaApiSmokeTest`) still pass a `Game&`, which upcasts implicitly — no call-site changes.

**Pure internal refactor — no change to the Lua surface game authors see.** `modules.json` / `lua_api.smoke.lua` are byte-identical (no drift).

`grep '#include.*Game/Game.h' src/Lua/` now returns nothing — the stage's done-when condition.

## Test plan

- [x] `editor-release` builds clean; `ctest` 4/4 (LuaApi + AssetPipeline + Process + ProjectIni)
- [x] `player-release` builds clean
- [x] Headless `--startup-mode bake` of the example project exits 0 (exercises the SceneModule bake path through the new interface)
- [x] No Lua API artifact drift
- [ ] CI green
