### PR TITLE
CI: fix the blocking clang-tidy step (unsupported -warnings-as-errors)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,11 +146,17 @@ jobs:
             diff_tool="$RUNNER_TEMP/clang-tidy-diff.py"
             curl -fsSL https://raw.githubusercontent.com/llvm/llvm-project/llvmorg-18.1.8/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py -o "$diff_tool"
           fi
-          # -p1 strips the a/ b/ diff prefixes; -path points at compile_commands.json; any diagnostic
-          # on a touched line is promoted to an error and fails the step.
-          git diff -U0 "$base"...HEAD -- 'src/*' 'tests/*' \
-            | python3 "$diff_tool" -p1 -path "build/${{ matrix.preset }}" \
-                -clang-tidy-binary clang-tidy-18 -warnings-as-errors='*'
+          # -p1 strips the a/ b/ diff prefixes; -path points at compile_commands.json. Note: no
+          # released clang-tidy-diff.py accepts -warnings-as-errors (it forwards only post-`--` args,
+          # and those go to the *compiler*, not clang-tidy), and the wrapper exits 0 on warnings — so
+          # we capture its output and fail the step ourselves on any diagnostic against a touched line.
+          report="$(git diff -U0 "$base"...HEAD -- 'src/*' 'tests/*' \
+            | python3 "$diff_tool" -p1 -path "build/${{ matrix.preset }}" -clang-tidy-binary clang-tidy-18 2>&1)"
+          printf '%s\n' "$report"
+          if printf '%s\n' "$report" | grep -qE '^[^ ]+:[0-9]+:[0-9]+: (warning|error):'; then
+            echo "::error::clang-tidy reported issues on changed lines (see log above)."
+            exit 1
+          fi
 
       - name: Stage runtime DLLs (Windows)
         if: matrix.platform == 'windows'


### PR DESCRIPTION
## Problem

The **`clang-tidy (changed lines, blocking)`** step (added in #110) calls `clang-tidy-diff.py` with `-warnings-as-errors='*'` — but **no released `clang-tidy-diff.py` accepts that argument** (checked 18.1.3 / 18.1.8 / 19.1.0 / 20.1.0). It forwards only post-`--` args, and those go to the *compiler*, not clang-tidy. argparse rejects it:

```
clang-tidy-diff.py: error: unrecognized arguments: -warnings-as-errors=*
```

So the step errors **before analyzing anything** and fails **every PR that touches C++**. `main` never caught it because the step is gated on `github.event_name == 'pull_request'` — skipped on push, only run on PRs. (First surfaced on #114.)

The `find /usr/lib/llvm-18 … | head -1` preference also defeated the intended pinned-upstream fallback: apt's `clang-tidy-18` ships an 18.1.3 copy of the script, so the curl'd 18.1.8 copy was never reached (and it lacks the flag too).

## Fix

Keep warnings-as-errors **CI-scoped** (the original intent — it was in the workflow, not `.clang-tidy`), and don't change lint semantics. Drop the bogus flag and fail the step by inspecting `clang-tidy-diff.py`'s output: it prints diagnostics but exits 0 on warnings (non-zero only when a file errors), so grep for any `file:line:col: warning|error:` on a touched line and fail explicitly. `-line-filter` still scopes findings to changed lines, so pre-existing debt in unchanged headers is ignored.

## Verification

End-to-end against #114's actual changed lines using a real `clang-tidy-diff.py` + `compile_commands.json`: clean code → no diagnostics → gate passes; a planted finding → matches → gate fails. The detection regex matches real diagnostic lines and ignores `N warnings generated` / source-context / caret lines.

## Why this matters now

Unblocks #114 (Stage 10) and every subsequent PR (Architecture plan Stages 11–13). After this merges, those PRs pick up the fixed workflow on their next run.