### PR TITLE
Make release builds portable; tighten local lint/format parity

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -159,6 +159,11 @@ readability-string-compare,
 readability-uniqueptr-delete-release,
 readability-use-anyofallof'
 
+# Kept empty on purpose: clang-tidy stays advisory for editor integration and for whole-tree
+# `-DOCTARINE_ENABLE_LINTING=ON` builds, neither of which should hard-fail on pre-existing debt in
+# untouched files. CI enforces the gate where it matters — promoting every check to an error over a
+# PR's *changed lines only* (`-warnings-as-errors='*'` via clang-tidy-diff in build.yml). Reproduce
+# that exact verdict locally with `scripts/lint-diff.sh` before pushing. See CONTRIBUTING.md § Lint.
 WarningsAsErrors: ''
 
 HeaderFilterRegex: 'src/.*'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,21 @@ pipx install clang-format==18.1.8      # then: cmake --build <preset> --target f
 > `AUTOFORMAT_PAT` (repo scope, `contents: write`). Without it the job still runs
 > but its fixup commit won't re-trigger the required checks.
 
+**Pre-commit hook (optional, recommended).** To catch formatting before it leaves
+your machine — and skip the CI fixup round-trip — enable the tracked hook once per
+clone:
+
+```bash
+git config core.hooksPath scripts/hooks
+```
+
+`scripts/hooks/pre-commit` runs clang-format (`--dry-run --Werror`) over your staged
+`src/`/`tests/` C/C++ files using the same filter as the CI gate, and blocks the
+commit on violations. Bypass a single commit with `git commit --no-verify`. It
+prefers `clang-format-18` and falls back to `clang-format` with a version warning.
+(Setting `core.hooksPath` points git at `scripts/hooks` for all hooks, so move any
+existing local hooks there if you rely on them.)
+
 ### Lint
 
 `.clang-tidy` enforces a curated check set. Two thresholds worth knowing:
@@ -89,6 +104,26 @@ pipx install clang-format==18.1.8      # then: cmake --build <preset> --target f
 If you trip either, the right fix is almost always to extract a helper.
 Suppressing with `// NOLINT` is reserved for genuinely unavoidable cases —
 add a one-line comment justifying it.
+
+**Local vs CI — where it's advisory, where it bites.** `.clang-tidy` deliberately
+leaves `WarningsAsErrors` empty, so clang-tidy stays *advisory* locally: editor
+squiggles and whole-tree `-DOCTARINE_ENABLE_LINTING=ON` builds surface warnings
+without hard-failing on pre-existing debt in files you didn't touch. The
+enforcement happens in CI, which promotes every check to an **error over your
+PR's changed lines only** (via `clang-tidy-diff`). So a check can scroll past
+locally as a warning yet fail the PR.
+
+To get CI's exact verdict before you push:
+
+```bash
+cmake --preset editor-release          # emits build/editor-release/compile_commands.json
+scripts/lint-diff.sh                   # tidies your changed lines, warnings-as-errors, vs origin/main
+```
+
+`scripts/lint-diff.sh [BASE_REF] [BUILD_DIR]` mirrors the CI gate line-for-line.
+Match CI's pinned major version for identical results — `apt install clang-tidy-18`
+(the script prefers `clang-tidy-18`, falling back to whatever `clang-tidy` is on
+`PATH` with a warning).
 
 ### Naming
 

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Pre-commit hook: block a commit whose staged C/C++ changes aren't clang-format-clean, mirroring the
+# blocking `lint (clang-format)` gate in .github/workflows/build.yml. Catching it here avoids the CI
+# round-trip where autoformat.yml pushes a "style: apply clang-format" fixup back onto your branch.
+#
+# Enable once per clone:   git config core.hooksPath scripts/hooks
+# Bypass for one commit:   git commit --no-verify
+#
+# Checks the working-tree copy of staged files (clang-format needs the on-disk path for -style=file
+# discovery). For whole-file stages — the common case — that's the same content being committed.
+set -euo pipefail
+
+# Match CI's filter exactly: staged add/copy/modify/rename under src/ or tests/, C/C++ extensions.
+mapfile -t files < <(git diff --cached --name-only --diff-filter=ACMR -- 'src/*' 'tests/*' \
+  | grep -E '\.(cpp|h|hpp)$' || true)
+if [ ${#files[@]} -eq 0 ]; then
+  exit 0
+fi
+
+# Prefer the CI-pinned major version; fall back to whatever clang-format is on PATH with a warning,
+# since output differs across clang-format versions (CI pins 18.1.8).
+if command -v clang-format-18 >/dev/null 2>&1; then
+  fmt=clang-format-18
+elif command -v clang-format >/dev/null 2>&1; then
+  fmt=clang-format
+  echo "pre-commit: clang-format-18 not found; using '$fmt'. CI pins clang-format 18.1.8 — output can differ." >&2
+else
+  echo "pre-commit: no clang-format on PATH; skipping format check (CI still gates it)." >&2
+  exit 0
+fi
+
+if ! "$fmt" --dry-run --Werror -style=file "${files[@]}"; then
+  echo >&2
+  echo "pre-commit: staged C/C++ files aren't clang-format-clean (diff above)." >&2
+  echo "  Fix:     cmake --build build/<preset> --target format   (or: $fmt -i -style=file <files>)" >&2
+  echo "  Bypass:  git commit --no-verify" >&2
+  exit 1
+fi

--- a/scripts/lint-diff.sh
+++ b/scripts/lint-diff.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Reproduce CI's blocking clang-tidy gate locally.
+#
+# CI ("clang-tidy (changed lines, blocking)" in .github/workflows/build.yml) promotes every
+# clang-tidy diagnostic on the lines your branch *changed* to an error, while ignoring pre-existing
+# debt on untouched lines. .clang-tidy itself keeps WarningsAsErrors empty so editor integration and
+# whole-tree `-DOCTARINE_ENABLE_LINTING=ON` builds stay advisory — so the only place that strict,
+# changed-lines verdict exists is CI. This script runs that exact verdict on your machine so you can
+# confirm the lint gate passes before pushing.
+#
+# Usage:
+#   scripts/lint-diff.sh [BASE_REF] [BUILD_DIR]
+#     BASE_REF   git ref to diff against (default: origin/main, then main)
+#     BUILD_DIR  dir containing compile_commands.json (default: build/editor-release)
+#
+# Requires a configured build that emitted compile_commands.json (editor-release matches CI).
+# Prefers clang-tidy-18 to match CI's pinned major version; falls back to whatever clang-tidy is on
+# PATH with a warning, since diagnostics can differ across clang-tidy versions.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+base="${1:-}"
+build_dir="${2:-build/editor-release}"
+
+# Resolve a base ref. `git diff A...HEAD` already diffs from the merge-base of A and HEAD, so this
+# only ever surfaces your branch's own changes — exactly what CI passes as the PR base.
+if [ -z "$base" ]; then
+  if git rev-parse --verify --quiet origin/main >/dev/null; then
+    base="origin/main"
+  elif git rev-parse --verify --quiet main >/dev/null; then
+    base="main"
+  else
+    echo "lint-diff: no origin/main or main found; pass a BASE_REF explicitly." >&2
+    exit 2
+  fi
+fi
+
+if [ ! -f "$build_dir/compile_commands.json" ]; then
+  echo "lint-diff: $build_dir/compile_commands.json not found." >&2
+  echo "  Configure a build first, e.g.:  cmake --preset editor-release" >&2
+  exit 2
+fi
+
+if command -v clang-tidy-18 >/dev/null 2>&1; then
+  tidy_bin=clang-tidy-18
+elif command -v clang-tidy >/dev/null 2>&1; then
+  tidy_bin=clang-tidy
+  echo "lint-diff: clang-tidy-18 not found; using '$tidy_bin'. CI pins clang-tidy-18, so results may differ." >&2
+else
+  echo "lint-diff: no clang-tidy on PATH. Install clang-tidy-18 to match CI." >&2
+  exit 2
+fi
+
+changed="$(git diff --name-only --diff-filter=ACMR "$base"...HEAD -- 'src/*' 'tests/*' | grep -E '\.cpp$' || true)"
+if [ -z "$changed" ]; then
+  echo "lint-diff: no changed .cpp files under src/ or tests/ — nothing to lint."
+  exit 0
+fi
+printf 'lint-diff: tidying changed lines in:\n%s\n' "$(printf '  %s\n' $changed)"
+
+# clang-tidy-diff.py ships inside the llvm-18 toolchain (the apt clang-tidy-18 copy carries the
+# -warnings-as-errors flag CI relies on). Fall back to the upstream `main` copy, which also defines
+# that flag — released tags (≤ llvm 20) and older system copies (e.g. llvm-14) do NOT, and silently
+# misapplying it would let violations pass. Prefer the llvm-18 copy.
+diff_tool="$(find /usr/lib/llvm-18 -name 'clang-tidy-diff.py' 2>/dev/null | head -1 || true)"
+if [ -z "$diff_tool" ]; then
+  diff_tool="$(mktemp -t clang-tidy-diff.XXXXXX.py)"
+  trap 'rm -f "$diff_tool"' EXIT
+  curl -fsSL https://raw.githubusercontent.com/llvm/llvm-project/main/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py -o "$diff_tool"
+fi
+
+# Guard: never run a clang-tidy-diff.py that lacks -warnings-as-errors — without it, diagnostics on
+# changed lines would NOT be promoted to errors and the gate would falsely pass.
+if ! grep -q -- '-warnings-as-errors' "$diff_tool"; then
+  echo "lint-diff: $diff_tool has no -warnings-as-errors support; it would falsely pass." >&2
+  echo "  Install the apt clang-tidy-18 toolchain (provides a compatible clang-tidy-diff.py)." >&2
+  exit 2
+fi
+
+# -p1 strips the a/ b/ diff prefixes; -path points at compile_commands.json; the diff's -U0 hunks
+# limit diagnostics to touched lines; any diagnostic there is promoted to an error and fails the run.
+git diff -U0 "$base"...HEAD -- 'src/*' 'tests/*' \
+  | python3 "$diff_tool" -p1 -path "$build_dir" \
+      -clang-tidy-binary "$tidy_bin" -warnings-as-errors='*'


### PR DESCRIPTION
Three dev-environment hardening changes surfaced by a repo health audit. Each is self-contained and low-risk.

## 1. Release builds are no longer host-CPU-locked
`-march=native` (GCC/Clang) and `/arch:AVX2` (MSVC) were applied to **every** non-Debug build — including the shippable `ship-release` and CPack packaging configs. A binary built on an AVX2/AVX-512 host can fault with `SIGILL` (illegal instruction) on an older end-user CPU.

- New `OCTARINE_NATIVE_ARCH` option gates these flags across all three sites (the per-lib helper, the final exe, and benchmarks).
- **Auto-defaults OFF** for any distributable build (`OCTARINE_SHIPPED`, `OCTARINE_PACKAGE_PROJECT`, or `ANDROID`) and **ON** otherwise — so dev/`player-release`/profile builds stay host-optimized while shipped artifacts stay portable. Override explicitly for a known-homogeneous fleet.
- Each flag is now emitted via its own generator expression instead of a combined space-joined string.

Verified: `editor-release` → `NATIVE_ARCH=ON` (`-march=native` present); `ship-release` → `NATIVE_ARCH=OFF` (stripped, with `-Werror`/`-ffast-math` retained); a real TU compiles under the stripped flag set.

## 2. clang-tidy: local ↔ CI parity without breaking the opt-in lint build
CI promotes clang-tidy to errors over a PR's **changed lines only**. `.clang-tidy` left `WarningsAsErrors` empty, so locally checks scroll past as warnings — a surprising CI failure. Flipping it to `'*'` globally is *not* safe: there's pre-existing whole-tree debt that CI never sees, and global promotion would break the opt-in `-DOCTARINE_ENABLE_LINTING=ON` build on untouched files.

- `.clang-tidy` stays advisory (with an explanatory comment).
- New `scripts/lint-diff.sh` reproduces CI's exact changed-lines gate locally (prefers `clang-tidy-18`; capability-guarded so it fails loudly rather than ever false-passing).
- Documented in CONTRIBUTING § Lint.

## 3. Opt-in clang-format pre-commit hook
`scripts/hooks/pre-commit` runs clang-format (`--dry-run --Werror`) over staged `src/`/`tests/` C/C++ files using the same filter as the CI gate, blocking unformatted commits before the `autoformat.yml` fixup round-trip.

- Enable once: `git config core.hooksPath scripts/hooks`. Bypass: `git commit --no-verify`.
- Documented in CONTRIBUTING § Format.

## Verification
- `cmake --preset editor-release` / `--preset ship-release` configure cleanly; `OCTARINE_NATIVE_ARCH` resolves ON/OFF respectively; a real translation unit compiles under the ship-release flag set.
- `scripts/lint-diff.sh` exercised end-to-end (no-op path, download fallback, line-filtered run).
- `scripts/hooks/pre-commit` exercised: clean → pass, misformatted → block with guidance, reformatted → pass.