### PR TITLE
Add systems, events, and profiling reference docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ see [`docs/device-builds.md`](docs/device-builds.md). Shipping config is the `sh
 preset (and `ship-mac-universal` for universal macOS).
 
 Contributing? See [`CONTRIBUTING.md`](CONTRIBUTING.md) for workflow, coding
-standards, commit style, and the `SRC_FILES` rule.
+standards, commit style, and how to register new source files.
 
 ### Running the Engine
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -74,17 +74,20 @@ CI (`.github/workflows/build.yml`) runs both on the Linux editor-release leg on 
 | To add… | Touch points |
 |---------|--------------|
 | A **component** | `src/Components/X.h` + `src/Lua/Bindings/XLuaBinding.h` + a `registerComponent<X>()` line in `src/Lua/Bindings/RegisterAllBindings.cpp`. Header-only — no CMake edit. |
-| A **Lua module** (free-function globals) | `src/Lua/Modules/XModuleLuaBinding.{h,cpp}` + an `install` line in `src/Lua/Modules/RegisterAllModules.cpp` + append the `.cpp` to `SRC_FILES` in `CMakeLists.txt`. |
-| A **system** | `src/Systems/X.h` + a registration call in `Game::Setup` (`RegisterSystem` / `RegisterParallelSystem` / `RegisterBulkSystem`). Optional `LuaSystemBinding<X>` if it exposes a Lua surface. Mind `Game::Setup` ordering — see [`docs/lua-scripting.md`](lua-scripting.md). |
-| An **event** | `src/Events/X.h` + `EmitEvent<X>(...)` in producers + `SubscribeEvent<X>(...)` in each consumer's `Init`. |
-| A **new `.cpp`** under `src/` | Append to `SRC_FILES` in `CMakeLists.txt`. |
+| A **Lua module** (free-function globals) | `src/Lua/Modules/XModuleLuaBinding.{h,cpp}` + an `install` line in `src/Lua/Modules/RegisterAllModules.cpp` + add the `.cpp` to the `octarine_lua` list in `src/CMakeLists.txt`. |
+| A **system** | `src/Systems/X.h` + a registration call in `Game::Setup` (`RegisterSystem` / `RegisterParallelSystem` / `RegisterBulkSystem`). Optional `LuaSystemBinding<X>` if it exposes a Lua surface. Mind registration order — see [`docs/systems.md`](systems.md). |
+| An **event** | `src/Events/X.h` + `EmitEvent<X>(...)` in producers + `SubscribeEvent<X>(...)` in each consumer's `Init` — see [`docs/events.md`](events.md). |
+| A **new `.cpp`** under `src/` | Add it to the matching per-layer source list in `src/CMakeLists.txt` (`octarine_core`/`_assets`/`_renderer`/`_lua`/`_systems`/`_editor`/`_engine`). |
 
 ## Deeper reading
 
 - [`docs/ecs-architecture.md`](ecs-architecture.md) — archetype graph, chunk storage, query model
 - [`docs/ecs-components.md`](ecs-components.md) — every component's Lua shape
 - [`docs/lua-scripting.md`](lua-scripting.md) — how Lua scripts wire into the engine
+- [`docs/systems.md`](systems.md) — built-in systems and the order they run in
+- [`docs/events.md`](events.md) — the event bus and every event type
 - [`docs/scenes.md`](scenes.md) — scene file shape, lifecycle, `load_scene` / `reload_scene`
 - [`docs/asset-pipeline.md`](asset-pipeline.md) — `.meta` sidecars, bake step, atlases, audio normalize
+- [`docs/profiling.md`](profiling.md) — profiling build, PerfUtils, benchmarks, the perf dashboard
 - [`docs/device-builds.md`](device-builds.md) — shipping artifacts for desktop and Android
 - `lua_api.smoke.lua` — generated, exhaustive reference for the live Lua surface

--- a/docs/events.md
+++ b/docs/events.md
@@ -1,0 +1,63 @@
+# Events
+
+The engine has a small, type-erased publish/subscribe bus for decoupled communication — input,
+collisions, and audio triggers flow through it rather than through direct calls between systems.
+
+## The bus
+
+`EventBus` (`src/EventBus/EventBus.h`) keys subscriptions by `std::type_index`, so any C++ type can be
+an event; there's no base-class requirement beyond deriving from the empty `Event` marker
+(`src/EventBus/Event.h`). The single bus instance lives in the engine's `EngineContext` singleton
+(`src/Engine/EngineContext.h`), reachable as `registry->Get<EngineContext>().eventBus`. Systems
+usually receive it in their `Init` / `SubscribeToEvents` hook rather than fetching it themselves.
+
+API:
+
+- `SubscribeEvent<Owner, Event>(owner, &Owner::method)` — register a member-function handler. The
+  handler takes `Event&` or `const Event&` (both overloads exist).
+- `EmitEvent<Event>(args...)` — construct an `Event` from `args` and dispatch it to every subscriber,
+  synchronously, in subscription order. Emitting an event with no subscribers is a no-op.
+- `UnsubscribeAll(owner)` — drop every subscription owned by `owner`.
+
+```cpp
+// Subscribe (typically in a system's Init/SubscribeToEvents):
+eventBus->SubscribeEvent<DamageSystem, CollisionEvent>(this, &DamageSystem::OnCollision);
+
+// Emit (from wherever the thing happens):
+eventBus->EmitEvent<CollisionEvent>(entityA, entityB);
+```
+
+Subscriptions are wired once during startup (`Game::Setup`, each system's `Init` /
+`SubscribeToEvents`) and persist for the lifetime of the bus.
+
+> **Dangling-callback hazard.** The bus stores raw owner pointers. If a subscriber is destroyed
+> before the bus, the next `EmitEvent` calls into freed memory. A subscriber whose lifetime can end
+> before the bus's must call `eventBus->UnsubscribeAll(this)` in its destructor. (Today's subscribers
+> all live as long as the bus, so none do — keep this in mind when adding a shorter-lived one.)
+
+## Event catalog
+
+| Event | Payload | Emitted by | Subscribed by |
+|-------|---------|------------|---------------|
+| `AudioPlayEvent` | `clipId: string`, `volume: float` | Lua `play_sound()` (`AudioModuleLuaBinding.cpp`) | `AudioSystem::OnAudioPlay` |
+| `CollisionEvent` | `entityA: Entity`, `entityB: Entity` | `CollisionSystem` (narrowphase) | `DamageSystem::OnCollision`, `ObstacleBounceSystem::OnCollision` |
+| `KeyInputEvent` | `inputKey: SDL_Keycode`, `inputModifier: SDL_Keymod`, `isPressed: bool` | `Game::ProcessInput` (SDL key events) | `InputSystem::OnKeyInput`, `Game::OnKeyInputEvent` |
+| `MouseInputEvent` | `event: SDL_MouseButtonEvent` | `Game::ProcessInput` (SDL mouse-button events) | `InputSystem::OnMouseInput`, `UIButtonSystem::OnMouseInput` |
+| `MouseWheelEvent` | `dx: float`, `dy: float` | `Game::ProcessInput` (SDL wheel events) | `InputSystem::OnMouseWheel` |
+
+Event types live in `src/Events/`.
+
+### Flows at a glance
+
+- **Input:** SDL events → `Game::ProcessInput` emits `KeyInputEvent` / `MouseInputEvent` /
+  `MouseWheelEvent` → `InputSystem` folds them into per-frame state (also `Game` for engine hotkeys,
+  `UIButtonSystem` for clicks).
+- **Collision:** `CollisionSystem` detects overlaps and emits `CollisionEvent` → `DamageSystem` and
+  `ObstacleBounceSystem` react.
+- **Audio:** Lua `play_sound(clip, volume)` emits `AudioPlayEvent` → `AudioSystem` plays the clip.
+
+## Adding an event
+
+Add `src/Events/<Name>Event.h` (derive from `Event`, give it a constructor over its payload). Emit it
+with `EmitEvent<Name>(...)` at the producing site, and subscribe in each consumer's `Init` /
+`SubscribeToEvents`. No registration list to update — the bus discovers types on first use.

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -1,0 +1,69 @@
+# Profiling and benchmarks
+
+The engine has three layers of performance tooling: compile-time scoped timers you can sprinkle in
+code, a macro-benchmark harness that runs the real engine headless, and micro-benchmarks for hot data
+structures. CI tracks the latter two nightly.
+
+## The `player-profile` preset
+
+Profiling instrumentation is compiled out by default (zero overhead). Turn it on with the
+`player-profile` preset, which builds `RelWithDebInfo` with `OCTARINE_ENABLE_PROFILING=ON`:
+
+```bash
+cmake --preset player-profile
+cmake --build build/player-profile
+./build/player-profile/bin/relwithdebinfo/OctarineEngine-player ../Octarine-Engine-Example
+```
+
+`OCTARINE_ENABLE_PROFILING` defines `OCTARINE_PROFILING`, which activates the `PerfUtils` macros. With
+it off, every macro below expands to `((void)0)`.
+
+## In-code timers — `src/General/PerfUtils.h`
+
+| Macro | Use |
+|-------|-----|
+| `PROFILE_SCOPE` | Time the enclosing scope, labeled by function name. Emits a `TIMER:` line. |
+| `PROFILE_NAMED_SCOPE(name)` | Same, with an explicit label. |
+| `ACCUMULATE_PROFILE_SCOPE(name)` | Accumulate time across many calls under one label (per-frame totals). |
+| `PROFILE_COUNTER_ADD/SET/INC(name, …)` | Numeric counters (e.g. chunks processed). |
+| `PROFILE_COUNTERS_REPORT()` | Dump accumulated counters. |
+
+`Registry::Update` already wraps each system in `ACCUMULATE_PROFILE_SCOPE(<system name>)`, so a
+profiling build gives you per-system frame costs for free. In ImGui builds, `RenderDebugGUISystem`
+surfaces these in an on-screen profiler window.
+
+## Macro-benchmarks — `scripts/bench.sh`
+
+Runs the actual engine headless for a few seconds and captures the `TIMER:` output:
+
+```bash
+scripts/bench.sh [duration_seconds]   # default 8s
+```
+
+It builds the `player-profile` preset if needed, runs with `SDL_VIDEODRIVER=dummy` /
+`SDL_AUDIODRIVER=dummy` and `--startup-mode stress`, then formats the timer stream via
+`scripts/parse_bench_output.py`. Override the game dir with `OCT_BENCH_GAME` and the scene with
+`OCT_BENCH_MODE` (default `stress`; the example game also accepts `main`, `map_editor`, `overlap`).
+
+## Micro-benchmarks — Google Benchmark
+
+Targeted benchmarks for hot paths (e.g. entity create/blam, pool spawn) live in `tests/benchmarks/`
+and build into `OctarineBenchmarks` when `OCTARINE_ENABLE_BENCHMARKS=ON`:
+
+```bash
+cmake --preset player-profile -DOCTARINE_ENABLE_BENCHMARKS=ON
+cmake --build build/player-profile --target OctarineBenchmarks
+./build/player-profile/bin/relwithdebinfo/OctarineBenchmarks --benchmark_format=json
+```
+
+## CI and the dashboard
+
+`.github/workflows/benchmark.yml` runs nightly on a self-hosted runner (for stable numbers), and on
+manual dispatch. It runs both the micro and macro suites and publishes results via
+`benchmark-action/github-action-benchmark` to GitHub Pages (the project's Pages site, under
+`dev/bench/`), so you can watch trends over time.
+
+Regressions past the **200%** alert threshold are flagged but **do not fail** the run — the dashboard
+and alert are advisory. Benchmarks are intentionally not part of the per-PR gate (they need the
+dedicated runner); check the dashboard after a perf-sensitive change rather than relying on CI to
+block one.

--- a/docs/systems.md
+++ b/docs/systems.md
@@ -1,0 +1,89 @@
+# Built-in systems
+
+Systems are the logic half of the ECS. Each one runs a query over entities with a given set of
+components and does work every frame. This page catalogs the engine's built-in systems and — just as
+importantly — the **order they run in**, which is load-bearing for correct behavior.
+
+For how systems are written and the three execution models (serial / parallel / bulk), see
+[`ecs-architecture.md`](ecs-architecture.md). For the Lua side, see
+[`lua-scripting.md`](lua-scripting.md).
+
+## How systems run
+
+Systems are registered on the `Registry` during engine startup and driven once per frame by
+`Registry::Update(dt)`:
+
+- `RegisterSystem<Components...>(fn)` — serial, one call per matching entity.
+- `RegisterParallelSystem<Components...>(fn)` — same, but chunks are spread across a thread pool.
+  The callback must be data-parallel (no shared mutable state); registry mutations go through an
+  `EntityCommandBuffer` played back after the pass.
+- `RegisterBulkSystem<Components...>(fn)` — called once per frame with the whole matching set, for
+  full-pass work (transforms, collision broadphase).
+
+**Registration order is execution order.** There is no separate scheduling layer — the sequence below
+is exactly the order written in `Game::Setup` (which composes the shared boot phases in
+`src/Engine/EngineBootstrap.{h,cpp}`). That file is the source of truth; this table mirrors it. A
+handful of systems are *not* per-frame: they are event-driven or invoked on demand (see the later
+sections).
+
+## Per-frame update order
+
+| # | System | Model · query | What it does |
+|--:|--------|---------------|--------------|
+| 1 | `ScriptSystem` | serial · `ScriptComponent` | Runs each entity's Lua `on_update` (and `on_debug_gui`) callback. |
+| 2 | `AudioSystem` | serial · `AudioSourceComponent` | Drives the mixer / audio-track pool; also handles `AudioPlayEvent` (see below). |
+| 3 | `AnimationSystem` | parallel · `SpriteComponent, AnimationComponent` | Advances frame timers and updates the sprite source rect. |
+| 4 | `ProjectileLifecycleSystem` | parallel · `ProjectileComponent` | Counts down projectile lifetime and despawns on expiry. |
+| 5 | `VelocityIntegrationSystem` | parallel · `PositionComponent, RigidBodyComponent` | Integrates velocity into local position. Runs **before** transform resolution. |
+| 6 | `OffScreenDespawnSystem` | parallel · `PositionComponent, SpriteComponent` | Despawns non-player entities that leave the playable bounds. |
+| 7 | `TransformSystem` | bulk · `GlobalTransformComponent` (+ optional position/scale/rotation) | Resolves the entity hierarchy into world-space `GlobalTransformComponent`. Fast path when no `ChildOf` relationships exist. |
+| 8 | `CollisionSystem` | bulk · `GlobalTransformComponent, BoxColliderComponent, EntityMaskComponent` | Broadphase + OBB narrowphase; **emits `CollisionEvent`** for each overlapping pair. |
+| 9 | `UpdateListenerTransformSystem` | bulk · `GlobalTransformComponent, AudioListenerComponent` | Snapshots the active listener's position/velocity for the spatial-audio chain. |
+| 10 | `AudioCullingSystem` | serial · `GlobalTransformComponent, AudioSourceComponent` | Gates spatial sources by listener radius (adds/removes the active tag + sink). |
+| 11 | `SpatialAudioSystem` | serial · `GlobalTransformComponent, AudioSourceComponent, AudioSinkComponent` | Distance attenuation + stereo pan for active spatial sources. |
+| 12 | `DopplerSystem` | serial · `GlobalTransformComponent, RigidBodyComponent, AudioSourceComponent, AudioSinkComponent` | Doppler pitch shift from relative emitter/listener velocity. |
+| 13 | `CameraFollowSystem` | serial · `PositionComponent, CameraFollowComponent` | Moves the camera viewport to follow its target within bounds. |
+| 14 | `RenderSpriteSystem` | parallel · `GlobalTransformComponent, SpriteComponent` | Resolves textures and enqueues visible sprites into the render queue (viewport-culled). |
+| 15 | `RenderTextSystem` | serial · `TextLabelComponent` | Rasterizes/caches glyphs and enqueues visible text (viewport-culled). |
+| 16 | `RenderPrimitiveSystem` | parallel · `SquarePrimitiveComponent, GlobalTransformComponent` | Enqueues square primitives (viewport-culled). |
+
+The render systems (14–16) only *produce* render-queue entries; `Game::Render` sorts the queue and
+draws it after `Update` (see [`ecs-architecture.md`](ecs-architecture.md) § Rendering).
+
+### Why the order matters
+
+- **Velocity (5) → Transform (7) → Collision (8) / Render (14–16):** local position must be integrated
+  before transforms resolve, and transforms must be world-space before collision and rendering read
+  them.
+- **Listener (9) → cull (10) → spatial (11) → doppler (12):** the spatial-audio chain depends on the
+  current listener snapshot, then progressively narrows to the sources that need full processing.
+
+## Event-driven systems
+
+These are created and subscribed during setup but do **not** run on a per-frame query — they react to
+events on the [event bus](events.md):
+
+| System | Reacts to | What it does |
+|--------|-----------|--------------|
+| `DamageSystem` | `CollisionEvent` | Applies projectile damage / health deduction and despawns. |
+| `ObstacleBounceSystem` | `CollisionEvent` | Bounces an entity off an obstacle and flips its sprite. |
+| `UIButtonSystem` | `MouseInputEvent` | Hit-tests clicks against button colliders and invokes callbacks. |
+
+## Services and on-demand systems
+
+Not per-frame query systems, but part of the engine:
+
+| System | How it's used | Lua surface |
+|--------|---------------|-------------|
+| `InputSystem` | Installed at boot; subscribes to the input events and tracks per-frame key/mouse/wheel state and action bindings. | `input.*` (held/pressed/released, actions) |
+| `EntityPoolManager` (`EntityPoolSystem.h`) | Object pool for recycling entities (e.g. projectiles); used by `ProjectileEmitSystem`. | — |
+| `ProjectileEmitSystem` | Installed at boot; spawns projectiles on demand, driven by the Lua `fire_projectile` global. | via `fire_projectile` |
+| `DrawColliderSystem` | Instantiated per frame in `Game::Render` only when the `drawColliders` option is on. Draws collider wireframes. | debug (ImGui builds) |
+| `RenderDebugGUISystem` | Called from `Game::Render`; renders the ImGui editor/profiler/hierarchy. Compiled out unless `OCTARINE_WITH_IMGUI`. | editor UI |
+
+## Adding a system
+
+`src/Systems/<Name>System.{h,cpp}` (a `.cpp` also goes in the `octarine_systems` list in
+`src/CMakeLists.txt`), then register it in `Game::Setup` at the right point in the order above. If it
+needs a Lua surface, add a `LuaSystemBinding` (see [`lua-scripting.md`](lua-scripting.md)); if it
+reacts to events, subscribe in its `Init` / `SubscribeToEvents` hook (see [`events.md`](events.md)).


### PR DESCRIPTION
Reference docs for surfaces that previously lived only in source — part of making the repo navigable without grepping.

- **`docs/systems.md`** — every built-in system with its execution model and component query, in **registration (= execution) order** taken from `Game::Setup`/`EngineBootstrap` (the order is load-bearing). Plus the event-driven systems and the on-demand/service systems (InputSystem, pools, debug/editor).
- **`docs/events.md`** — the `EventBus` model (now held in the `EngineContext` singleton), the subscribe/emit/unsubscribe API, the dangling-callback hazard, and a catalog of all five events with payload, emitters, and subscribers.
- **`docs/profiling.md`** — the `player-profile` preset, `PerfUtils` macros, `scripts/bench.sh` macro-benchmarks, the Google Benchmark micro suite, and the nightly dashboard / 200% advisory threshold.

All three are cross-linked from `QUICKSTART.md` § Deeper reading.

Also fixes leftover `SRC_FILES` references in `QUICKSTART.md` and `README.md` from the engine-layer CMake split (new sources go in the per-layer lists in `src/CMakeLists.txt`).

**Not included:** `tilemaps.md` — tilemaps aren't implemented yet (no loader/system in `src/`), so there's nothing to document. `project.ini` is already consolidated in `device-builds.md`.
