### PR TITLE
Stage 11: EventBus RAII subscription handle replaces void* owner tracking

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -13,27 +13,32 @@ usually receive it in their `Init` / `SubscribeToEvents` hook rather than fetchi
 
 API:
 
-- `SubscribeEvent<Owner, Event>(owner, &Owner::method)` — register a member-function handler. The
-  handler takes `Event&` or `const Event&` (both overloads exist).
+- `SubscribeEvent<Owner, Event>(owner, &Owner::method)` — register a member-function handler and
+  return a `[[nodiscard]] EventBus::SubscriptionHandle`. The handler takes `Event&` or `const Event&`
+  (both overloads exist). **You must keep the returned handle** — its destructor unsubscribes, so a
+  discarded handle unsubscribes immediately.
 - `EmitEvent<Event>(args...)` — construct an `Event` from `args` and dispatch it to every subscriber,
   synchronously, in subscription order. Emitting an event with no subscribers is a no-op.
-- `UnsubscribeAll(owner)` — drop every subscription owned by `owner`.
 
 ```cpp
-// Subscribe (typically in a system's Init/SubscribeToEvents):
-eventBus->SubscribeEvent<DamageSystem, CollisionEvent>(this, &DamageSystem::OnCollision);
+// Subscribe (typically in a system's Init/SubscribeToEvents) — store the handle as a member:
+subscription_ = eventBus->SubscribeEvent<DamageSystem, CollisionEvent>(this, &DamageSystem::OnCollision);
+// ...where the class declares:  EventBus::SubscriptionHandle subscription_;
+// (use a std::vector<EventBus::SubscriptionHandle> when a system subscribes to several events).
 
 // Emit (from wherever the thing happens):
 eventBus->EmitEvent<CollisionEvent>(entityA, entityB);
 ```
 
 Subscriptions are wired once during startup (`Game::Setup`, each system's `Init` /
-`SubscribeToEvents`) and persist for the lifetime of the bus.
+`SubscribeToEvents`) and last as long as the handle the subscriber holds.
 
-> **Dangling-callback hazard.** The bus stores raw owner pointers. If a subscriber is destroyed
-> before the bus, the next `EmitEvent` calls into freed memory. A subscriber whose lifetime can end
-> before the bus's must call `eventBus->UnsubscribeAll(this)` in its destructor. (Today's subscribers
-> all live as long as the bus, so none do — keep this in mind when adding a shorter-lived one.)
+> **Lifetime is RAII, order-independent.** `SubscriptionHandle` owns the subscription: its destructor
+> removes the callback, and it holds a `weak_ptr` to the bus's dispatch table, so destroying the handle
+> *after* the bus is a safe no-op. A subscriber simply keeps its handle(s) as a member and never has to
+> unsubscribe by hand — there is no `UnsubscribeAll` and no dangling-callback hazard. Call
+> `handle.Reset()` to unsubscribe early; `handle.Active()` reports whether the subscription is still
+> live on a surviving bus.
 
 ## Event catalog
 
@@ -41,7 +46,7 @@ Subscriptions are wired once during startup (`Game::Setup`, each system's `Init`
 |-------|---------|------------|---------------|
 | `AudioPlayEvent` | `clipId: string`, `volume: float` | Lua `play_sound()` (`AudioModuleLuaBinding.cpp`) | `AudioSystem::OnAudioPlay` |
 | `CollisionEvent` | `entityA: Entity`, `entityB: Entity` | `CollisionSystem` (narrowphase) | `DamageSystem::OnCollision`, `ObstacleBounceSystem::OnCollision` |
-| `KeyInputEvent` | `inputKey: SDL_Keycode`, `inputModifier: SDL_Keymod`, `isPressed: bool` | `Game::ProcessInput` (SDL key events) | `InputSystem::OnKeyInput`, `Game::OnKeyInputEvent` |
+| `KeyInputEvent` | `inputKey: SDL_Keycode`, `inputModifier: SDL_Keymod`, `isPressed: bool` | `Game::ProcessInput` (SDL key events) | `InputSystem::OnKeyInput`, `FrameLoop::OnKeyInputEvent` |
 | `MouseInputEvent` | `event: SDL_MouseButtonEvent` | `Game::ProcessInput` (SDL mouse-button events) | `InputSystem::OnMouseInput`, `UIButtonSystem::OnMouseInput` |
 | `MouseWheelEvent` | `dx: float`, `dy: float` | `Game::ProcessInput` (SDL wheel events) | `InputSystem::OnMouseWheel` |
 
@@ -50,8 +55,8 @@ Event types live in `src/Events/`.
 ### Flows at a glance
 
 - **Input:** SDL events → `Game::ProcessInput` emits `KeyInputEvent` / `MouseInputEvent` /
-  `MouseWheelEvent` → `InputSystem` folds them into per-frame state (also `Game` for engine hotkeys,
-  `UIButtonSystem` for clicks).
+  `MouseWheelEvent` → `InputSystem` folds them into per-frame state (also `FrameLoop` for engine
+  hotkeys, `UIButtonSystem` for clicks).
 - **Collision:** `CollisionSystem` detects overlaps and emits `CollisionEvent` → `DamageSystem` and
   `ObstacleBounceSystem` react.
 - **Audio:** Lua `play_sound(clip, volume)` emits `AudioPlayEvent` → `AudioSystem` plays the clip.

--- a/events.json
+++ b/events.json
@@ -58,7 +58,7 @@
         },
         {
           "file": "src/Systems/ObstacleBounceSystem.h",
-          "line": 19,
+          "line": 20,
           "owner": "ObstacleBounceSystem"
         }
       ]
@@ -84,18 +84,18 @@
       "emit_sites": [
         {
           "file": "src/Engine/FrameLoop.cpp",
-          "line": 68
+          "line": 72
         }
       ],
       "subscribe_sites": [
         {
-          "file": "src/Game/Game.cpp",
-          "line": 599,
+          "file": "src/Engine/FrameLoop.cpp",
+          "line": 44,
           "owner": "FrameLoop"
         },
         {
           "file": "src/Systems/InputSystem.h",
-          "line": 49,
+          "line": 50,
           "owner": "InputSystem"
         }
       ]
@@ -113,13 +113,13 @@
       "emit_sites": [
         {
           "file": "src/Engine/FrameLoop.cpp",
-          "line": 74
+          "line": 78
         }
       ],
       "subscribe_sites": [
         {
           "file": "src/Systems/InputSystem.h",
-          "line": 50,
+          "line": 51,
           "owner": "InputSystem"
         },
         {
@@ -146,13 +146,13 @@
       "emit_sites": [
         {
           "file": "src/Engine/FrameLoop.cpp",
-          "line": 78
+          "line": 82
         }
       ],
       "subscribe_sites": [
         {
           "file": "src/Systems/InputSystem.h",
-          "line": 51,
+          "line": 52,
           "owner": "InputSystem"
         }
       ]

--- a/src/Engine/FrameLoop.cpp
+++ b/src/Engine/FrameLoop.cpp
@@ -40,6 +40,10 @@ FrameLoop::FrameLoop(Game* game, Registry* registry, EventBus* eventBus, Rendere
   collider_query_ = registry_->CreateQuery<GlobalTransformComponent, BoxColliderComponent>();
 }
 
+void FrameLoop::SubscribeToEvents() {
+  key_input_subscription_ = event_bus_->SubscribeEvent<FrameLoop, KeyInputEvent>(this, &FrameLoop::OnKeyInputEvent);
+}
+
 void FrameLoop::Begin() { milliseconds_previous_frame_ = SDL_GetTicks(); }
 
 void FrameLoop::ProcessInput() {

--- a/src/Engine/FrameLoop.h
+++ b/src/Engine/FrameLoop.h
@@ -8,10 +8,10 @@
 #include "Components/BoxColliderComponent.h"
 #include "Components/GlobalTransformComponent.h"
 #include "ECS/Query.h"
+#include "EventBus/EventBus.h"
 
 class Game;
 class Registry;
-class EventBus;
 class Renderer;
 class EngineRuntime;
 // Defined in Events/KeyInputEvent.h. Forward-declared (not included) because that header is not
@@ -47,6 +47,10 @@ class FrameLoop {
   void Render(float deltaTime);
   [[nodiscard]] float WaitTime();
 
+  // Subscribe OnKeyInputEvent to the bus. Called once by Game during Setup; the returned RAII
+  // handle is held as a member so the subscription drops when this FrameLoop is destroyed.
+  void SubscribeToEvents();
+
   // KeyInputEvent subscriber (Esc → quit, backtick → toggle debug GUI). Public so Game can wire
   // it to the EventBus during Setup.
   void OnKeyInputEvent(const KeyInputEvent& event);
@@ -62,4 +66,5 @@ class FrameLoop {
   sol::state& lua_;
   Uint64 milliseconds_previous_frame_ = 0;
   std::unique_ptr<ComponentQuery<GlobalTransformComponent, BoxColliderComponent>> collider_query_;
+  EventBus::SubscriptionHandle key_input_subscription_;
 };

--- a/src/EventBus/EventBus.h
+++ b/src/EventBus/EventBus.h
@@ -153,7 +153,7 @@ class EventBus {
     const std::uint64_t id = next_id_++;
     dispatcher_->subscribers[eventTypeId].push_back(
         std::make_unique<EventCallback<TOwner, TEvent>>(id, ownerInstance, callbackFunction));
-    return SubscriptionHandle(dispatcher_, eventTypeId, id);
+    return {dispatcher_, eventTypeId, id};
   }
 
   template <typename TOwner, typename TEvent>
@@ -163,7 +163,7 @@ class EventBus {
     const std::uint64_t id = next_id_++;
     dispatcher_->subscribers[eventTypeId].push_back(
         std::make_unique<EventCallback<TOwner, TEvent>>(id, ownerInstance, callbackFunction));
-    return SubscriptionHandle(dispatcher_, eventTypeId, id);
+    return {dispatcher_, eventTypeId, id};
   }
 
   template <typename TEvent, typename... TArgs>

--- a/src/EventBus/EventBus.h
+++ b/src/EventBus/EventBus.h
@@ -1,19 +1,24 @@
 #pragma once
 
+#include <cstdint>
 #include <functional>  // Required for std::function
 #include <list>
 #include <map>
-#include <memory>  // Required for std::unique_ptr and std::make_unique
+#include <memory>  // Required for std::shared_ptr / std::weak_ptr / std::unique_ptr
 #include <typeindex>
+#include <utility>
 
 #include "../General/Logger.h"
 #include "Event.h"  // Assuming Event is a base class or relevant type
 
+// Each subscription is tagged with a process-unique id so a SubscriptionHandle can later find and
+// drop exactly the one callback it owns. Replaces the old `void* owner` identity, which forced
+// callers to re-find their callbacks by raw pointer in a destructor.
 class IEventCallback {
   virtual void CallEvent(Event& e) = 0;
 
  public:
-  explicit IEventCallback(void* owner = nullptr) : owner_(owner) {}
+  explicit IEventCallback(std::uint64_t id) : id_(id) {}
 
   IEventCallback(const IEventCallback&) = delete;
   IEventCallback& operator=(const IEventCallback&) = delete;
@@ -25,10 +30,10 @@ class IEventCallback {
 
   void Execute(Event& e) { CallEvent(e); }
 
-  [[nodiscard]] void* Owner() const { return owner_; }
+  [[nodiscard]] std::uint64_t Id() const { return id_; }
 
  private:
-  void* owner_;
+  std::uint64_t id_;
 };
 
 template <typename TOwner, typename TEvent>
@@ -36,14 +41,14 @@ class EventCallback final : public IEventCallback {
   std::function<void(Event&)> invoker_;
 
  public:
-  EventCallback(TOwner* ownerInstance, void (TOwner::*callbackFunction)(TEvent&))
-      : IEventCallback(static_cast<void*>(ownerInstance)), invoker_([ownerInstance, callbackFunction](Event& e) {
+  EventCallback(std::uint64_t id, TOwner* ownerInstance, void (TOwner::*callbackFunction)(TEvent&))
+      : IEventCallback(id), invoker_([ownerInstance, callbackFunction](Event& e) {
           std::invoke(callbackFunction, ownerInstance, static_cast<TEvent&>(e));
         }) {}
 
   // Constructor for const TEvent&
-  EventCallback(TOwner* ownerInstance, void (TOwner::*callbackFunction)(const TEvent&))
-      : IEventCallback(static_cast<void*>(ownerInstance)), invoker_([ownerInstance, callbackFunction](Event& e) {
+  EventCallback(std::uint64_t id, TOwner* ownerInstance, void (TOwner::*callbackFunction)(const TEvent&))
+      : IEventCallback(id), invoker_([ownerInstance, callbackFunction](Event& e) {
           std::invoke(callbackFunction, ownerInstance, static_cast<const TEvent&>(e));
         }) {}
 
@@ -66,9 +71,72 @@ class EventCallback final : public IEventCallback {
 typedef std::list<std::unique_ptr<IEventCallback>> HandlerList;
 
 class EventBus {
-  std::map<std::type_index, std::unique_ptr<HandlerList>> subscribers_;
+  // The dispatch table is held behind a shared_ptr so SubscriptionHandles can hold a weak_ptr to
+  // it. A handle that outlives the bus then finds the table expired and unsubscribes to nothing —
+  // shutdown order between the bus and its subscribers no longer matters.
+  struct Dispatcher {
+    std::map<std::type_index, HandlerList> subscribers;
+
+    void Remove(const std::type_index& eventTypeId, std::uint64_t id) {
+      const auto it = subscribers.find(eventTypeId);
+      if (it == subscribers.end()) return;
+      it->second.remove_if([id](const std::unique_ptr<IEventCallback>& cb) { return cb && cb->Id() == id; });
+    }
+  };
+
+  std::shared_ptr<Dispatcher> dispatcher_ = std::make_shared<Dispatcher>();
+  std::uint64_t next_id_ = 1;
 
  public:
+  // RAII handle for a single subscription. Its destructor removes the callback from the bus, so a
+  // subscriber just keeps the handle (or a vector of them) as a member and never has to unsubscribe
+  // by hand. Move-only; a default-constructed or moved-from handle owns nothing. Resetting after the
+  // bus has been destroyed is a safe no-op.
+  class [[nodiscard]] SubscriptionHandle {
+   public:
+    SubscriptionHandle() = default;
+
+    SubscriptionHandle(std::weak_ptr<Dispatcher> dispatcher, std::type_index eventTypeId, std::uint64_t id)
+        : dispatcher_(std::move(dispatcher)), event_type_id_(eventTypeId), id_(id) {}
+
+    SubscriptionHandle(const SubscriptionHandle&) = delete;
+    SubscriptionHandle& operator=(const SubscriptionHandle&) = delete;
+
+    SubscriptionHandle(SubscriptionHandle&& other) noexcept
+        : dispatcher_(std::move(other.dispatcher_)), event_type_id_(other.event_type_id_), id_(other.id_) {
+      other.dispatcher_.reset();
+    }
+
+    SubscriptionHandle& operator=(SubscriptionHandle&& other) noexcept {
+      if (this != &other) {
+        Reset();
+        dispatcher_ = std::move(other.dispatcher_);
+        event_type_id_ = other.event_type_id_;
+        id_ = other.id_;
+        other.dispatcher_.reset();
+      }
+      return *this;
+    }
+
+    ~SubscriptionHandle() { Reset(); }
+
+    // Unsubscribe now instead of waiting for the destructor. Idempotent.
+    void Reset() {
+      if (const auto dispatcher = dispatcher_.lock()) {
+        dispatcher->Remove(event_type_id_, id_);
+      }
+      dispatcher_.reset();
+    }
+
+    // True while the subscription is still live on a surviving bus.
+    [[nodiscard]] bool Active() const { return !dispatcher_.expired(); }
+
+   private:
+    std::weak_ptr<Dispatcher> dispatcher_;
+    std::type_index event_type_id_ = typeid(void);
+    std::uint64_t id_ = 0;
+  };
+
   EventBus() { Logger::Info("Event bus created"); }
 
   EventBus(const EventBus&) = delete;
@@ -80,43 +148,31 @@ class EventBus {
   ~EventBus() { Logger::Info("Event bus destructed"); }
 
   template <typename TOwner, typename TEvent>
-  void SubscribeEvent(TOwner* ownerInstance, void (TOwner::*callbackFunction)(TEvent&)) {
+  [[nodiscard]] SubscriptionHandle SubscribeEvent(TOwner* ownerInstance, void (TOwner::*callbackFunction)(TEvent&)) {
     const std::type_index eventTypeId = typeid(TEvent);
-    if (!subscribers_[eventTypeId]) {
-      subscribers_[eventTypeId] = std::make_unique<HandlerList>();
-    }
-    auto subscriber = std::make_unique<EventCallback<TOwner, TEvent>>(ownerInstance, callbackFunction);
-    subscribers_[eventTypeId]->push_back(std::move(subscriber));
+    const std::uint64_t id = next_id_++;
+    dispatcher_->subscribers[eventTypeId].push_back(
+        std::make_unique<EventCallback<TOwner, TEvent>>(id, ownerInstance, callbackFunction));
+    return SubscriptionHandle(dispatcher_, eventTypeId, id);
   }
 
   template <typename TOwner, typename TEvent>
-  void SubscribeEvent(TOwner* ownerInstance, void (TOwner::*callbackFunction)(const TEvent&)) {
+  [[nodiscard]] SubscriptionHandle SubscribeEvent(TOwner* ownerInstance,
+                                                  void (TOwner::*callbackFunction)(const TEvent&)) {
     const std::type_index eventTypeId = typeid(TEvent);
-    if (!subscribers_[eventTypeId]) {
-      subscribers_[eventTypeId] = std::make_unique<HandlerList>();
-    }
-    auto subscriber = std::make_unique<EventCallback<TOwner, TEvent>>(ownerInstance, callbackFunction);
-    subscribers_[eventTypeId]->push_back(std::move(subscriber));
-  }
-
-  // Drop every subscription whose owner pointer matches `owner`. Call from a system's
-  // destructor when its lifetime can end before the bus's, otherwise the bus would invoke
-  // a dangling callback on the next emit.
-  void UnsubscribeAll(void* owner) {
-    if (!owner) return;
-    for (auto& [_, handlers] : subscribers_) {
-      if (!handlers) continue;
-      handlers->remove_if([owner](const std::unique_ptr<IEventCallback>& cb) { return cb && cb->Owner() == owner; });
-    }
+    const std::uint64_t id = next_id_++;
+    dispatcher_->subscribers[eventTypeId].push_back(
+        std::make_unique<EventCallback<TOwner, TEvent>>(id, ownerInstance, callbackFunction));
+    return SubscriptionHandle(dispatcher_, eventTypeId, id);
   }
 
   template <typename TEvent, typename... TArgs>
   void EmitEvent(TArgs&&... args) {
     const std::type_index eventTypeId = typeid(TEvent);
-    auto it = subscribers_.find(eventTypeId);
-    if (it != subscribers_.end() && it->second) {
+    const auto it = dispatcher_->subscribers.find(eventTypeId);
+    if (it != dispatcher_->subscribers.end()) {
       TEvent event(std::forward<TArgs>(args)...);
-      for (auto& callback_ptr : *(it->second)) {
+      for (auto& callback_ptr : it->second) {
         if (callback_ptr) {
           callback_ptr->Execute(event);
         }

--- a/src/Game/Game.cpp
+++ b/src/Game/Game.cpp
@@ -595,8 +595,8 @@ void Game::Setup() {
   registry_->RegisterSystem<TextLabelComponent>(RenderTextSystem());
   registry_->RegisterParallelSystem<SquarePrimitiveComponent, GlobalTransformComponent>(RenderPrimitiveSystem());
 
-  // Event subscriptions (one-time)
-  event_bus_->SubscribeEvent<FrameLoop, KeyInputEvent>(frame_loop_.get(), &FrameLoop::OnKeyInputEvent);
+  // Event subscriptions (one-time). FrameLoop holds its own RAII subscription handle.
+  frame_loop_->SubscribeToEvents();
   // Event-driven systems with no per-frame Update — owned by the Registry instead of
   // living as parallel members on Game. Keeps the registry as the single source of truth.
   auto& uiButtonSystem = registry_->Set<UIButtonSystem>(UIButtonSystem());

--- a/src/Systems/AudioSystem.cpp
+++ b/src/Systems/AudioSystem.cpp
@@ -62,7 +62,7 @@ bool AudioSystem::Init(Registry* registry, const std::unique_ptr<EventBus>& even
 
   // Mixer is published onto EngineContext by Game::Setup once Init returns; AudioSystem owns
   // the pointer and exposes it via Mixer() so callers don't need a Registry round-trip.
-  eventBus->SubscribeEvent<AudioSystem, AudioPlayEvent>(this, &AudioSystem::OnAudioPlay);
+  audio_subscription_ = eventBus->SubscribeEvent<AudioSystem, AudioPlayEvent>(this, &AudioSystem::OnAudioPlay);
 
   Logger::Info("AudioSystem initialized; track pool size = " + std::to_string(state_->track_pool.size()) +
                ", max = " + std::to_string(trackPoolMax));

--- a/src/Systems/AudioSystem.h
+++ b/src/Systems/AudioSystem.h
@@ -62,4 +62,5 @@ class AudioSystem {
   Registry* registry_ = nullptr;
   std::shared_ptr<AudioSystemState> state_;
   CommandBuffer cmd_buffer_;
+  EventBus::SubscriptionHandle audio_subscription_;
 };

--- a/src/Systems/DamageSystem.h
+++ b/src/Systems/DamageSystem.h
@@ -13,7 +13,7 @@ class DamageSystem {
     projectiles_ = registry_->Tag<ProjectileTag>();
     enemies_ = registry_->TagId("enemies");
     player_ = registry_->TagId("player");
-    eventBus->SubscribeEvent<DamageSystem, CollisionEvent>(this, &DamageSystem::OnCollision);
+    subscription_ = eventBus->SubscribeEvent<DamageSystem, CollisionEvent>(this, &DamageSystem::OnCollision);
   }
 
   void OnCollision(const CollisionEvent& event) {
@@ -47,4 +47,5 @@ class DamageSystem {
   Entity projectiles_{};
   Entity enemies_{};
   Entity player_{};
+  EventBus::SubscriptionHandle subscription_;
 };

--- a/src/Systems/InputSystem.h
+++ b/src/Systems/InputSystem.h
@@ -46,9 +46,10 @@ class InputSystem {
 
   void SubscribeToEvents(const std::unique_ptr<EventBus>& eventBus, Registry* registry) {
     registry_ = registry;
-    eventBus->SubscribeEvent<InputSystem, KeyInputEvent>(this, &InputSystem::OnKeyInput);
-    eventBus->SubscribeEvent<InputSystem, MouseInputEvent>(this, &InputSystem::OnMouseInput);
-    eventBus->SubscribeEvent<InputSystem, MouseWheelEvent>(this, &InputSystem::OnMouseWheel);
+    subscriptions_.clear();
+    subscriptions_.push_back(eventBus->SubscribeEvent<InputSystem, KeyInputEvent>(this, &InputSystem::OnKeyInput));
+    subscriptions_.push_back(eventBus->SubscribeEvent<InputSystem, MouseInputEvent>(this, &InputSystem::OnMouseInput));
+    subscriptions_.push_back(eventBus->SubscribeEvent<InputSystem, MouseWheelEvent>(this, &InputSystem::OnMouseWheel));
   }
 
   // Called near the top of Game::Update so polling APIs see a fresh cursor position
@@ -151,6 +152,9 @@ class InputSystem {
   }
 
   Registry* registry_;
+  // One handle per SubscribeToEvents subscription; their destructors drop the bus callbacks when
+  // this system is torn down, regardless of whether the bus outlives it.
+  std::vector<EventBus::SubscriptionHandle> subscriptions_;
   std::unordered_set<std::string> pressedKeys_;
   std::unordered_set<std::string> releasedKeys_;
   std::unordered_set<std::string> heldKeys_;

--- a/src/Systems/ObstacleBounceSystem.h
+++ b/src/Systems/ObstacleBounceSystem.h
@@ -16,7 +16,8 @@ class ObstacleBounceSystem {
     registry_ = registry;
     enemies_ = registry_->TagId("enemies");
     obstacles_ = registry_->TagId("obstacles");
-    eventBus->SubscribeEvent<ObstacleBounceSystem, CollisionEvent>(this, &ObstacleBounceSystem::OnCollision);
+    subscription_ =
+        eventBus->SubscribeEvent<ObstacleBounceSystem, CollisionEvent>(this, &ObstacleBounceSystem::OnCollision);
   }
 
   void OnCollision(const CollisionEvent& event) {
@@ -46,4 +47,5 @@ class ObstacleBounceSystem {
   Registry* registry_ = nullptr;
   Entity enemies_{};
   Entity obstacles_{};
+  EventBus::SubscriptionHandle subscription_;
 };

--- a/src/Systems/UIButtonSystem.h
+++ b/src/Systems/UIButtonSystem.h
@@ -21,7 +21,7 @@ class UIButtonSystem {
  public:
   void Init(Registry* registry, const std::unique_ptr<EventBus>& eventBus) {
     registry_ = registry;
-    eventBus->SubscribeEvent<UIButtonSystem, MouseInputEvent>(this, &UIButtonSystem::OnMouseInput);
+    subscription_ = eventBus->SubscribeEvent<UIButtonSystem, MouseInputEvent>(this, &UIButtonSystem::OnMouseInput);
   }
 
   void OnMouseInput(const MouseInputEvent& event) {
@@ -82,4 +82,5 @@ class UIButtonSystem {
 
  private:
   Registry* registry_ = nullptr;
+  EventBus::SubscriptionHandle subscription_;
 };

--- a/tests/EventBusTest.cpp
+++ b/tests/EventBusTest.cpp
@@ -1,7 +1,10 @@
 // Behavioral checks for the type-erased EventBus pub/sub. The documented hazard is a dangling
-// callback after an owner dies, so UnsubscribeAll is exercised explicitly. gtest-free; exit code =
+// callback after an owner dies; the bus now hands back a RAII SubscriptionHandle whose destructor
+// drops the callback, so handle lifetime is exercised explicitly. gtest-free; exit code =
 // failed-check count. Registered with ctest as EventBusTest. Header-only bus; links Logger only.
 
+#include <memory>
+#include <optional>
 #include <vector>
 
 #include "EventBus/Event.h"
@@ -50,7 +53,7 @@ int main() {
   {
     EventBus bus;
     Listener listener;
-    bus.SubscribeEvent<Listener, PingEvent>(&listener, &Listener::OnPing);
+    auto sub = bus.SubscribeEvent<Listener, PingEvent>(&listener, &Listener::OnPing);
     bus.EmitEvent<PingEvent>(7);
     Check(listener.count == 1, "subscribed handler fired exactly once");
     Check(listener.last == 7, "handler received the forwarded payload");
@@ -61,7 +64,7 @@ int main() {
     EventBus bus;
     bus.EmitEvent<SilentEvent>();  // must not throw or crash
     Listener listener;
-    bus.SubscribeEvent<Listener, PingEvent>(&listener, &Listener::OnPing);
+    auto sub = bus.SubscribeEvent<Listener, PingEvent>(&listener, &Listener::OnPing);
     bus.EmitEvent<SilentEvent>();  // a different event type has no PingEvent subscribers
     Check(listener.count == 0, "emit of an unsubscribed event type invokes nothing");
   }
@@ -72,31 +75,62 @@ int main() {
     std::vector<int> order;
     OrderRecorder first{&order, 1};
     OrderRecorder second{&order, 2};
-    bus.SubscribeEvent<OrderRecorder, PingEvent>(&first, &OrderRecorder::OnPing);
-    bus.SubscribeEvent<OrderRecorder, PingEvent>(&second, &OrderRecorder::OnPing);
+    auto sub1 = bus.SubscribeEvent<OrderRecorder, PingEvent>(&first, &OrderRecorder::OnPing);
+    auto sub2 = bus.SubscribeEvent<OrderRecorder, PingEvent>(&second, &OrderRecorder::OnPing);
     bus.EmitEvent<PingEvent>(0);
     Check(order.size() == 2, "every subscriber fired");
     Check(order.size() == 2 && order[0] == 1 && order[1] == 2, "subscribers fire in subscription order");
   }
 
-  // UnsubscribeAll drops exactly the named owner's callbacks (the dangling-callback guard).
+  // Resetting a SubscriptionHandle drops exactly that callback (the dangling-callback guard),
+  // leaving sibling subscriptions intact.
   {
     EventBus bus;
     Listener stays;
     Listener leaves;
-    bus.SubscribeEvent<Listener, PingEvent>(&stays, &Listener::OnPing);
-    bus.SubscribeEvent<Listener, PingEvent>(&leaves, &Listener::OnPing);
-    bus.UnsubscribeAll(&leaves);
+    auto staysSub = bus.SubscribeEvent<Listener, PingEvent>(&stays, &Listener::OnPing);
+    auto leavesSub = bus.SubscribeEvent<Listener, PingEvent>(&leaves, &Listener::OnPing);
+    leavesSub.Reset();
     bus.EmitEvent<PingEvent>(3);
-    Check(leaves.count == 0, "unsubscribed owner is not invoked");
-    Check(stays.count == 1, "other owners remain subscribed after UnsubscribeAll");
+    Check(leaves.count == 0, "explicitly reset subscription is not invoked");
+    Check(stays.count == 1, "other subscriptions remain after one is reset");
+    Check(!leavesSub.Active(), "a reset handle reports inactive");
+    Check(staysSub.Active(), "a live handle reports active");
+  }
+
+  // A handle going out of scope unsubscribes via its destructor — no manual call needed.
+  {
+    EventBus bus;
+    Listener listener;
+    {
+      auto sub = bus.SubscribeEvent<Listener, PingEvent>(&listener, &Listener::OnPing);
+      bus.EmitEvent<PingEvent>(1);
+      Check(listener.count == 1, "handler fires while the handle is alive");
+    }
+    bus.EmitEvent<PingEvent>(1);
+    Check(listener.count == 1, "handler stops firing once its handle is destroyed");
+  }
+
+  // Shutdown-order independence: a handle that outlives the bus is a safe no-op. The handle below
+  // is destroyed AFTER the bus, the reverse of the old void*-owner teardown ordering.
+  {
+    Listener listener;
+    std::optional<EventBus::SubscriptionHandle> sub;
+    {
+      EventBus bus;
+      sub = bus.SubscribeEvent<Listener, PingEvent>(&listener, &Listener::OnPing);
+      Check(sub->Active(), "handle is active while its bus lives");
+    }  // bus destroyed here, before the handle
+    Check(!sub->Active(), "handle reports inactive once its bus is gone");
+    sub.reset();  // must not touch the freed bus
+    Check(listener.count == 0, "handle destruction after the bus is a safe no-op");
   }
 
   // The const-ref callback overload dispatches too.
   {
     EventBus bus;
     ConstListener listener;
-    bus.SubscribeEvent<ConstListener, PingEvent>(&listener, &ConstListener::OnPing);
+    auto sub = bus.SubscribeEvent<ConstListener, PingEvent>(&listener, &ConstListener::OnPing);
     bus.EmitEvent<PingEvent>(5);
     Check(listener.count == 1 && listener.last == 5, "const TEvent& handler overload dispatches");
   }


### PR DESCRIPTION
## Summary

Stage 11 of the architecture-cleanup plan (P2). `SubscribeEvent` now returns a
`[[nodiscard]] EventBus::SubscriptionHandle` (move-only RAII) whose destructor removes the
callback. Subscribers keep the handle as a member and never unsubscribe by hand — the old
`void* owner` identity, `IEventCallback::Owner()`, and `EventBus::UnsubscribeAll(void*)` are
gone.

**Shutdown-order independence.** The dispatch table moved behind a `shared_ptr<Dispatcher>`;
handles hold a `weak_ptr` + `(type_index, monotonic id)`. A handle that outlives the bus finds
the table expired and unsubscribes to nothing. This matters here because the Registry-owned
subscribers (UIButton/Damage/ObstacleBounce/Audio/Input) are destroyed **after** `event_bus_`,
while `FrameLoop`'s handle is destroyed **before** it — both orders are now safe.

## Changes

- `src/EventBus/EventBus.h` — id-based callbacks, `shared_ptr<Dispatcher>`, RAII
  `SubscriptionHandle` (`Reset()` / `Active()`); `SubscribeEvent` is `[[nodiscard]]`.
- Subscribers store handles: `InputSystem` → `vector<SubscriptionHandle>` (3), others one each.
- `FrameLoop` — `KeyInputEvent` wiring moved from `Game::Setup` into
  `FrameLoop::SubscribeToEvents()`, holding its own handle.
- `tests/EventBusTest.cpp` — rewrote the `UnsubscribeAll` case into handle-reset, scope-exit
  unsubscribe, and an explicit handle-outlives-bus shutdown-order check.
- `events.json` regenerated (KeyInputEvent subscribe site moved `Game.cpp` → `FrameLoop.cpp`);
  `docs/events.md` documents the RAII contract and fixes a stale `Game::OnKeyInputEvent`
  reference.

## Done-when (from the plan) — all met

- `UnsubscribeAll(void*)` deleted; no `void* owner_` in `EventCallback`.
- Shutdown-order independence verified by a dedicated test.

## Out of scope — documented follow-up

The `AudioSinkComponent` `MIX_Track*` slot/generation decouple (the last Stage-2 POD leak) is
**not** included. Earlier plan notes paired it with Stage 11, but the two share no code; it
stands alone as an unscheduled follow-up. Rationale is documented inline in
`src/Components/AudioSinkComponent.h`. Not a blocker for any later stage.

## Test plan

- [x] `editor-debug` configures + builds clean
- [x] `ctest` 11/11 (incl. `EventBusTest`, `GameBakeTest` headless boot replay)
- [x] `clang-format --Werror` clean on all touched files
- [x] catalog drift gate (`gen_api_catalogs.py --check`) passes
- [ ] CI green