### PR TITLE
LLM-Workability tail: system/event catalogs, blocking clang-tidy, tilemaps doc

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,25 +123,34 @@ jobs:
             modules.json
           if-no-files-found: error
 
-      # Advisory clang-tidy over the PR's changed .cpp files, using the compile_commands.json the
-      # editor-release build just emitted. Non-blocking (continue-on-error) for now: the 81-check
-      # ruleset against a codebase with no tidy history surfaces pre-existing debt, so gating hard
-      # would block unrelated PRs. Staged to changed-lines-as-errors later once the set is clean.
-      - name: clang-tidy (advisory)
+      # Blocking clang-tidy over the PR's changed LINES (not whole files), using the
+      # compile_commands.json the editor-release build just emitted. clang-tidy-diff.py with -U0
+      # restricts diagnostics to lines the PR actually touched, so pre-existing debt in a modified
+      # file never blocks an unrelated change while any new violation fails the job. (Previously
+      # advisory/continue-on-error; tightened now that the changed-file set is reliably clean.)
+      - name: clang-tidy (changed lines, blocking)
         if: matrix.platform == 'linux' && matrix.preset == 'editor-release' && github.event_name == 'pull_request'
-        continue-on-error: true
         shell: bash
         run: |
-          sudo apt-get update && sudo apt-get install -y clang-tidy
+          sudo apt-get update && sudo apt-get install -y clang-tidy-18
           base="${{ github.event.pull_request.base.sha }}"
-          mapfile -t files < <(git diff --name-only --diff-filter=ACMR "$base"...HEAD -- 'src/*' 'tests/*' \
-            | grep -E '\.cpp$' || true)
-          if [ ${#files[@]} -eq 0 ]; then
+          changed="$(git diff --name-only --diff-filter=ACMR "$base"...HEAD -- 'src/*' 'tests/*' | grep -E '\.cpp$' || true)"
+          if [ -z "$changed" ]; then
             echo "No changed .cpp files to lint."
             exit 0
           fi
-          printf 'tidying:\n%s\n' "$(printf '  %s\n' "${files[@]}")"
-          clang-tidy -p build/${{ matrix.preset }} "${files[@]}"
+          printf 'tidying changed lines in:\n%s\n' "$(printf '  %s\n' $changed)"
+          # clang-tidy-diff.py ships inside the llvm-18 toolchain; fall back to the pinned upstream copy.
+          diff_tool="$(find /usr/lib/llvm-18 -name 'clang-tidy-diff.py' 2>/dev/null | head -1)"
+          if [ -z "$diff_tool" ]; then
+            diff_tool="$RUNNER_TEMP/clang-tidy-diff.py"
+            curl -fsSL https://raw.githubusercontent.com/llvm/llvm-project/llvmorg-18.1.8/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py -o "$diff_tool"
+          fi
+          # -p1 strips the a/ b/ diff prefixes; -path points at compile_commands.json; any diagnostic
+          # on a touched line is promoted to an error and fails the step.
+          git diff -U0 "$base"...HEAD -- 'src/*' 'tests/*' \
+            | python3 "$diff_tool" -p1 -path "build/${{ matrix.preset }}" \
+                -clang-tidy-binary clang-tidy-18 -warnings-as-errors='*'
 
       - name: Stage runtime DLLs (Windows)
         if: matrix.platform == 'windows'
@@ -164,8 +173,8 @@ jobs:
 
   # Style gate. Lightweight (no vcpkg/SDL): formats only the files a PR actually changed, so the
   # large pre-existing tree never blocks on legacy style. Auto-fixable via the CMake `format` target.
-  # clang-tidy runs as an advisory (non-blocking) step in the editor-release build leg above, which
-  # has the compile_commands.json it needs; it will be tightened to blocking on changed lines later.
+  # clang-tidy runs as a blocking changed-lines gate in the editor-release build leg above, which
+  # has the compile_commands.json it needs. This job also drift-gates the static system/event catalogs.
   lint:
     name: lint (clang-format)
     runs-on: ubuntu-latest
@@ -198,5 +207,16 @@ jobs:
           printf 'checking:\n%s\n' "$(printf '  %s\n' "${files[@]}")"
           if ! clang-format --dry-run --Werror -style=file "${files[@]}"; then
             echo "::error::clang-format violations. Fix with pinned clang-format ${CLANG_FORMAT_VERSION}: cmake --build build/editor-release --target format"
+            exit 1
+          fi
+
+      # systems.json / events.json are produced by static source inspection (no build needed), so
+      # the drift gate lives here in the lightweight lint job rather than the editor-release leg that
+      # gates the runtime-introspected components.json / modules.json. Regenerate + diff.
+      - name: Check system/event catalog drift
+        shell: bash
+        run: |
+          if ! python3 scripts/gen_api_catalogs.py --check; then
+            git diff -- systems.json events.json | head -200
             exit 1
           fi

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -88,6 +88,7 @@ CI (`.github/workflows/build.yml`) runs both on the Linux editor-release leg on 
 - [`docs/events.md`](events.md) — the event bus and every event type
 - [`docs/editor.md`](editor.md) — editor windows, hotkeys, Run Player, Export Build
 - [`docs/scenes.md`](scenes.md) — scene file shape, lifecycle, `load_scene` / `reload_scene`
+- [`docs/tilemaps.md`](tilemaps.md) — what the scene `tilemap` field does (and doesn't) today
 - [`docs/asset-pipeline.md`](asset-pipeline.md) — `.meta` sidecars, bake step, atlases, audio normalize
 - [`docs/profiling.md`](profiling.md) — profiling build, PerfUtils, benchmarks, the perf dashboard
 - [`docs/device-builds.md`](device-builds.md) — shipping artifacts for desktop and Android

--- a/docs/scenes.md
+++ b/docs/scenes.md
@@ -60,7 +60,8 @@ return {
     -- Optional: ids the static scan can't see (runtime spawns, load-time injection).
     preload = { "explosion", "music-gameplay" },
 
-    -- Optional: tilemap drives a parallel asset reference and renders into the world.
+    -- Optional: only texture_asset_id is tracked as an asset reference today; the `map`
+    -- file is not yet parsed or rendered by the engine. See docs/tilemaps.md.
     tilemap = {
         texture_asset_id = assets["tilemap-forest"],
         map = "tilemaps/forest.map",

--- a/docs/tilemaps.md
+++ b/docs/tilemaps.md
@@ -1,0 +1,85 @@
+# Tilemaps
+
+What Octarine does with a scene's `tilemap` today, and — just as important — what
+it does **not** yet do. Read this before assuming the engine parses or renders a
+tile grid: it does not.
+
+Audience: project authors who see `tilemap` in scene files and want to know what
+it actually buys them. Scene file shape and lifecycle live in
+[`docs/scenes.md`](scenes.md); the asset/refcount side is in
+[`docs/asset-pipeline.md`](asset-pipeline.md).
+
+---
+
+## The `tilemap` field in a scene
+
+A scene table may carry an optional `tilemap` block (see
+[`docs/scenes.md`](scenes.md) for the full scene shape):
+
+```lua
+return {
+    tilemap = {
+        texture_asset_id = assets["tilemap-forest"],
+        map = "tilemaps/forest.map",
+    },
+    entities = { --[[ ... ]] },
+}
+```
+
+## What the engine does with it today
+
+Exactly one thing: **asset tracking for the texture.** When a scene loads,
+`SceneAssetScanner` reads `tilemap.texture_asset_id` and adds it to the scene's
+asset reference set so the texture is acquired (and refcount-released on swap)
+alongside everything else — see `src/AssetManager/SceneAssetScanner.cpp` (the
+`tilemap.` branch) and the per-scene tracking in `Game::TrackSceneAssets`.
+
+That is the whole integration. In particular, the engine does **not**:
+
+- **parse the `map` file.** The `map = "tilemaps/forest.map"` path is a plain
+  string. No `.map` format is defined, and no loader reads it — the scanner only
+  pulls `texture_asset_id` out of the `tilemap` table, never `map`.
+- **build a tile grid** or expose any tile-query API (no "tile at (x, y)").
+- **render tiles.** `RenderSpriteSystem` draws individual sprite entities; there
+  is no tilemap layer/renderer. See [`docs/systems.md`](systems.md).
+- **collide against tiles.** `CollisionSystem` operates on `BoxColliderComponent`
+  entities, not tiles.
+
+Treat `tilemap.map` as a forward-looking convention a project may adopt: today it
+is the project's own responsibility to load and interpret that file (e.g. from a
+scene or startup script). There is intentionally no engine `.map` schema to
+conform to yet.
+
+## Map dimensions ≠ a tilemap
+
+The one map-shaped runtime surface that *is* wired up is the **playable-area
+size**, exposed from Lua and unrelated to any tile grid:
+
+```lua
+set_game_map_dimensions(width, height)   -- sets the playable area
+local size = get_game_map_dimensions()   -- -> vec2(width, height)
+```
+
+These read/write `GameConfig.playableAreaWidth/Height`, which bound
+`OffScreenDespawnSystem` (entities outside the area despawn). They define
+*world extents for despawn*, not a tile layout. See
+`src/Lua/Modules/GameModuleLuaBinding.cpp`.
+
+## Building tiled levels in the meantime
+
+Until a `.map` loader exists, lay out tiled content as ordinary sprite entities
+in the scene's `entities` list (one entity per tile, or larger sprites for
+backgrounds), reusing the shared `tilemap.texture_asset_id` as each sprite's
+texture. The entity-from-table shape is documented in
+[`docs/scenes.md`](scenes.md) and [`docs/ecs-components.md`](ecs-components.md).
+
+---
+
+## Where to look in the source
+
+| Concern | File |
+|---------|------|
+| Scene `tilemap` texture scanning (only field read) | `src/AssetManager/SceneAssetScanner.cpp` |
+| Per-scene asset acquire/release | `Game::TrackSceneAssets`, `AssetManager::AcquireAll` / `ReleaseAll` |
+| `get_game_map_dimensions` / `set_game_map_dimensions` | `src/Lua/Modules/GameModuleLuaBinding.cpp` |
+| Playable-area despawn bounds | `src/Systems/OffScreenDespawnSystem.h`, `GameConfig` |

--- a/events.json
+++ b/events.json
@@ -1,0 +1,161 @@
+{
+  "_generated_by": "scripts/gen_api_catalogs.py",
+  "_note": "Static catalog of src/Events. Regenerate with scripts/gen_api_catalogs.py.",
+  "events": [
+    {
+      "name": "AudioPlayEvent",
+      "kind": "struct",
+      "source": "src/Events/AudioPlayEvent.h",
+      "fields": [
+        {
+          "type": "std::string",
+          "name": "clipId"
+        },
+        {
+          "type": "float",
+          "name": "volume"
+        }
+      ],
+      "emit_sites": [
+        {
+          "file": "src/Lua/Modules/AudioModuleLuaBinding.cpp",
+          "line": 19
+        }
+      ],
+      "subscribe_sites": [
+        {
+          "file": "src/Systems/AudioSystem.cpp",
+          "line": 65,
+          "owner": "AudioSystem"
+        }
+      ]
+    },
+    {
+      "name": "CollisionEvent",
+      "kind": "class",
+      "source": "src/Events/CollisionEvent.h",
+      "fields": [
+        {
+          "type": "Entity",
+          "name": "entityA"
+        },
+        {
+          "type": "Entity",
+          "name": "entityB"
+        }
+      ],
+      "emit_sites": [
+        {
+          "file": "src/Systems/CollisionSystem.h",
+          "line": 106
+        }
+      ],
+      "subscribe_sites": [
+        {
+          "file": "src/Systems/DamageSystem.h",
+          "line": 16,
+          "owner": "DamageSystem"
+        },
+        {
+          "file": "src/Systems/ObstacleBounceSystem.h",
+          "line": 19,
+          "owner": "ObstacleBounceSystem"
+        }
+      ]
+    },
+    {
+      "name": "KeyInputEvent",
+      "kind": "struct",
+      "source": "src/Events/KeyInputEvent.h",
+      "fields": [
+        {
+          "type": "SDL_Keycode",
+          "name": "inputKey"
+        },
+        {
+          "type": "SDL_Keymod",
+          "name": "inputModifier"
+        },
+        {
+          "type": "bool",
+          "name": "isPressed"
+        }
+      ],
+      "emit_sites": [
+        {
+          "file": "src/Engine/FrameLoop.cpp",
+          "line": 68
+        }
+      ],
+      "subscribe_sites": [
+        {
+          "file": "src/Game/Game.cpp",
+          "line": 682,
+          "owner": "FrameLoop"
+        },
+        {
+          "file": "src/Systems/InputSystem.h",
+          "line": 49,
+          "owner": "InputSystem"
+        }
+      ]
+    },
+    {
+      "name": "MouseInputEvent",
+      "kind": "struct",
+      "source": "src/Events/MouseInputEvent.h",
+      "fields": [
+        {
+          "type": "SDL_MouseButtonEvent",
+          "name": "event"
+        }
+      ],
+      "emit_sites": [
+        {
+          "file": "src/Engine/FrameLoop.cpp",
+          "line": 74
+        }
+      ],
+      "subscribe_sites": [
+        {
+          "file": "src/Systems/InputSystem.h",
+          "line": 50,
+          "owner": "InputSystem"
+        },
+        {
+          "file": "src/Systems/UIButtonSystem.h",
+          "line": 24,
+          "owner": "UIButtonSystem"
+        }
+      ]
+    },
+    {
+      "name": "MouseWheelEvent",
+      "kind": "struct",
+      "source": "src/Events/MouseWheelEvent.h",
+      "fields": [
+        {
+          "type": "float",
+          "name": "dx"
+        },
+        {
+          "type": "float",
+          "name": "dy"
+        }
+      ],
+      "emit_sites": [
+        {
+          "file": "src/Engine/FrameLoop.cpp",
+          "line": 78
+        }
+      ],
+      "subscribe_sites": [
+        {
+          "file": "src/Systems/InputSystem.h",
+          "line": 51,
+          "owner": "InputSystem"
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/gen_api_catalogs.py
+++ b/scripts/gen_api_catalogs.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Generate the machine-readable systems.json and events.json catalogs.
+
+Unlike components.json / modules.json -- which the engine emits at runtime from
+the self-registering LuaComponentRegistry / LuaModuleRegistry (see
+src/Lua/LuaApiManifest.cpp) -- systems and events carry NO runtime metadata:
+the ECS erases the queried-component template pack once a SystemWrapper is built
+(src/ECS/Registry.h), and the EventBus is purely template-dispatched with no
+central type registry (src/EventBus/EventBus.h). There is nothing to introspect.
+
+So these two catalogs are produced by static inspection of the source tree:
+
+  * systems.json -- one entry per src/Systems/*.h, enriched with the registration
+    tier ("serial" / "parallel" / "bulk") and queried components parsed from the
+    Register*System<...>() calls in Game::Setup, plus the events each system
+    emits / subscribes to and whether it exposes a Lua binding surface.
+  * events.json  -- one entry per event struct in src/Events/*.h (name + payload
+    fields), with every EmitEvent<> and SubscribeEvent<> call site in the tree.
+
+Output is deterministic (sorted, fixed formatting) so it can be drift-gated in CI
+exactly like the Lua artifacts: regenerate, then `git diff --quiet`. Run with no
+arguments to (re)write both files at the repo root; pass --check to fail (exit 1)
+if either file would change without writing.
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SRC = REPO / "src"
+
+# Register{,Parallel,Bulk}System<Components...>(SystemName()) -- the optional
+# <...> holds the queried components (no nested templates in practice), and the
+# constructor call names the system. \s* spans the multi-line DopplerSystem case.
+REG_RE = re.compile(r"Register(Parallel|Bulk)?System\s*(?:<([^>]*)>)?\s*\(\s*([A-Za-z_]\w*)\s*\(")
+EMIT_RE = re.compile(r"EmitEvent\s*<\s*([A-Za-z_]\w*)\s*>")
+SUB_RE = re.compile(r"SubscribeEvent\s*<\s*([A-Za-z_]\w*)\s*,\s*([A-Za-z_]\w*)\s*>")
+EVENT_DECL_RE = re.compile(r"\b(struct|class)\s+([A-Za-z_]\w*)\s*:\s*(?:public\s+)?Event\b")
+FIELD_RE = re.compile(r"^\s+([A-Za-z_][\w:]*(?:\s*<[^>]*>)?)\s+([A-Za-z_]\w*)\s*;\s*$")
+
+TIER = {"": "serial", "Parallel": "parallel", "Bulk": "bulk"}
+
+
+def rel(path: Path) -> str:
+    return path.relative_to(REPO).as_posix()
+
+
+def all_src_files():
+    for ext in ("*.h", "*.hpp", "*.cpp"):
+        yield from SRC.rglob(ext)
+
+
+def parse_registrations():
+    """system name -> {tier, order, queried_components} from Game::Setup."""
+    text = (SRC / "Game" / "Game.cpp").read_text(encoding="utf-8")
+    out = {}
+    for order, m in enumerate(REG_RE.finditer(text)):
+        kind, comps, name = m.group(1) or "", m.group(2), m.group(3)
+        out[name] = {
+            "tier": TIER[kind],
+            "order": order,
+            "queried_components": [c.strip() for c in comps.split(",")] if comps and comps.strip() else [],
+        }
+    return out
+
+
+def parse_event_sites():
+    """Collect every emit and subscribe call site across the tree."""
+    emits = {}  # event -> list[{file,line}]
+    subs = {}   # event -> list[{file,line,owner}]
+    for path in all_src_files():
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            for m in EMIT_RE.finditer(line):
+                emits.setdefault(m.group(1), []).append({"file": rel(path), "line": lineno})
+            for m in SUB_RE.finditer(line):
+                subs.setdefault(m.group(2), []).append({"file": rel(path), "line": lineno, "owner": m.group(1)})
+    return emits, subs
+
+
+def parse_events(emits, subs):
+    events = []
+    for path in sorted((SRC / "Events").glob("*.h")):
+        lines = path.read_text(encoding="utf-8").splitlines()
+        decl = next((m for line in lines if (m := EVENT_DECL_RE.search(line))), None)
+        if not decl:
+            continue
+        name = decl.group(2)
+        fields, in_body = [], False
+        for line in lines:
+            if EVENT_DECL_RE.search(line):
+                in_body = True
+                continue
+            if in_body and "(" in line:  # reached the constructor -- fields come first
+                break
+            if in_body and (fm := FIELD_RE.match(line)):
+                fields.append({"type": fm.group(1).strip(), "name": fm.group(2)})
+        events.append({
+            "name": name,
+            "kind": decl.group(1),
+            "source": rel(path),
+            "fields": fields,
+            "emit_sites": sorted(emits.get(name, []), key=lambda s: (s["file"], s["line"])),
+            "subscribe_sites": sorted(subs.get(name, []), key=lambda s: (s["file"], s["line"])),
+        })
+    return sorted(events, key=lambda e: e["name"])
+
+
+def has_lua_surface(name: str) -> bool:
+    return any((SRC / "Lua").rglob(f"{name}LuaBinding.*"))
+
+
+def parse_systems(regs, emits, subs):
+    # event -> systems that emit/subscribe it, attributed by the source file's stem.
+    emit_by_system, sub_by_system = {}, {}
+    for event, sites in emits.items():
+        for s in sites:
+            stem = Path(s["file"]).stem
+            if stem.endswith("System"):
+                emit_by_system.setdefault(stem, set()).add(event)
+    for event, sites in subs.items():
+        for s in sites:
+            if s["owner"].endswith("System"):
+                sub_by_system.setdefault(s["owner"], set()).add(event)
+
+    systems = []
+    for path in sorted((SRC / "Systems").glob("*.h")):
+        name = path.stem
+        reg = regs.get(name)
+        systems.append({
+            "name": name,
+            "source": rel(path),
+            "tier": reg["tier"] if reg else None,
+            "setup_order": reg["order"] if reg else None,
+            "queried_components": reg["queried_components"] if reg else [],
+            "emits": sorted(emit_by_system.get(name, [])),
+            "subscribes": sorted(sub_by_system.get(name, [])),
+            "lua_surface": has_lua_surface(name),
+        })
+    return systems
+
+
+def render(obj) -> str:
+    return json.dumps(obj, indent=2) + "\n"
+
+
+def main() -> int:
+    check = "--check" in sys.argv[1:]
+    regs = parse_registrations()
+    emits, subs = parse_event_sites()
+
+    payloads = {
+        REPO / "systems.json": {
+            "_generated_by": "scripts/gen_api_catalogs.py",
+            "_note": "Static catalog of src/Systems. Regenerate with scripts/gen_api_catalogs.py.",
+            "systems": parse_systems(regs, emits, subs),
+        },
+        REPO / "events.json": {
+            "_generated_by": "scripts/gen_api_catalogs.py",
+            "_note": "Static catalog of src/Events. Regenerate with scripts/gen_api_catalogs.py.",
+            "events": parse_events(emits, subs),
+        },
+    }
+
+    drifted = []
+    for path, payload in payloads.items():
+        new = render(payload)
+        old = path.read_text(encoding="utf-8") if path.exists() else None
+        if old != new:
+            drifted.append(rel(path))
+            if not check:
+                path.write_text(new, encoding="utf-8")
+
+    if check and drifted:
+        print("API catalogs are stale: " + ", ".join(drifted), file=sys.stderr)
+        print("Run scripts/gen_api_catalogs.py and commit the result.", file=sys.stderr)
+        return 1
+    if not check:
+        for path in payloads:
+            print(f"wrote {rel(path)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/systems.json
+++ b/systems.json
@@ -1,0 +1,302 @@
+{
+  "_generated_by": "scripts/gen_api_catalogs.py",
+  "_note": "Static catalog of src/Systems. Regenerate with scripts/gen_api_catalogs.py.",
+  "systems": [
+    {
+      "name": "AnimationSystem",
+      "source": "src/Systems/AnimationSystem.h",
+      "tier": "parallel",
+      "setup_order": 2,
+      "queried_components": [
+        "SpriteComponent",
+        "AnimationComponent"
+      ],
+      "emits": [],
+      "subscribes": [],
+      "lua_surface": false
+    },
+    {
+      "name": "AudioCullingSystem",
+      "source": "src/Systems/AudioCullingSystem.h",
+      "tier": "serial",
+      "setup_order": 9,
+      "queried_components": [
+        "GlobalTransformComponent",
+        "AudioSourceComponent"
+      ],
+      "emits": [],
+      "subscribes": [],
+      "lua_surface": false
+    },
+    {
+      "name": "AudioSystem",
+      "source": "src/Systems/AudioSystem.h",
+      "tier": "serial",
+      "setup_order": 1,
+      "queried_components": [
+        "AudioSourceComponent"
+      ],
+      "emits": [],
+      "subscribes": [
+        "AudioPlayEvent"
+      ],
+      "lua_surface": false
+    },
+    {
+      "name": "CameraFollowSystem",
+      "source": "src/Systems/CameraFollowSystem.h",
+      "tier": "serial",
+      "setup_order": 12,
+      "queried_components": [
+        "PositionComponent",
+        "CameraFollowComponent"
+      ],
+      "emits": [],
+      "subscribes": [],
+      "lua_surface": false
+    },
+    {
+      "name": "CollisionSystem",
+      "source": "src/Systems/CollisionSystem.h",
+      "tier": "bulk",
+      "setup_order": 7,
+      "queried_components": [],
+      "emits": [
+        "CollisionEvent"
+      ],
+      "subscribes": [],
+      "lua_surface": false
+    },
+    {
+      "name": "DamageSystem",
+      "source": "src/Systems/DamageSystem.h",
+      "tier": null,
+      "setup_order": null,
+      "queried_components": [],
+      "emits": [],
+      "subscribes": [
+        "CollisionEvent"
+      ],
+      "lua_surface": false
+    },
+    {
+      "name": "DopplerSystem",
+      "source": "src/Systems/DopplerSystem.h",
+      "tier": "serial",
+      "setup_order": 11,
+      "queried_components": [
+        "GlobalTransformComponent",
+        "RigidBodyComponent",
+        "AudioSourceComponent",
+        "AudioSinkComponent"
+      ],
+      "emits": [],
+      "subscribes": [],
+      "lua_surface": false
+    },
+    {
+      "name": "DrawColliderSystem",
+      "source": "src/Systems/DrawColliderSystem.h",
+      "tier": null,
+      "setup_order": null,
+      "queried_components": [],
+      "emits": [],
+      "subscribes": [],
+      "lua_surface": false
+    },
+    {
+      "name": "EntityPoolSystem",
+      "source": "src/Systems/EntityPoolSystem.h",
+      "tier": null,
+      "setup_order": null,
+      "queried_components": [],
+      "emits": [],
+      "subscribes": [],
+      "lua_surface": false
+    },
+    {
+      "name": "InputSystem",
+      "source": "src/Systems/InputSystem.h",
+      "tier": null,
+      "setup_order": null,
+      "queried_components": [],
+      "emits": [],
+      "subscribes": [
+        "KeyInputEvent",
+        "MouseInputEvent",
+        "MouseWheelEvent"
+      ],
+      "lua_surface": true
+    },
+    {
+      "name": "ObstacleBounceSystem",
+      "source": "src/Systems/ObstacleBounceSystem.h",
+      "tier": null,
+      "setup_order": null,
+      "queried_components": [],
+      "emits": [],
+      "subscribes": [
+        "CollisionEvent"
+      ],
+      "lua_surface": false
+    },
+    {
+      "name": "OffScreenDespawnSystem",
+      "source": "src/Systems/OffScreenDespawnSystem.h",
+      "tier": "parallel",
+      "setup_order": 5,
+      "queried_components": [
+        "PositionComponent",
+        "SpriteComponent"
+      ],
+      "emits": [],
+      "subscribes": [],
+      "lua_surface": false
+    },
+    {
+      "name": "ProjectileEmitSystem",
+      "source": "src/Systems/ProjectileEmitSystem.h",
+      "tier": null,
+      "setup_order": null,
+      "queried_components": [],
+      "emits": [],
+      "subscribes": [],
+      "lua_surface": false
+    },
+    {
+      "name": "ProjectileLifecycleSystem",
+      "source": "src/Systems/ProjectileLifecycleSystem.h",
+      "tier": "parallel",
+      "setup_order": 3,
+      "queried_components": [
+        "ProjectileComponent"
+      ],
+      "emits": [],
+      "subscribes": [],
+      "lua_surface": false
+    },
+    {
+      "name": "RenderDebugGUISystem",
+      "source": "src/Systems/RenderDebugGUISystem.h",
+      "tier": null,
+      "setup_order": null,
+      "queried_components": [],
+      "emits": [],
+      "subscribes": [],
+      "lua_surface": false
+    },
+    {
+      "name": "RenderPrimitiveSystem",
+      "source": "src/Systems/RenderPrimitiveSystem.h",
+      "tier": "parallel",
+      "setup_order": 15,
+      "queried_components": [
+        "SquarePrimitiveComponent",
+        "GlobalTransformComponent"
+      ],
+      "emits": [],
+      "subscribes": [],
+      "lua_surface": false
+    },
+    {
+      "name": "RenderSpriteSystem",
+      "source": "src/Systems/RenderSpriteSystem.h",
+      "tier": "parallel",
+      "setup_order": 13,
+      "queried_components": [
+        "GlobalTransformComponent",
+        "SpriteComponent"
+      ],
+      "emits": [],
+      "subscribes": [],
+      "lua_surface": false
+    },
+    {
+      "name": "RenderTextSystem",
+      "source": "src/Systems/RenderTextSystem.h",
+      "tier": "serial",
+      "setup_order": 14,
+      "queried_components": [
+        "TextLabelComponent"
+      ],
+      "emits": [],
+      "subscribes": [],
+      "lua_surface": false
+    },
+    {
+      "name": "ScriptSystem",
+      "source": "src/Systems/ScriptSystem.h",
+      "tier": "serial",
+      "setup_order": 0,
+      "queried_components": [
+        "ScriptComponent"
+      ],
+      "emits": [],
+      "subscribes": [],
+      "lua_surface": false
+    },
+    {
+      "name": "SpatialAudioSystem",
+      "source": "src/Systems/SpatialAudioSystem.h",
+      "tier": "serial",
+      "setup_order": 10,
+      "queried_components": [
+        "GlobalTransformComponent",
+        "AudioSourceComponent",
+        "AudioSinkComponent"
+      ],
+      "emits": [],
+      "subscribes": [],
+      "lua_surface": false
+    },
+    {
+      "name": "TransformSystem",
+      "source": "src/Systems/TransformSystem.h",
+      "tier": "bulk",
+      "setup_order": 6,
+      "queried_components": [
+        "GlobalTransformComponent"
+      ],
+      "emits": [],
+      "subscribes": [],
+      "lua_surface": false
+    },
+    {
+      "name": "UIButtonSystem",
+      "source": "src/Systems/UIButtonSystem.h",
+      "tier": null,
+      "setup_order": null,
+      "queried_components": [],
+      "emits": [],
+      "subscribes": [
+        "MouseInputEvent"
+      ],
+      "lua_surface": false
+    },
+    {
+      "name": "UpdateListenerTransformSystem",
+      "source": "src/Systems/UpdateListenerTransformSystem.h",
+      "tier": "bulk",
+      "setup_order": 8,
+      "queried_components": [
+        "GlobalTransformComponent"
+      ],
+      "emits": [],
+      "subscribes": [],
+      "lua_surface": false
+    },
+    {
+      "name": "VelocityIntegrationSystem",
+      "source": "src/Systems/VelocityIntegrationSystem.h",
+      "tier": "parallel",
+      "setup_order": 4,
+      "queried_components": [
+        "PositionComponent",
+        "RigidBodyComponent"
+      ],
+      "emits": [],
+      "subscribes": [],
+      "lua_surface": false
+    }
+  ]
+}


### PR DESCRIPTION
Closes the remaining tail of the LLM-Workability plan (validation stream + B2 docs already shipped in #99/#102/#104/#105).

## B1 — machine-readable catalogs
- New `scripts/gen_api_catalogs.py` produces `systems.json` and `events.json`. Unlike `components.json`/`modules.json` (emitted at runtime from self-registering Lua registries), systems and events carry **no runtime metadata** — the ECS erases the queried-component template pack and the EventBus is pure template dispatch. So these are derived by **static source inspection**:
  - **systems.json**: one entry per `src/Systems/*.h`, enriched from the `Register*System<...>` calls in `Game::Setup` (tier, queried components, setup order) plus emit/subscribe edges and Lua-surface flag.
  - **events.json**: one entry per `src/Events/*.h` event struct (payload fields) with every `EmitEvent<>`/`SubscribeEvent<>` call site.
- Output is deterministic; CI drift-gates it.

## C3 — clang-tidy advisory → blocking
- The editor-release `clang-tidy` step is now **blocking on changed lines** via `clang-tidy-diff.py -U0` (new violations fail; pre-existing debt in a touched file does not).

## B2/B4 — docs
- New `docs/tilemaps.md` documenting what the scene `tilemap` field actually does today (only `texture_asset_id` is tracked) and what it does **not** (no `.map` parser/tile API/renderer/collision yet). Linked from QUICKSTART; corrected a misleading scenes.md comment.

## Verification
- `python3 scripts/gen_api_catalogs.py --check` is clean and idempotent; catalogs regenerate correctly against the post-#107 source layout (input events now emit from `FrameLoop.cpp`, picked up automatically).
- No C++/CMake changes. CI will exercise the new gates on this PR.