### PR TITLE
Stage 10: split AssetManager into typed stores + refcounter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -467,6 +467,21 @@ if (OCTARINE_ENABLE_TESTS)
     endif ()
     add_test(NAME EventBusTest COMMAND OctarineEventBusTest)
 
+    # AssetRefcounter unit test (Stage 10): the acquire-count policy split out of AssetManager is
+    # pure bookkeeping — no SDL, no renderer, no Logger — so the test links nothing but the standard
+    # library. This is the "catalog/asset logic testable without SDL_CreateRenderer" outcome.
+    add_executable(OctarineAssetRefcounterTest tests/AssetRefcounterTest.cpp)
+    set_target_properties(OctarineAssetRefcounterTest PROPERTIES
+            CXX_STANDARD 20
+            CXX_STANDARD_REQUIRED ON
+            CXX_EXTENSIONS OFF)
+    target_include_directories(OctarineAssetRefcounterTest PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/src)
+    if (MSVC)
+        target_compile_options(OctarineAssetRefcounterTest PRIVATE /W4 /permissive- /MP /EHsc)
+    endif ()
+    add_test(NAME AssetRefcounterTest COMMAND OctarineAssetRefcounterTest)
+
     # DevListenServer smoke test (Stage 6 PR-A): standalone — only the server source + Logger.
     # Bound to the same OCTARINE_SHIPPED gate as the engine-side server.
     if (NOT OCTARINE_SHIPPED)

--- a/src/AssetManager/AssetManager.cpp
+++ b/src/AssetManager/AssetManager.cpp
@@ -1,18 +1,13 @@
 #include "AssetManager.h"
 
 #include <SDL3/SDL.h>
-#include <SDL3_image/SDL_image.h>
-#include <SDL3_mixer/SDL_mixer.h>
-#include <SDL3_ttf/SDL_ttf.h>
 
 #include <filesystem>
-#include <ranges>
 #include <set>
 
 #include "../Game/GameConfig.h"
 #include "../General/Logger.h"
 #include "AssetManager/AssetPak.h"
-#include "AssetManager/GlyphAtlas.h"
 
 AssetManager::~AssetManager() { ClearAssets(); }
 
@@ -29,6 +24,7 @@ SDL_IOStream *AssetManager::OpenAssetIO(const std::string &fullPath) const {
   }
   return SDL_IOFromFile(fullPath.c_str(), "rb");
 }
+
 void AssetManager::LoadGameConfig(const GameConfig &config) {
   base_path_ = config.GetAssetPath();
   if (config.GetDefaultScaleMode().has_value()) {
@@ -37,32 +33,24 @@ void AssetManager::LoadGameConfig(const GameConfig &config) {
 }
 
 void AssetManager::ClearAssets() {
-  for (const auto &snd : textures_ | std::views::values) {
-    SDL_DestroyTexture(snd);
-  }
-  for (const auto &snd : fonts_ | std::views::values) {
-    TTF_CloseFont(snd);
-  }
-  for (const auto &clip : audio_clips_ | std::views::values) {
-    MIX_DestroyAudio(clip);
-  }
-
-  textures_.clear();
-  fonts_.clear();
-  audio_clips_.clear();
-  refcounts_.clear();
+  texture_store_.Clear();
+  font_store_.Clear();
+  audio_store_.Clear();
+  refcounter_.Clear();
 }
 
+// Recurses into Acquire(atlasId) when an atlas member is requested (one hop — atlases do not nest).
+// NOLINTNEXTLINE(misc-no-recursion)
 bool AssetManager::Acquire(const std::string &assetId, SDL_Renderer *renderer, MIX_Mixer *mixer) {
   // Existing reference — just bump the count, no reload.
-  if (const auto it = refcounts_.find(assetId); it != refcounts_.end() && it->second > 0) {
-    ++it->second;
+  if (refcounter_.Has(assetId)) {
+    refcounter_.Increment(assetId);
     return true;
   }
 
   // Already resident with no refcount (legacy load_asset path) — adopt at count 1.
-  if (textures_.contains(assetId) || fonts_.contains(assetId) || audio_clips_.contains(assetId)) {
-    refcounts_[assetId] = 1;
+  if (texture_store_.Contains(assetId) || font_store_.Contains(assetId) || audio_store_.Contains(assetId)) {
+    refcounter_.Adopt(assetId);
     return true;
   }
 
@@ -74,20 +62,20 @@ bool AssetManager::Acquire(const std::string &assetId, SDL_Renderer *renderer, M
 
   // Atlas member: piggy-back on the backing atlas's SDL_Texture* rather than loading the
   // member's source bytes. The atlas gains one refcount per acquired member; releasing the
-  // member drops that refcount back. The member id never appears in textures_, so GetTexture
-  // walks the catalog atlas_id -> textures_[atlas_id] on lookup.
+  // member drops that refcount back. The member id never appears in the texture store, so
+  // GetTexture walks the catalog atlas_id -> texture store on lookup.
   if (entry->type == AssetType::Texture && entry->atlasId.has_value()) {
     if (!Acquire(*entry->atlasId, renderer, mixer)) {
       Logger::Error("AssetManager::Acquire: failed to acquire atlas '" + *entry->atlasId + "' for member '" + assetId +
                     "'");
       return false;
     }
-    refcounts_[assetId] = 1;
+    refcounter_.Adopt(assetId);
     return true;
   }
 
   const bool loaded = LoadFromCatalog(*entry, assetId, renderer, mixer);
-  if (loaded) refcounts_[assetId] = 1;
+  if (loaded) refcounter_.Adopt(assetId);
   return loaded;
 }
 
@@ -98,16 +86,16 @@ bool AssetManager::LoadFromCatalog(const CatalogEntry &entry, const std::string 
       AddTexture(renderer, assetId, entry.fullPath);
       // Per-asset scale mode from the catalog overrides the project default applied in AddTexture.
       if (entry.scaleMode.has_value()) {
-        if (SDL_Texture *texture = textures_.contains(assetId) ? textures_.at(assetId) : nullptr) {
+        if (SDL_Texture *texture = texture_store_.Get(assetId)) {
           SDL_SetTextureScaleMode(texture,
                                   *entry.scaleMode == ScaleMode::Linear ? SDL_SCALEMODE_LINEAR : SDL_SCALEMODE_NEAREST);
         }
       }
-      return textures_.contains(assetId);
+      return texture_store_.Contains(assetId);
     }
     case AssetType::Font:
       AddFont(assetId, entry.fullPath, entry.fontSize);
-      return fonts_.contains(assetId);
+      return font_store_.Contains(assetId);
     case AssetType::Audio:
       if (!mixer) {
         // Audio stack disabled (no mixer was Set — AudioSystem::Init failed at startup and already
@@ -117,16 +105,17 @@ bool AssetManager::LoadFromCatalog(const CatalogEntry &entry, const std::string 
         return false;
       }
       AddAudioClip(mixer, assetId, entry.fullPath, entry.stream);
-      return audio_clips_.contains(assetId);
+      return audio_store_.Contains(assetId);
   }
   return false;
 }
 
+// Mutually recursive with UnloadAsset: releasing an atlas member drops its stake in the atlas's
+// refcount, which can reach zero and unload it.
+// NOLINTNEXTLINE(misc-no-recursion)
 void AssetManager::Release(const std::string &assetId) {
-  const auto it = refcounts_.find(assetId);
-  if (it == refcounts_.end()) return;  // never acquired / untracked
-  if (--it->second > 0) return;        // still referenced elsewhere
-  refcounts_.erase(it);
+  const int remaining = refcounter_.Decrement(assetId);
+  if (remaining != 0) return;  // -1 == never acquired / untracked; > 0 == still referenced elsewhere
   UnloadAsset(assetId);
 }
 
@@ -134,36 +123,28 @@ void AssetManager::ReleaseAll(const std::vector<std::string> &assetIds) {
   for (const auto &id : assetIds) Release(id);
 }
 
-int AssetManager::RefCount(const std::string &assetId) const {
-  const auto it = refcounts_.find(assetId);
-  return it == refcounts_.end() ? 0 : it->second;
-}
+int AssetManager::RefCount(const std::string &assetId) const { return refcounter_.Count(assetId); }
 
+// Mutually recursive with Release: an atlas member's unload path calls Release(atlasId).
+// NOLINTNEXTLINE(misc-no-recursion)
 void AssetManager::UnloadAsset(const std::string &assetId) {
-  // Atlas-member alias: shares the atlas's SDL_Texture* via catalog redirect, not via a
-  // textures_ entry. Drop the member's stake in the atlas's refcount and we're done — the
-  // SDL handle stays alive until the last member (or the atlas itself) releases.
+  // Atlas-member alias: shares the atlas's SDL_Texture* via catalog redirect, not via a texture
+  // store entry. Drop the member's stake in the atlas's refcount and we're done — the SDL handle
+  // stays alive until the last member (or the atlas itself) releases.
   if (const CatalogEntry *e = catalog_.Find(assetId); e != nullptr && e->atlasId.has_value()) {
     Release(*e->atlasId);
     Logger::Info("Unloaded atlas member: " + assetId);
     return;
   }
-  if (const auto it = textures_.find(assetId); it != textures_.end()) {
-    SDL_DestroyTexture(it->second);
-    textures_.erase(it);
-    ++texture_generation_;  // invalidate cached SDL_Texture* in sprite renderers
+  if (texture_store_.Remove(assetId)) {
     Logger::Info("Unloaded texture: " + assetId);
     return;
   }
-  if (const auto it = fonts_.find(assetId); it != fonts_.end()) {
-    TTF_CloseFont(it->second);
-    fonts_.erase(it);
+  if (font_store_.Remove(assetId)) {
     Logger::Info("Unloaded font: " + assetId);
     return;
   }
-  if (const auto it = audio_clips_.find(assetId); it != audio_clips_.end()) {
-    MIX_DestroyAudio(it->second);
-    audio_clips_.erase(it);
+  if (audio_store_.Remove(assetId)) {
     Logger::Info("Unloaded audio clip: " + assetId);
   }
 }
@@ -213,39 +194,17 @@ void AssetManager::AddTexture(SDL_Renderer *renderer, const std::string &assetId
     Logger::Error("Failed to open texture file " + fullPath + ": " + std::string(SDL_GetError()));
     return;
   }
-  SDL_Texture *texture = IMG_LoadTexture_IO(renderer, io, true);  // closes the stream
-  if (!texture) {
-    Logger::Error("Failed to create texture: " + std::string(SDL_GetError()));
-    return;
-  }
-
-  if (default_scale_mode_.has_value()) {
-    SDL_SetTextureScaleMode(texture, default_scale_mode_.value());
-  }
-
-  // Replace prior texture under the same id rather than leaking it.
-  if (const auto it = textures_.find(assetId); it != textures_.end()) {
-    Logger::Warn("Replacing existing texture: " + assetId);
-    SDL_DestroyTexture(it->second);
-    it->second = texture;
-  } else {
-    textures_.emplace(assetId, texture);
-  }
-  ++texture_generation_;
-
-  Logger::Info("Added texture: " + assetId + " from path: " + fullPath);
+  texture_store_.Add(renderer, assetId, io, fullPath);
 }
 
 SDL_Texture *AssetManager::GetTexture(const std::string &assetId) const {
-  if (const auto it = textures_.find(assetId); it != textures_.end()) {
-    return it->second;
+  if (SDL_Texture *texture = texture_store_.Get(assetId)) {
+    return texture;
   }
-  // Atlas members are never inserted into textures_ directly — resolve the catalog redirect
+  // Atlas members are never inserted into the texture store directly — resolve the catalog redirect
   // to the backing atlas's SDL_Texture*. One-hop only (atlases do not nest).
   if (const CatalogEntry *e = catalog_.Find(assetId); e != nullptr && e->atlasId.has_value()) {
-    if (const auto ait = textures_.find(*e->atlasId); ait != textures_.end()) {
-      return ait->second;
-    }
+    return texture_store_.Get(*e->atlasId);
   }
   // No per-frame warning: scene-load validation (AssetManager::Validate) is the authoritative
   // miss check. Renderers tolerate a null texture.
@@ -266,40 +225,11 @@ void AssetManager::AddFont(const std::string &assetId, const std::string &path, 
     Logger::Error("Failed to open font file " + assetId + " from " + fullPath + ": " + std::string(SDL_GetError()));
     return;
   }
-  TTF_Font *font = TTF_OpenFontIO(io, true, fontSize);  // closes the stream
-  if (!font) {
-    Logger::Error("Failed to load font " + assetId + " from " + fullPath + ": " + std::string(SDL_GetError()));
-    return;
-  }
-
-  if (const auto it = fonts_.find(assetId); it != fonts_.end()) {
-    Logger::Warn("Replacing existing font: " + assetId);
-    TTF_CloseFont(it->second);
-    it->second = font;
-  } else {
-    fonts_.emplace(assetId, font);
-  }
-
-  Logger::Info("Added font: " + assetId + " from path: " + fullPath);
-
-  // Probe for a glyph-atlas sidecar pair (Stage 14 B3). The bake step writes them under
-  // <basePath>/atlases/<asset_id>.atlas.{png,lua}; presence is the opt-in. SDL_IOFromFile is used
-  // for the existence check so the probe transparently resolves through a shipped pak too.
-  if (base_path_.empty()) return;
-  const std::filesystem::path atlasPng = std::filesystem::path(base_path_) / "atlases" / (assetId + ".atlas.png");
-  const std::filesystem::path atlasLua = std::filesystem::path(base_path_) / "atlases" / (assetId + ".atlas.lua");
-  SDL_IOStream *probe = SDL_IOFromFile(atlasPng.string().c_str(), "rb");
-  if (probe == nullptr) return;
-  SDL_CloseIO(probe);
-  auto atlas = std::make_unique<GlyphAtlas>();
-  if (atlas->Load(atlasPng.string(), atlasLua.string())) {
-    glyph_atlases_[assetId] = std::move(atlas);
-  }
+  font_store_.Add(assetId, io, fontSize, base_path_);
 }
 
 const GlyphAtlas *AssetManager::GetGlyphAtlas(const std::string &fontAssetId) const {
-  const auto it = glyph_atlases_.find(fontAssetId);
-  return it == glyph_atlases_.end() ? nullptr : it->second.get();
+  return font_store_.GetGlyphAtlas(fontAssetId);
 }
 
 void AssetManager::AddAudioClip(MIX_Mixer *mixer, const std::string &assetId, const std::string &path,
@@ -315,41 +245,12 @@ void AssetManager::AddAudioClip(MIX_Mixer *mixer, const std::string &assetId, co
     Logger::Error("Failed to open audio file " + assetId + " from " + fullPath + ": " + std::string(SDL_GetError()));
     return;
   }
-  // predecode=true is the default for short SFX — full PCM in RAM at load time, lowest play-call
-  // latency. predecode=false (meta.stream=true on the source) keeps the file compressed and
-  // decodes on demand; pays back as flat memory for long-form music + ambient beds.
-  MIX_Audio *clip = MIX_LoadAudio_IO(mixer, io, !stream, true);  // closes the stream regardless
-  if (!clip) {
-    Logger::Error("Failed to load audio clip " + assetId + " from " + fullPath + ": " + std::string(SDL_GetError()));
-    return;
-  }
-
-  if (const auto it = audio_clips_.find(assetId); it != audio_clips_.end()) {
-    Logger::Warn("Replacing existing audio clip: " + assetId);
-    MIX_DestroyAudio(it->second);
-    it->second = clip;
-  } else {
-    audio_clips_.emplace(assetId, clip);
-  }
-
-  Logger::Info("Added audio clip: " + assetId + " from path: " + fullPath);
+  audio_store_.Add(mixer, assetId, io, stream, fullPath);
 }
 
-MIX_Audio *AssetManager::GetAudioClip(const std::string &assetId) const {
-  const auto it = audio_clips_.find(assetId);
-  if (it == audio_clips_.end()) {
-    return nullptr;  // see GetTexture: validation owns the miss check.
-  }
-  return it->second;
-}
+MIX_Audio *AssetManager::GetAudioClip(const std::string &assetId) const { return audio_store_.Get(assetId); }
 
-TTF_Font *AssetManager::GetFont(const std::string &assetId) const {
-  const auto it = fonts_.find(assetId);
-  if (it == fonts_.end()) {
-    return nullptr;  // see GetTexture: validation owns the miss check.
-  }
-  return it->second;
-}
+TTF_Font *AssetManager::GetFont(const std::string &assetId) const { return font_store_.Get(assetId); }
 
 std::string AssetManager::GetFullPath(const std::string &relativePath) const {
   const std::filesystem::path basePath = base_path_;
@@ -359,9 +260,9 @@ std::string AssetManager::GetFullPath(const std::string &relativePath) const {
 
 void AssetManager::SetDefaultScaleMode(const std::string &scaleMode) {
   if (scaleMode == "nearest") {
-    default_scale_mode_ = SDL_SCALEMODE_NEAREST;
+    texture_store_.SetDefaultScaleMode(SDL_SCALEMODE_NEAREST);
   } else if (scaleMode == "linear") {
-    default_scale_mode_ = SDL_SCALEMODE_LINEAR;
+    texture_store_.SetDefaultScaleMode(SDL_SCALEMODE_LINEAR);
   } else {
     Logger::Error("Invalid scale mode: " + scaleMode);
   }

--- a/src/AssetManager/AssetManager.h
+++ b/src/AssetManager/AssetManager.h
@@ -6,43 +6,43 @@
 
 #include <cstdint>
 #include <map>
-#include <memory>
 #include <optional>
 #include <string>
 #include <vector>
 
 #include "AssetManager/AssetCatalog.h"
+#include "AssetManager/AssetRefcounter.h"
 #include "AssetManager/AssetReference.h"
+#include "AssetManager/AudioClipStore.h"
+#include "AssetManager/FontStore.h"
+#include "AssetManager/TextureStore.h"
 
 class AssetPak;
 class GameConfig;
 class GlyphAtlas;
 
+// Composes the asset subsystem: the AssetCatalog (what exists + how to load it), three typed handle
+// stores (TextureStore / FontStore / AudioClipStore — the resident SDL/TTF/MIX handles), and an
+// AssetRefcounter (acquire counts). AssetManager itself owns only the cross-cutting concerns the
+// pieces can't: the project base path, the optional shipped-bundle pak, IO resolution, and the
+// Acquire/Release orchestration that ties refcounts to catalog-driven loads. Public API is
+// unchanged from the pre-split monolith — consumers see the same surface.
 class AssetManager {
   std::string base_path_;
-  std::map<std::string, SDL_Texture*> textures_;
-  std::map<std::string, TTF_Font*> fonts_;
-  std::map<std::string, MIX_Audio*> audio_clips_;
-  std::optional<SDL_ScaleMode> default_scale_mode_;
-  // Index of every discoverable asset (id -> file + metadata). Loads nothing on its own;
-  // Acquire consults it to load on demand.
+  // Index of every discoverable asset (id -> file + metadata). Loads nothing on its own; Acquire
+  // consults it to load on demand.
   AssetCatalog catalog_;
-  // Per-id acquire count. The 0 -> 1 transition loads the underlying handle; the N -> 0
-  // transition unloads it. Assets loaded via the legacy load_asset path are adopted at refcount 1
-  // on first Acquire. Entries at zero are erased.
-  std::map<std::string, int> refcounts_;
-  // Bumped whenever a texture is added or replaced. Sprite renderers compare against
-  // their cached generation to know when to re-resolve a stale SDL_Texture* pointer.
-  std::uint64_t texture_generation_{0};
+  TextureStore texture_store_;
+  FontStore font_store_;
+  AudioClipStore audio_store_;
+  // Per-id acquire count. The 0 -> 1 transition loads the underlying handle; the N -> 0 transition
+  // unloads it. Assets loaded via the legacy load_asset path are adopted at refcount 1 on first
+  // Acquire.
+  AssetRefcounter refcounter_;
   // Optional shipped-bundle archive (Stage 14 / B4). When set, AssetManager prefers reading each
   // asset's bytes from the pak over the loose file at `fullPath`. Non-owning — the Registry owns
   // the AssetPak instance.
   const AssetPak* asset_pak_{nullptr};
-  // Per-font glyph atlases (Stage 14 / B3) keyed by catalog asset id (e.g. "main-16"). Populated
-  // lazily inside AddFont when a `<basePath>/atlases/<id>.atlas.{png,lua}` sidecar pair is present;
-  // consumed by RenderTextSystem's compose path. unique_ptr to keep GlyphAtlas pinned across the
-  // map's rehashes (the surface wraps a vector<uint8_t> that must not be moved underneath SDL).
-  std::map<std::string, std::unique_ptr<GlyphAtlas>> glyph_atlases_;
 
  public:
   AssetManager() = default;
@@ -82,8 +82,8 @@ class AssetManager {
 
   void AddTexture(SDL_Renderer* renderer, const std::string& assetId, const std::string& path);
   // Resolves to the SDL_Texture under `assetId`. For atlas-member ids this walks the catalog to
-  // the backing atlas (whose SDL_Texture* lives in textures_) — members themselves never appear
-  // in textures_, which is what lets one atlas keep one SDL handle even with N member ids.
+  // the backing atlas (whose SDL_Texture* lives in the texture store) — members themselves never
+  // appear in the store, which is what lets one atlas keep one SDL handle even with N member ids.
   [[nodiscard]] SDL_Texture* GetTexture(const std::string& assetId) const;
   // Pixel-rect of `assetId` within its atlas, when `assetId` is an atlas member. Nullopt for
   // loose textures and non-textures. Sprite render adds slice.x/y to the sprite's logical
@@ -98,7 +98,7 @@ class AssetManager {
   [[nodiscard]] MIX_Audio* GetAudioClip(const std::string& assetId) const;
   [[nodiscard]] std::string GetFullPath(const std::string& relativePath) const;
   void SetDefaultScaleMode(const std::string& scaleMode);
-  [[nodiscard]] std::uint64_t TextureGeneration() const { return texture_generation_; }
+  [[nodiscard]] std::uint64_t TextureGeneration() const { return texture_store_.Generation(); }
 
   [[nodiscard]] AssetCatalog& GetCatalog() { return catalog_; }
   [[nodiscard]] const AssetCatalog& GetCatalog() const { return catalog_; }
@@ -117,9 +117,9 @@ class AssetManager {
   // Current acquire count for an id (0 if untracked). Test/diagnostic aid.
   [[nodiscard]] int RefCount(const std::string& assetId) const;
 
-  [[nodiscard]] const std::map<std::string, SDL_Texture*>& GetTextures() const { return textures_; }
-  [[nodiscard]] const std::map<std::string, TTF_Font*>& GetFonts() const { return fonts_; }
-  [[nodiscard]] const std::map<std::string, MIX_Audio*>& GetAudioClips() const { return audio_clips_; }
+  [[nodiscard]] const std::map<std::string, SDL_Texture*>& GetTextures() const { return texture_store_.All(); }
+  [[nodiscard]] const std::map<std::string, TTF_Font*>& GetFonts() const { return font_store_.All(); }
+  [[nodiscard]] const std::map<std::string, MIX_Audio*>& GetAudioClips() const { return audio_store_.All(); }
 
  private:
   // Open a read-only SDL_IOStream over `fullPath`. Tries the wired AssetPak first (lookup by
@@ -131,7 +131,7 @@ class AssetManager {
   // the handle is resident afterwards.
   bool LoadFromCatalog(const CatalogEntry& entry, const std::string& assetId, SDL_Renderer* renderer, MIX_Mixer* mixer);
 
-  // Destroy and erase whichever resident handle backs `assetId` (texture/font/audio). Bumps
-  // texture_generation_ when a texture is dropped so cached SDL_Texture* pointers re-resolve.
+  // Destroy and erase whichever resident handle backs `assetId` (texture/font/audio). The texture
+  // store bumps its generation when a texture is dropped so cached SDL_Texture* pointers re-resolve.
   void UnloadAsset(const std::string& assetId);
 };

--- a/src/AssetManager/AssetRefcounter.h
+++ b/src/AssetManager/AssetRefcounter.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <map>
+#include <string>
+
+// Per-asset acquire counts. Pure bookkeeping — no SDL, no catalog, no I/O — so the refcount policy
+// can be unit-tested on its own. AssetManager owns the side effects: it drives the 0 -> 1 load and
+// the N -> 0 unload transitions; this class only tracks the integer behind each id.
+//
+// Scene-reference handling (which ids a scene pulls in, and on-disk validation of them) lives in
+// AssetManager::AcquireAll / Validate against the AssetCatalog, not here — those need the catalog,
+// whereas the count itself does not.
+class AssetRefcounter {
+ public:
+  [[nodiscard]] int Count(const std::string& id) const {
+    const auto it = counts_.find(id);
+    return it == counts_.end() ? 0 : it->second;
+  }
+
+  // True when the id currently holds at least one live reference.
+  [[nodiscard]] bool Has(const std::string& id) const { return Count(id) > 0; }
+
+  // Bump the reference count, returning the new value. A result of 1 marks the 0 -> 1 transition,
+  // i.e. the caller should load the underlying handle now.
+  int Increment(const std::string& id) { return ++counts_[id]; }
+
+  // Force the count to 1. Used when adopting a handle that became resident outside the refcount
+  // path (a legacy direct Add, or an atlas member that piggy-backs on its atlas's handle).
+  void Adopt(const std::string& id) { counts_[id] = 1; }
+
+  // Drop one reference. Returns the new count, erasing the entry when it hits zero. Returns -1 when
+  // the id was never tracked so callers can treat that as a no-op (untracked ids are ignored).
+  int Decrement(const std::string& id) {
+    const auto it = counts_.find(id);
+    if (it == counts_.end()) return -1;
+    if (--it->second > 0) return it->second;
+    counts_.erase(it);
+    return 0;
+  }
+
+  void Clear() { counts_.clear(); }
+
+ private:
+  std::map<std::string, int> counts_;
+};

--- a/src/AssetManager/AudioClipStore.cpp
+++ b/src/AssetManager/AudioClipStore.cpp
@@ -1,0 +1,46 @@
+#include "AssetManager/AudioClipStore.h"
+
+#include "General/Logger.h"
+
+MIX_Audio* AudioClipStore::Add(MIX_Mixer* mixer, const std::string& id, SDL_IOStream* io, const bool stream,
+                               const std::string& logPath) {
+  // predecode=true is the default for short SFX — full PCM in RAM at load time, lowest play-call
+  // latency. predecode=false (meta.stream=true on the source) keeps the file compressed and
+  // decodes on demand; pays back as flat memory for long-form music + ambient beds.
+  MIX_Audio* clip = MIX_LoadAudio_IO(mixer, io, !stream, true);  // closes the stream regardless
+  if (!clip) {
+    Logger::Error("Failed to load audio clip " + id + " from " + logPath + ": " + std::string(SDL_GetError()));
+    return nullptr;
+  }
+
+  if (const auto it = audio_clips_.find(id); it != audio_clips_.end()) {
+    Logger::Warn("Replacing existing audio clip: " + id);
+    MIX_DestroyAudio(it->second);
+    it->second = clip;
+  } else {
+    audio_clips_.emplace(id, clip);
+  }
+
+  Logger::Info("Added audio clip: " + id + " from path: " + logPath);
+  return clip;
+}
+
+MIX_Audio* AudioClipStore::Get(const std::string& id) const {
+  const auto it = audio_clips_.find(id);
+  return it == audio_clips_.end() ? nullptr : it->second;
+}
+
+bool AudioClipStore::Remove(const std::string& id) {
+  const auto it = audio_clips_.find(id);
+  if (it == audio_clips_.end()) return false;
+  MIX_DestroyAudio(it->second);
+  audio_clips_.erase(it);
+  return true;
+}
+
+void AudioClipStore::Clear() {
+  for (const auto& [id, clip] : audio_clips_) {
+    MIX_DestroyAudio(clip);
+  }
+  audio_clips_.clear();
+}

--- a/src/AssetManager/AudioClipStore.h
+++ b/src/AssetManager/AudioClipStore.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <SDL3/SDL.h>
+#include <SDL3_mixer/SDL_mixer.h>
+
+#include <map>
+#include <string>
+
+// Owns the resident MIX_Audio* handles keyed by asset id. Pak-agnostic like the texture/font
+// stores: AssetManager opens the IO stream and passes it in along with the mixer and the catalog's
+// `stream` flag (predecode toggle).
+class AudioClipStore {
+ public:
+  AudioClipStore() = default;
+  AudioClipStore(const AudioClipStore&) = delete;
+  AudioClipStore& operator=(const AudioClipStore&) = delete;
+  AudioClipStore(AudioClipStore&&) noexcept = default;
+  AudioClipStore& operator=(AudioClipStore&&) noexcept = default;
+  ~AudioClipStore() { Clear(); }
+
+  // Load an audio clip from an already-opened, owned IO stream (consumed and closed by the loader),
+  // replacing any prior handle under `id`. `stream == false` predecodes the full PCM at load time
+  // (short SFX, lowest play latency); `stream == true` decodes on demand (long music / ambient).
+  // Returns the resident clip, or nullptr on failure. `logPath` feeds the log line only.
+  MIX_Audio* Add(MIX_Mixer* mixer, const std::string& id, SDL_IOStream* io, bool stream, const std::string& logPath);
+
+  [[nodiscard]] MIX_Audio* Get(const std::string& id) const;
+  [[nodiscard]] bool Contains(const std::string& id) const { return audio_clips_.contains(id); }
+
+  bool Remove(const std::string& id);
+  void Clear();
+
+  [[nodiscard]] const std::map<std::string, MIX_Audio*>& All() const { return audio_clips_; }
+
+ private:
+  std::map<std::string, MIX_Audio*> audio_clips_;
+};

--- a/src/AssetManager/FontStore.cpp
+++ b/src/AssetManager/FontStore.cpp
@@ -1,0 +1,72 @@
+#include "AssetManager/FontStore.h"
+
+#include <filesystem>
+#include <utility>
+
+#include "AssetManager/GlyphAtlas.h"
+#include "General/Logger.h"
+
+// Out-of-line so the unique_ptr<GlyphAtlas> members can be destroyed/moved where GlyphAtlas is a
+// complete type (the header only forward-declares it).
+FontStore::FontStore() = default;
+FontStore::FontStore(FontStore&&) noexcept = default;
+FontStore& FontStore::operator=(FontStore&&) noexcept = default;
+FontStore::~FontStore() { Clear(); }
+
+TTF_Font* FontStore::Add(const std::string& id, SDL_IOStream* io, const float fontSize, const std::string& basePath) {
+  TTF_Font* font = TTF_OpenFontIO(io, true, fontSize);  // closes the stream
+  if (!font) {
+    Logger::Error("Failed to load font " + id + ": " + std::string(SDL_GetError()));
+    return nullptr;
+  }
+
+  if (const auto it = fonts_.find(id); it != fonts_.end()) {
+    Logger::Warn("Replacing existing font: " + id);
+    TTF_CloseFont(it->second);
+    it->second = font;
+  } else {
+    fonts_.emplace(id, font);
+  }
+
+  Logger::Info("Added font: " + id);
+
+  // Probe for a glyph-atlas sidecar pair (Stage 14 B3). The bake step writes them under
+  // <basePath>/atlases/<asset_id>.atlas.{png,lua}; presence is the opt-in. SDL_IOFromFile is used
+  // for the existence check so the probe transparently resolves through a shipped pak too.
+  if (basePath.empty()) return font;
+  const std::filesystem::path atlasPng = std::filesystem::path(basePath) / "atlases" / (id + ".atlas.png");
+  const std::filesystem::path atlasLua = std::filesystem::path(basePath) / "atlases" / (id + ".atlas.lua");
+  SDL_IOStream* probe = SDL_IOFromFile(atlasPng.string().c_str(), "rb");
+  if (probe == nullptr) return font;
+  SDL_CloseIO(probe);
+  auto atlas = std::make_unique<GlyphAtlas>();
+  if (atlas->Load(atlasPng.string(), atlasLua.string())) {
+    glyph_atlases_[id] = std::move(atlas);
+  }
+  return font;
+}
+
+TTF_Font* FontStore::Get(const std::string& id) const {
+  const auto it = fonts_.find(id);
+  return it == fonts_.end() ? nullptr : it->second;
+}
+
+const GlyphAtlas* FontStore::GetGlyphAtlas(const std::string& id) const {
+  const auto it = glyph_atlases_.find(id);
+  return it == glyph_atlases_.end() ? nullptr : it->second.get();
+}
+
+bool FontStore::Remove(const std::string& id) {
+  const auto it = fonts_.find(id);
+  if (it == fonts_.end()) return false;
+  TTF_CloseFont(it->second);
+  fonts_.erase(it);
+  return true;
+}
+
+void FontStore::Clear() {
+  for (const auto& [id, font] : fonts_) {
+    TTF_CloseFont(font);
+  }
+  fonts_.clear();
+}

--- a/src/AssetManager/FontStore.h
+++ b/src/AssetManager/FontStore.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <SDL3/SDL.h>
+#include <SDL3_ttf/SDL_ttf.h>
+
+#include <map>
+#include <memory>
+#include <string>
+
+class GlyphAtlas;
+
+// Owns the resident TTF_Font* handles keyed by asset id, plus the per-font glyph atlases probed
+// alongside them. Like TextureStore it is pak-agnostic: AssetManager opens the font's IO stream and
+// passes it in, along with the project base path used to probe for an `atlases/<id>.atlas.{png,lua}`
+// sidecar pair (the glyph-atlas opt-in consumed by RenderTextSystem's compose path).
+class FontStore {
+ public:
+  FontStore();
+  FontStore(const FontStore&) = delete;
+  FontStore& operator=(const FontStore&) = delete;
+  FontStore(FontStore&&) noexcept;
+  FontStore& operator=(FontStore&&) noexcept;
+  ~FontStore();
+
+  // Load a font from an already-opened, owned IO stream (consumed and closed by the loader) at
+  // `fontSize`px, replacing any prior handle under `id`. When `basePath` is non-empty, also probes
+  // for and loads a glyph-atlas sidecar for `id`. Returns the resident font, or nullptr on failure.
+  TTF_Font* Add(const std::string& id, SDL_IOStream* io, float fontSize, const std::string& basePath);
+
+  [[nodiscard]] TTF_Font* Get(const std::string& id) const;
+  [[nodiscard]] bool Contains(const std::string& id) const { return fonts_.contains(id); }
+
+  // Resident glyph atlas for `id`, or nullptr when none was loaded.
+  [[nodiscard]] const GlyphAtlas* GetGlyphAtlas(const std::string& id) const;
+
+  // Close and erase the font under `id`; returns whether one was removed. Mirrors the prior
+  // behavior of leaving any glyph atlas for `id` resident (atlases outlive their font handle and
+  // are refreshed on the next Add).
+  bool Remove(const std::string& id);
+
+  // Close every font. Glyph atlases are intentionally left resident (matching the pre-split
+  // ClearAssets, which only cleared the font handles); they are freed when the store is destroyed.
+  void Clear();
+
+  [[nodiscard]] const std::map<std::string, TTF_Font*>& All() const { return fonts_; }
+
+ private:
+  std::map<std::string, TTF_Font*> fonts_;
+  // Per-font glyph atlases keyed by font catalog id (e.g. "main-16"). unique_ptr keeps each
+  // GlyphAtlas pinned across the map's rehashes (its surface wraps a vector<uint8_t> that must not
+  // move underneath SDL).
+  std::map<std::string, std::unique_ptr<GlyphAtlas>> glyph_atlases_;
+};

--- a/src/AssetManager/TextureStore.cpp
+++ b/src/AssetManager/TextureStore.cpp
@@ -1,0 +1,52 @@
+#include "AssetManager/TextureStore.h"
+
+#include <SDL3_image/SDL_image.h>
+
+#include "General/Logger.h"
+
+SDL_Texture* TextureStore::Add(SDL_Renderer* renderer, const std::string& id, SDL_IOStream* io,
+                               const std::string& logPath) {
+  SDL_Texture* texture = IMG_LoadTexture_IO(renderer, io, true);  // closes the stream
+  if (!texture) {
+    Logger::Error("Failed to create texture: " + std::string(SDL_GetError()));
+    return nullptr;
+  }
+
+  if (default_scale_mode_.has_value()) {
+    SDL_SetTextureScaleMode(texture, default_scale_mode_.value());
+  }
+
+  // Replace prior texture under the same id rather than leaking it.
+  if (const auto it = textures_.find(id); it != textures_.end()) {
+    Logger::Warn("Replacing existing texture: " + id);
+    SDL_DestroyTexture(it->second);
+    it->second = texture;
+  } else {
+    textures_.emplace(id, texture);
+  }
+  ++generation_;
+
+  Logger::Info("Added texture: " + id + " from path: " + logPath);
+  return texture;
+}
+
+SDL_Texture* TextureStore::Get(const std::string& id) const {
+  const auto it = textures_.find(id);
+  return it == textures_.end() ? nullptr : it->second;
+}
+
+bool TextureStore::Remove(const std::string& id) {
+  const auto it = textures_.find(id);
+  if (it == textures_.end()) return false;
+  SDL_DestroyTexture(it->second);
+  textures_.erase(it);
+  ++generation_;  // invalidate cached SDL_Texture* in sprite renderers
+  return true;
+}
+
+void TextureStore::Clear() {
+  for (const auto& [id, texture] : textures_) {
+    SDL_DestroyTexture(texture);
+  }
+  textures_.clear();
+}

--- a/src/AssetManager/TextureStore.h
+++ b/src/AssetManager/TextureStore.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <SDL3/SDL.h>
+
+#include <cstdint>
+#include <map>
+#include <optional>
+#include <string>
+
+// Owns the resident SDL_Texture* handles keyed by asset id, the project default scale mode, and the
+// generation counter sprite renderers poll to know when a cached SDL_Texture* has gone stale.
+//
+// Deliberately narrow: it knows nothing about the catalog, refcounts, or asset paks. AssetManager
+// opens the SDL_IOStream (resolving paks / base path) and feeds it here; atlas-member redirection
+// stays in AssetManager because it needs the catalog. Lookups here are direct id -> handle.
+class TextureStore {
+ public:
+  TextureStore() = default;
+  TextureStore(const TextureStore&) = delete;
+  TextureStore& operator=(const TextureStore&) = delete;
+  TextureStore(TextureStore&&) noexcept = default;
+  TextureStore& operator=(TextureStore&&) noexcept = default;
+  ~TextureStore() { Clear(); }
+
+  void SetDefaultScaleMode(std::optional<SDL_ScaleMode> mode) { default_scale_mode_ = mode; }
+
+  // Create a texture from an already-opened, owned IO stream (consumed and closed by the loader).
+  // Applies the default scale mode, replaces any prior handle under `id`, and bumps the generation.
+  // Returns the resident texture, or nullptr on load failure. `logPath` feeds the log line only.
+  SDL_Texture* Add(SDL_Renderer* renderer, const std::string& id, SDL_IOStream* io, const std::string& logPath);
+
+  // Direct lookup — no atlas-member redirect (that lives in AssetManager, which has the catalog).
+  [[nodiscard]] SDL_Texture* Get(const std::string& id) const;
+  [[nodiscard]] bool Contains(const std::string& id) const { return textures_.contains(id); }
+
+  // Destroy and erase the handle under `id`, bumping the generation so cached pointers re-resolve.
+  // Returns whether an entry was removed.
+  bool Remove(const std::string& id);
+  void Clear();
+
+  [[nodiscard]] std::uint64_t Generation() const { return generation_; }
+  [[nodiscard]] const std::map<std::string, SDL_Texture*>& All() const { return textures_; }
+
+ private:
+  std::map<std::string, SDL_Texture*> textures_;
+  std::optional<SDL_ScaleMode> default_scale_mode_;
+  // Bumped whenever a texture is added, replaced, or removed. Sprite renderers compare against their
+  // cached value to know when to re-resolve a stale SDL_Texture* pointer.
+  std::uint64_t generation_{0};
+};

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -68,9 +68,12 @@ octarine_library(octarine_assets
         AssetManager/AssetManager.cpp
         AssetManager/AssetPak.cpp
         AssetManager/AtlasBaker.cpp
+        AssetManager/AudioClipStore.cpp
         AssetManager/AudioNormalizer.cpp
+        AssetManager/FontStore.cpp
         AssetManager/GlyphAtlas.cpp
         AssetManager/TextureAtlasBaker.cpp
+        AssetManager/TextureStore.cpp
         AssetManager/SceneAssetScanner.cpp
 )
 set_source_files_properties(

--- a/tests/AssetRefcounterTest.cpp
+++ b/tests/AssetRefcounterTest.cpp
@@ -1,0 +1,66 @@
+// Unit checks for AssetRefcounter — the pure acquire-count bookkeeping split out of AssetManager
+// in Stage 10. The point of the split is that this policy needs neither SDL nor a renderer, so the
+// test links nothing but the standard library. gtest-free; exit code = failed-check count.
+// Registered with ctest as AssetRefcounterTest.
+
+#include "AssetManager/AssetRefcounter.h"
+#include "TestHarness.h"
+
+using octarine::test::Check;
+using octarine::test::CheckEq;
+
+int main() {
+  {
+    AssetRefcounter rc;
+    CheckEq(rc.Count("a"), 0, "untracked id counts as 0");
+    Check(!rc.Has("a"), "untracked id is not Has()");
+    CheckEq(rc.Decrement("a"), -1, "Decrement of untracked id returns -1 (no-op signal)");
+  }
+
+  {
+    // 0 -> 1 transition signals the caller to load; subsequent bumps do not.
+    AssetRefcounter rc;
+    CheckEq(rc.Increment("tex"), 1, "first Increment yields 1 (load transition)");
+    Check(rc.Has("tex"), "id is Has() after Increment");
+    CheckEq(rc.Increment("tex"), 2, "second Increment yields 2");
+    CheckEq(rc.Increment("tex"), 3, "third Increment yields 3");
+    CheckEq(rc.Count("tex"), 3, "Count reflects the three references");
+  }
+
+  {
+    // Decrement walks back down; the entry is erased exactly at zero (the unload transition).
+    AssetRefcounter rc;
+    rc.Increment("snd");
+    rc.Increment("snd");
+    CheckEq(rc.Decrement("snd"), 1, "Decrement from 2 yields 1 (still referenced)");
+    CheckEq(rc.Decrement("snd"), 0, "Decrement from 1 yields 0 (unload transition)");
+    CheckEq(rc.Count("snd"), 0, "count is 0 after reaching zero");
+    Check(!rc.Has("snd"), "id is no longer Has() after reaching zero");
+    CheckEq(rc.Decrement("snd"), -1, "Decrement past zero returns -1 (untracked again)");
+  }
+
+  {
+    // Adopt forces an already-resident handle to count 1 regardless of prior state.
+    AssetRefcounter rc;
+    rc.Adopt("font");
+    CheckEq(rc.Count("font"), 1, "Adopt sets count to 1");
+    rc.Increment("font");
+    rc.Adopt("font");
+    CheckEq(rc.Count("font"), 1, "Adopt resets a higher count back to 1");
+  }
+
+  {
+    // Independent ids do not interfere; Clear drops everything.
+    AssetRefcounter rc;
+    rc.Increment("a");
+    rc.Increment("b");
+    rc.Increment("b");
+    CheckEq(rc.Count("a"), 1, "id 'a' isolated from 'b'");
+    CheckEq(rc.Count("b"), 2, "id 'b' isolated from 'a'");
+    rc.Clear();
+    CheckEq(rc.Count("a"), 0, "Clear drops 'a'");
+    CheckEq(rc.Count("b"), 0, "Clear drops 'b'");
+  }
+
+  return octarine::test::ReportSummary("AssetRefcounterTest");
+}


### PR DESCRIPTION
## Architecture Improvements Plan — Stage 10 (P2)

Decomposes the `AssetManager` monolith (catalog ownership + three typed handle stores + refcounts + scale mode + validation + SDL/TTF/MIX load shims + generation counter) into composed pieces in the `octarine_assets` layer.

### New units
| Unit | Owns | Needs SDL? |
|------|------|-----------|
| `TextureStore` | `SDL_Texture*` map + default scale mode + generation counter | yes (load shim) |
| `FontStore` | `TTF_Font*` map + per-font glyph atlases | yes (load shim) |
| `AudioClipStore` | `MIX_Audio*` map | yes (load shim) |
| `AssetRefcounter` | id → acquire count | **no** — pure bookkeeping |

`AssetManager` keeps only the cross-cutting concerns the pieces can't: the project base path, the optional shipped-bundle pak, `OpenAssetIO` resolution, and the `Acquire`/`Release` orchestration that ties refcounts to catalog-driven loads (including the atlas-member piggyback). It opens each asset's IO stream and feeds it to the relevant store, so the stores stay pak-agnostic; atlas-member texture redirection stays in `AssetManager` because it needs the catalog.

### Outcomes vs. plan "done when"
- **Catalog/asset logic testable without `SDL_CreateRenderer`**: `AssetRefcounter` is pure logic; the new `AssetRefcounterTest` links nothing but the standard library and is registered with ctest.
- `AssetManager.cpp`: **368 → 262 LOC**.
- **Public API unchanged** — the ~25 consumers (render systems, Lua modules, editor, engine bootstrap) compile untouched.

### No behavior change
Pure restructuring. Behavior is preserved exactly, including the pre-split quirk where `ClearAssets()` leaves glyph atlases resident (they free when the font store is destroyed) — documented in a comment rather than silently changed.

### Verification (real exit codes)
| Config | Result |
|--------|--------|
| editor-debug | configure + build clean; 3 store objects compiled |
| editor-release (`-Werror`) + tests | build clean; **ctest 12/12** incl. new `AssetRefcounterTest` |
| player-release (no ImGui) | configure + build clean |