### PR TITLE
Fix CI SIGILL flake: default to portable arch baseline instead of -march=native

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,22 @@ if (OCTARINE_USE_CCACHE AND NOT CMAKE_CXX_COMPILER_LAUNCHER)
     endif ()
 endif ()
 
+# Architecture tuning for optimized (non-Debug) GCC/Clang builds. -march=native pins codegen to the
+# BUILD machine's exact CPU, which is unsafe two ways: (1) a ccache object built on one CI runner and
+# reused on another with fewer instructions crashes at runtime via SIGILL, and (2) shipping artifacts
+# won't run on older end-user CPUs than the build box. Default to a portable baseline (x86-64-v3 ~ the
+# Windows /arch:AVX2 floor: AVX2 + BMI + FMA, Haswell-era 2013+). Opt into -march=native locally with
+# -DOCTARINE_NATIVE_ARCH=ON where build and run are the same machine. MSVC uses /arch:AVX2 below and
+# ignores this; Android gets its arch from the NDK toolchain (this var is empty there).
+option(OCTARINE_NATIVE_ARCH "Tune optimized builds for the local CPU (-march=native); not portable, keep off for CI/shipping" OFF)
+if (OCTARINE_NATIVE_ARCH)
+    set(OCTARINE_ARCH_FLAG "-march=native")
+elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64|amd64)$")
+    set(OCTARINE_ARCH_FLAG "-march=x86-64-v3")
+else ()
+    set(OCTARINE_ARCH_FLAG "")  # non-x86 (e.g. Apple Silicon): leave the compiler's portable default
+endif ()
+
 # LTO for non-Debug builds. Combines with --gc-sections to drop unreferenced
 # code/data from statically linked third-party libs (SDL3, Lua, etc).
 include(CheckIPOSupported)
@@ -200,7 +216,7 @@ else ()
         )
     else ()
         target_compile_options(${PROJECT_NAME} PRIVATE
-                $<IF:$<CONFIG:Debug>,,-Werror -march=native -ffast-math>
+                $<IF:$<CONFIG:Debug>,,-Werror ${OCTARINE_ARCH_FLAG} -ffast-math>
         )
     endif ()
     target_compile_options(${PROJECT_NAME} PRIVATE
@@ -317,7 +333,7 @@ if (OCTARINE_ENABLE_BENCHMARKS)
     else ()
         target_compile_options(OctarineBenchmarks PRIVATE -Wall -Wextra -Wpedantic)
         target_compile_options(OctarineBenchmarks PRIVATE
-                $<IF:$<CONFIG:Debug>,,-Werror -march=native -ffast-math>
+                $<IF:$<CONFIG:Debug>,,-Werror ${OCTARINE_ARCH_FLAG} -ffast-math>
         )
     endif ()
 

--- a/cmake/octarine_library.cmake
+++ b/cmake/octarine_library.cmake
@@ -62,7 +62,7 @@ function(octarine_library NAME)
             )
         else ()
             target_compile_options(${NAME} PRIVATE
-                    $<IF:$<CONFIG:Debug>,,-Werror -march=native -ffast-math>
+                    $<IF:$<CONFIG:Debug>,,-Werror ${OCTARINE_ARCH_FLAG} -ffast-math>
             )
         endif ()
         target_compile_options(${NAME} PRIVATE


### PR DESCRIPTION
## The flake
Intermittent `linux (editor-release)` failures where `LuaApiSmokeTest`, `LuaBehaviorTest`, and `GameBakeTest` crash with `***Exception: Illegal` (SIGILL). The reds appeared on commits that changed **no C++** (e.g. an Android-YAML-only commit), and a plain re-run goes green.

## Root cause
Optimized GCC/Clang builds used **`-march=native`** (`cmake/octarine_library.cmake`, `CMakeLists.txt` ×2), which bakes in the **build runner's** exact CPU instructions. The CI **ccache** (added in #102) is keyed only on `platform-preset`, and ccache hashes the literal string `-march=native` — identical on every runner — so it serves a `.o` **compiled for a different CPU**. GitHub's `ubuntu-latest` runners have heterogeneous CPUs, so a cached object built on an AVX-512 runner and reused on one without it **SIGILLs** the moment that instruction executes. Only the three tests linking the full `octarine_engine` (vectorized glm/audio/bake paths) trip it; the lighter `octarine_core`/spdlog tests don't. Timeline confirms: every pre-ccache build was green; flakes only began after #102.

This was also a **latent shipping bug** — `player-release`/`ship-release` artifacts built with `-march=native` fault on any end-user CPU older than the build box.

## Fix
Default optimized builds to a portable **`-march=x86-64-v3`** on x86-64 (AVX2+BMI+FMA — matches the existing Windows `/arch:AVX2` floor); leave non-x86 (Apple Silicon) on the compiler default; keep `-march=native` as an opt-in via **`-DOCTARINE_NATIVE_ARCH=ON`** for local build==run machines. With a fixed baseline, the cross-runner ccache reuse is now correct.

## Verification
- No `-march=native` remains in active flags; `${OCTARINE_ARCH_FLAG}` wired into all 3 optimized-flag sites.
- Local g++ accepts `-march=x86-64-v3`.
- CI here exercises the full 4-platform × 2-preset build; this leg should now be stable across re-runs.