### PR TITLE
CI: cancel superseded PR builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,13 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+# Cancel a PR's in-flight build when a newer commit lands on it — e.g. the fixup the autoformat
+# workflow pushes — so the full matrix doesn't run twice. Pushes to main are NOT cancelled (each
+# gets its own group via github.ref) so every mainline build completes.
+concurrency:
+  group: build-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
 


### PR DESCRIPTION
## What
Adds a workflow-level `concurrency` group to `build.yml` so that when a newer commit lands on a PR, the in-flight build matrix is cancelled rather than run to completion alongside the new one.

## Why
The new `autoformat` workflow (#104) pushes a fixup commit to a PR when it reformats. Without this, that second commit triggers a *second* full Linux/macOS/Windows/Android matrix while the first is still running. This cancels the now-superseded run.

## Safety
- Cancellation is gated to `pull_request` events only (`cancel-in-progress: ${{ github.event_name == 'pull_request' }}`).
- Pushes to `main` group by `github.ref`, so every mainline build runs to completion (artifacts/caching unaffected).