### PR TITLE
Auto-apply clang-format to PRs

### DIFF
--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -1,0 +1,74 @@
+name: autoformat
+
+# Auto-applies clang-format to a PR's changed C/C++ sources and pushes the fixup back to the PR
+# branch, so contributors don't have to format by hand. The blocking `lint (clang-format)` job in
+# build.yml stays as the gate — it covers fork PRs (which this job can't push to) and acts as the
+# required status. Keep this job's clang-format version identical to that gate's.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+
+# Needed to push the fixup commit back to the PR branch.
+permissions:
+  contents: write
+
+# Supersede an in-flight autoformat when new commits land on the same PR.
+concurrency:
+  group: autoformat-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  autoformat:
+    name: autoformat (clang-format)
+    runs-on: ubuntu-latest
+    # Skip fork PRs: the token is read-only for forks and the push would fail. The lint gate still
+    # blocks them, so a fork contributor formats locally instead.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    env:
+      # MUST match build.yml's lint job. Bump both together and re-run the format target tree-wide.
+      CLANG_FORMAT_VERSION: 18.1.8
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+          # AUTOFORMAT_PAT (fine-grained PAT, contents:write) lets the fixup push re-trigger the
+          # lint/build checks on the new commit. With the default GITHUB_TOKEN the push still works,
+          # but pushed commits do NOT re-trigger workflows, so the required checks would stay on the
+          # pre-fix commit. See CONTRIBUTING.md "Format".
+          token: ${{ secrets.AUTOFORMAT_PAT || github.token }}
+
+      - name: Install pinned clang-format
+        run: pipx install "clang-format==${CLANG_FORMAT_VERSION}"
+
+      - name: Format changed files
+        shell: bash
+        run: |
+          base="${{ github.event.pull_request.base.sha }}"
+          mapfile -t files < <(git diff --name-only --diff-filter=ACMR "$base"...HEAD -- 'src/*' 'tests/*' \
+            | grep -E '\.(cpp|h|hpp)$' || true)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No changed C/C++ sources to format."
+            exit 0
+          fi
+          printf 'formatting:\n%s\n' "$(printf '  %s\n' "${files[@]}")"
+          clang-format -i -style=file "${files[@]}"
+
+      - name: Commit and push if anything changed
+        shell: bash
+        run: |
+          if git diff --quiet; then
+            echo "Already correctly formatted — nothing to push."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # No [skip ci]: with AUTOFORMAT_PAT this push must re-trigger lint/build on the fixed
+          # commit. No infinite loop — the re-triggered autoformat run finds nothing left to format
+          # and exits without pushing.
+          git commit -am "style: apply clang-format"
+          git push origin "HEAD:${{ github.event.pull_request.head.ref }}"
+          echo "::notice::Applied clang-format and pushed a fixup commit to this PR."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,8 +57,27 @@ CI runs both on the Linux editor-release leg.
 ### Format
 
 `.clang-format` is foundational. Run it before committing — most editors do
-this on save with the right config. CI does not currently auto-format, but
-PRs with format-noise diffs will get pushback.
+this on save with the right config.
+
+**Pinned version.** clang-format output differs between major versions, so CI
+pins an exact one (`CLANG_FORMAT_VERSION` in `.github/workflows/build.yml`).
+Match it locally — the simplest way is the pip wheel:
+
+```
+pipx install clang-format==18.1.8      # then: cmake --build <preset> --target format
+```
+
+**CI behavior.** Two jobs back this up:
+
+- `lint (clang-format)` (in build.yml) — blocking gate; fails a PR whose changed
+  files aren't formatted with the pinned version.
+- `autoformat` (autoformat.yml) — for same-repo PRs, formats the changed files
+  and pushes a fixup commit back to your branch automatically, so the gate goes
+  green on its own. Fork PRs aren't auto-pushed; format locally instead.
+
+> Maintainer setup: the auto-push uses a fine-grained PAT secret
+> `AUTOFORMAT_PAT` (repo scope, `contents: write`). Without it the job still runs
+> but its fixup commit won't re-trigger the required checks.
 
 ### Lint
 


### PR DESCRIPTION
## What
Adds `.github/workflows/autoformat.yml`: on a PR (same-repo branch), it formats the changed C/C++ sources with the pinned clang-format (18.1.8) and pushes a fixup commit back to the PR branch — so formatting is applied automatically instead of just being rejected.

## How it fits
- The blocking `lint (clang-format)` gate in `build.yml` stays as the required status and covers fork PRs (which can't be auto-pushed).
- Version is kept identical to the lint gate (`CLANG_FORMAT_VERSION: 18.1.8`).
- No infinite loop: the re-triggered run after a fixup finds nothing left to format and exits.

## ⚠️ Required maintainer setup
For the fixup commit to **re-trigger the required checks** (lint/build) on the new commit, add a repo secret **`AUTOFORMAT_PAT`** — a fine-grained PAT scoped to this repo with **`contents: write`**. Without it the job still runs and pushes, but pushes made with the default `GITHUB_TOKEN` do not re-trigger workflows, so the required checks would remain on the pre-fix commit.

CONTRIBUTING.md "Format" section updated with the pinned-version install (`pipx install clang-format==18.1.8`) and this CI behavior.