### PR TITLE
[DO NOT MERGE] Verify autoformat + PAT

### DIFF
--- a/src/AutoFormatProbe.h
+++ b/src/AutoFormatProbe.h
@@ -1,0 +1,14 @@
+#pragma once
+
+// TEMPORARY probe to verify the autoformat CI workflow end-to-end. Never included anywhere, so it
+// cannot affect the build. This PR is not meant to be merged — delete the file / close the PR after.
+namespace octarine
+{
+
+struct AutoFormatProbe
+{
+    int    value=0   ;
+    bool   ready =false ;
+};
+
+}  // namespace octarine

--- a/src/AutoFormatProbe.h
+++ b/src/AutoFormatProbe.h
@@ -2,13 +2,11 @@
 
 // TEMPORARY probe to verify the autoformat CI workflow end-to-end. Never included anywhere, so it
 // cannot affect the build. This PR is not meant to be merged — delete the file / close the PR after.
-namespace octarine
-{
+namespace octarine {
 
-struct AutoFormatProbe
-{
-    int    value=0   ;
-    bool   ready =false ;
+struct AutoFormatProbe {
+  int value = 0;
+  bool ready = false;
 };
 
 }  // namespace octarine


### PR DESCRIPTION
Throwaway PR to verify the `autoformat` workflow and the new `AUTOFORMAT_PAT` secret.

`src/AutoFormatProbe.h` is deliberately mis-formatted (and never #included, so it can't affect the build).

**Expected:** the `autoformat` job reformats it and pushes a fixup commit, and — because the push uses `AUTOFORMAT_PAT` — the lint/build checks **re-run on that fixup commit** and go green.

Will be closed without merging.