### PR TITLE
Strip MIX_Track* out of AudioSinkComponent into an entity-keyed AudioTrackCache

### DIFF
--- a/src/Audio/AudioTrackCache.h
+++ b/src/Audio/AudioTrackCache.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <SDL3_mixer/SDL_mixer.h>
+
+#include <cstdint>
+#include <unordered_map>
+
+#include "ECS/ECS.h"
+#include "ECS/Entity.h"
+
+// Audio-side cache mapping Entity -> the MIX_Track* AudioSystem assigned that emitter's
+// AudioSinkComponent, plus the track-pool generation issued for the acquisition. Mirrors
+// Renderer/SpriteRenderCache: it keeps AudioSinkComponent POD-no-SDL while SpatialAudioSystem /
+// DopplerSystem / AudioCullingSystem resolve the live track here each frame.
+//
+// A Registry singleton, Set on the live-frame path only (bake runs no audio systems) and Clear()ed
+// on scene unload. Single-threaded: every audio system runs serially (RegisterSystem, not the
+// parallel path), so unsynchronized map writes are safe — std::unordered_map cannot tolerate
+// concurrent insertion.
+class AudioTrackCache {
+ public:
+  struct Entry {
+    MIX_Track* track = nullptr;
+    std::uint32_t generation = 0;
+  };
+
+  void Store(Entity entity, MIX_Track* track, std::uint32_t generation) {
+    entries_[entity.GetId()] = {track, generation};
+  }
+
+  // The live MIX_Track* cached for this entity, or nullptr if none.
+  [[nodiscard]] MIX_Track* Track(Entity entity) const {
+    const auto it = entries_.find(entity.GetId());
+    return it != entries_.end() ? it->second.track : nullptr;
+  }
+
+  // The full (track, generation) entry, or nullptr if absent — used for the pool-ownership check.
+  [[nodiscard]] const Entry* Lookup(Entity entity) const {
+    const auto it = entries_.find(entity.GetId());
+    return it != entries_.end() ? &it->second : nullptr;
+  }
+
+  void Forget(Entity entity) { entries_.erase(entity.GetId()); }
+
+  void Clear() { entries_.clear(); }
+
+ private:
+  std::unordered_map<EcsId, Entry> entries_;
+};

--- a/src/Components/AudioSinkComponent.h
+++ b/src/Components/AudioSinkComponent.h
@@ -1,29 +1,24 @@
 #pragma once
 
-#include <SDL3_mixer/SDL_mixer.h>
-
-#include <cstdint>
-
-// Carries the MIX_Track* AudioSystem assigned this emitter, plus a generation guard so a track
-// reassigned to a different emitter after our clip stopped isn't mistakenly treated as ours.
-// Still SDL-typed — Stage 2's POD goal punts on this one because SpatialAudioSystem +
-// DopplerSystem read sink.track directly each frame and decoupling them via a resolve
-// indirection is a separate refactor. See ArchitectureImprovementsPlan follow-ups.
+// Marks an emitter that currently has an audio track, and caches the last-applied spatial/Doppler
+// values so SpatialAudioSystem / DopplerSystem only call MIX_Set* when something changed. POD: the
+// MIX_Track* itself lives in AudioTrackCache (Systems/AudioTrackCache.h) keyed by entity, so this
+// component carries no SDL/MIX types — keeping Components/ free of backend handles.
+//
+// `finished` latches once the track stops or is stolen back by the pool; a finished sink stays on
+// the entity as a "already tried" marker so AudioSystem doesn't re-acquire a track every frame.
 struct AudioSinkComponent {
-  MIX_Track* track = nullptr;
-  std::uint32_t generation = 0;
+  // lastPan sentinel: any value outside the valid pan range [-1, 1] forces the first stereo update
+  // to apply. SpatialAudioSystem resets lastPan to this when a source stops being spatial.
+  static constexpr float kPanSentinel = 2.0f;
+
   bool finished = false;
 
-  // Cached state for SpatialAudioSystem + DopplerSystem so they only call MIX_Set* when
-  // the computed value changed. Initial sentinels (lastGain < 0, lastPan outside [-1, 1],
-  // lastRatio < 0) force the first frame to apply regardless. `stereoApplied` separately
-  // tracks whether MIX_SetTrackStereo has a non-null override currently set; flipping a
-  // source from spatial→non-spatial calls MIX_SetTrackStereo(nullptr) once and clears it.
+  // Initial sentinels (lastGain < 0, lastPan = kPanSentinel, lastRatio < 0) force the first frame
+  // to apply regardless. `stereoApplied` separately tracks whether MIX_SetTrackStereo has a non-null
+  // override currently set; flipping a source from spatial→non-spatial clears it once.
   float lastGain = -1.0f;
-  float lastPan = 2.0f;
+  float lastPan = kPanSentinel;
   float lastRatio = -1.0f;
   bool stereoApplied = false;
-
-  AudioSinkComponent() = default;
-  AudioSinkComponent(MIX_Track* t_track, std::uint32_t t_generation) : track(t_track), generation(t_generation) {}
 };

--- a/src/Components/AudioSourceComponent.h
+++ b/src/Components/AudioSourceComponent.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <SDL3/SDL_stdinc.h>
-
+#include <cstdint>
 #include <string>
 
 struct AudioSourceComponent {
@@ -28,7 +27,7 @@ struct AudioSourceComponent {
   // MIX_GetTrackPlaybackPosition here when it culls a playing emitter, and AudioSystem
   // seeks the new track to this offset (then resets to -1) when the emitter comes back
   // in range and a fresh sink spawns. Looping sources resume mid-loop seamlessly.
-  Sint64 playbackOffsetFrames = -1;
+  std::int64_t playbackOffsetFrames = -1;
 
   explicit AudioSourceComponent(std::string t_clipId = "", float t_volume = 1.0f, float t_pitch = 1.0f,
                                 bool t_loop = false, bool t_playOnSpawn = true, bool t_despawnOnFinish = false,

--- a/src/Engine/EngineBootstrap.cpp
+++ b/src/Engine/EngineBootstrap.cpp
@@ -7,6 +7,7 @@
 
 #include "AssetManager/AssetManager.h"
 #include "AssetManager/GlyphAtlas.h"
+#include "Audio/AudioTrackCache.h"
 #include "Components/CameraComponents.h"
 #include "Components/ViewportInfo.h"
 #include "ECS/Registry.h"
@@ -84,18 +85,20 @@ void InstallLuaLibraries(sol::state& lua) {
 }
 
 void InstallCoreSingletons(Registry& registry, EngineContext& context, const int windowWidth, const int windowHeight,
-                           const bool withSpriteRenderCache) {
+                           const bool withFramePathCaches) {
   const octarine::Rect camera{0, 0, static_cast<float>(windowWidth), static_cast<float>(windowHeight)};
 
   registry.Set<RenderQueue>(RenderQueue());
   registry.Set<CameraComponent>(CameraComponent{camera});
   registry.Set<AssetManager>(AssetManager());
   registry.Set<ViewportInfo>(ViewportInfo{0, 0, static_cast<float>(windowWidth), static_cast<float>(windowHeight)});
-  if (withSpriteRenderCache) {
-    // Render-side cache mapping Entity → cached SDL_Texture*. Replaces the mutable
-    // cachedTexture member that used to live on SpriteComponent; keeps SpriteComponent
-    // POD-no-SDL. Bake runs no frames, so skips this slot.
+  if (withFramePathCaches) {
+    // Entity-keyed backend-handle caches, each replacing a handle that used to live on a POD
+    // component: SpriteRenderCache ← SpriteComponent.cachedTexture (SDL_Texture*), AudioTrackCache
+    // ← AudioSinkComponent.track (MIX_Track*). Bake runs no frames and no audio systems, so it
+    // skips both slots.
     registry.Set<SpriteRenderCache>(SpriteRenderCache());
+    registry.Set<AudioTrackCache>(AudioTrackCache());
   }
 
   // Publish the now-live AssetManager onto the context so consumers reach it without a

--- a/src/Engine/EngineBootstrap.h
+++ b/src/Engine/EngineBootstrap.h
@@ -34,11 +34,12 @@ void InstallLuaLibraries(sol::state& lua);
 
 // Set the engine-level Registry singletons that the startup script + Lua modules read at
 // install time: RenderQueue, CameraComponent (sized to the window), AssetManager,
-// ViewportInfo, and optionally SpriteRenderCache (live-frame path only — bake skips it
-// since no frames render). Also plumbs the freshly-Set AssetManager pointer onto the
-// EngineContext; other context fields must already be populated by the caller.
+// ViewportInfo, and — on the live-frame path only (withFramePathCaches; bake skips them since
+// no frames render and no audio systems run) — the entity-keyed backend-handle caches
+// SpriteRenderCache and AudioTrackCache. Also plumbs the freshly-Set AssetManager pointer onto
+// the EngineContext; other context fields must already be populated by the caller.
 void InstallCoreSingletons(Registry& registry, EngineContext& context, int windowWidth, int windowHeight,
-                           bool withSpriteRenderCache);
+                           bool withFramePathCaches);
 
 // EntityPoolManager + ProjectileEmitSystem. ProjectileEmitSystem::Init calls RegisterPool
 // against the EntityPoolManager, so EntityPoolManager must be Set first. Both bind Lua

--- a/src/Engine/SceneLoader.cpp
+++ b/src/Engine/SceneLoader.cpp
@@ -8,6 +8,7 @@
 
 #include "AssetManager/AssetManager.h"
 #include "AssetManager/SceneAssetScanner.h"
+#include "Audio/AudioTrackCache.h"
 #include "ECS/Registry.h"
 #include "Engine/EngineContext.h"
 #include "Engine/SdlFileReader.h"
@@ -198,6 +199,11 @@ void SceneLoader::clearSceneEntities() {
   // pass repopulates as those entities are recreated by the new scene's load.
   if (auto* spriteCache = registry_->TryGet<SpriteRenderCache>()) {
     spriteCache->Clear();
+  }
+  // Same for cached MIX_Track* handles — the just-blammed emitters' sinks are gone; AudioSystem
+  // re-acquires + re-caches tracks for the new scene's emitters as they play.
+  if (auto* trackCache = registry_->TryGet<AudioTrackCache>()) {
+    trackCache->Clear();
   }
 }
 

--- a/src/Game/Game.cpp
+++ b/src/Game/Game.cpp
@@ -317,10 +317,10 @@ bool Game::RunBakeValidation(const std::string& assetPath) {
   bakeCtx.config = &gameConfig;
   registry_->Set<EngineContext>(bakeCtx);
 
-  // Shared bootstrap spine. withSpriteRenderCache=false — bake runs no frames so the render
-  // cache slot is unused.
+  // Shared bootstrap spine. withFramePathCaches=false — bake runs no frames and no audio systems,
+  // so the SpriteRenderCache / AudioTrackCache slots are unused.
   engine_bootstrap::InstallCoreSingletons(*registry_, registry_->Get<EngineContext>(), gameConfig.windowWidth,
-                                          gameConfig.windowHeight, /*withSpriteRenderCache=*/false);
+                                          gameConfig.windowHeight, /*withFramePathCaches=*/false);
   engine_bootstrap::InstallPoolAndProjectile(*registry_);
   auto& inputSystem = engine_bootstrap::InstallInputSystem(*registry_, event_bus_);
   engine_bootstrap::RegisterAllComponentBindings();
@@ -455,10 +455,11 @@ void Game::Run() {
 void Game::Setup() {
   auto& gameConfig = registry_->Get<GameConfig>();
 
-  // Shared bootstrap spine (see engine_bootstrap/EngineBootstrap.h). withSpriteRenderCache=true
-  // — the live game loop reads the cache from the parallel sprite-render pass.
+  // Shared bootstrap spine (see engine_bootstrap/EngineBootstrap.h). withFramePathCaches=true —
+  // the live game loop reads SpriteRenderCache from the sprite-render pass and AudioTrackCache
+  // from the spatial/Doppler/culling audio systems.
   engine_bootstrap::InstallCoreSingletons(*registry_, registry_->Get<EngineContext>(), gameConfig.windowWidth,
-                                          gameConfig.windowHeight, /*withSpriteRenderCache=*/true);
+                                          gameConfig.windowHeight, /*withFramePathCaches=*/true);
 
   // ScriptSystem is registered as a per-frame system (vs. Bake's stack instance) so its
   // operator() runs each tick. CreateLuaBindings still happens below in the bootstrap spine.
@@ -572,7 +573,8 @@ void Game::Setup() {
   // Spatial audio: snapshot the listener entity (UpdateListenerTransformSystem) then mutate
   // gain + stereo pan on live spatial tracks (SpatialAudioSystem). Both must run AFTER
   // TransformSystem so emitter + listener globals are this-frame values; AudioSystem (above)
-  // is the one that creates the AudioSinkComponent's MIX_Track that these mutate.
+  // is the one that adds the AudioSinkComponent and caches its MIX_Track in AudioTrackCache,
+  // which these resolve per entity.
   registry_->Set<AudioListenerCache>(AudioListenerCache{});
   registry_->RegisterBulkSystem<GlobalTransformComponent>(UpdateListenerTransformSystem());
   // Phase 5 culling: pre-register the AudioActiveTag so its component entity exists

--- a/src/Systems/AudioCullingSystem.h
+++ b/src/Systems/AudioCullingSystem.h
@@ -4,6 +4,7 @@
 
 #include <glm/glm.hpp>
 
+#include "Audio/AudioTrackCache.h"
 #include "Components/AudioActiveTag.h"
 #include "Components/AudioListenerComponent.h"
 #include "Components/AudioSinkComponent.h"
@@ -32,7 +33,12 @@ class AudioCullingSystem {
     if (!source.spatial) return;
 
     auto* registry = ctx.GetRegistry();
-    if (!cache_) cache_ = &registry->Get<AudioListenerCache>();
+    // Both singleton caches are Set once at bootstrap and never reseated; resolve them together on
+    // the first tick so the pointers stay stable for the registry's lifetime.
+    if (!cache_) {
+      cache_ = &registry->Get<AudioListenerCache>();
+      track_cache_ = &registry->Get<AudioTrackCache>();
+    }
     if (!cache_->valid) return;
 
     const auto& engineOptions = registry->Get<GameConfig>().GetEngineOptions();
@@ -51,13 +57,16 @@ class AudioCullingSystem {
 
     if (!inRange && isActive) {
       if (registry->HasComponent<AudioSinkComponent>(entity)) {
-        auto& sink = registry->GetComponent<AudioSinkComponent>(entity);
-        if (sink.track && !sink.finished) {
+        const auto& sink = registry->GetComponent<AudioSinkComponent>(entity);
+        if (MIX_Track* track = track_cache_->Track(entity); track && !sink.finished) {
           // Capture position BEFORE Stop — MIX_GetTrackPlaybackPosition on a stopped
           // track may return 0 or undefined.
-          source.playbackOffsetFrames = MIX_GetTrackPlaybackPosition(sink.track);
-          MIX_StopTrack(sink.track, 0);
+          source.playbackOffsetFrames = MIX_GetTrackPlaybackPosition(track);
+          MIX_StopTrack(track, 0);
         }
+        // Drop the cache entry alongside the sink so the released track returns to the pool and a
+        // later re-entry (AudioSystem re-spawns the sink) starts from a clean slot.
+        track_cache_->Forget(entity);
         cmd_buffer_.RemoveComponent<AudioSinkComponent>(entity);
       }
       cmd_buffer_.RemoveTag<AudioActiveTag>(entity);
@@ -68,5 +77,6 @@ class AudioCullingSystem {
 
  private:
   const AudioListenerCache* cache_ = nullptr;
+  AudioTrackCache* track_cache_ = nullptr;
   CommandBuffer cmd_buffer_;
 };

--- a/src/Systems/AudioSystem.cpp
+++ b/src/Systems/AudioSystem.cpp
@@ -71,10 +71,10 @@ bool AudioSystem::Init(Registry* registry, const std::unique_ptr<EventBus>& even
 
 void AudioSystem::Shutdown() { state_.reset(); }
 
-bool AudioSystem::SinkOwnsTrack(const AudioSinkComponent& sink) const {
-  if (!state_ || !sink.track) return false;
+bool AudioSystem::SinkOwnsTrack(const AudioTrackCache::Entry& entry) const {
+  if (!state_ || !entry.track) return false;
   for (const TrackSlot& slot : state_->track_pool) {
-    if (slot.track == sink.track) return slot.generation == sink.generation;
+    if (slot.track == entry.track) return slot.generation == entry.generation;
   }
   return false;
 }
@@ -137,81 +137,94 @@ void AudioSystem::operator()(Entity entity, AudioSourceComponent& source) {
   const auto& engineOptions = registry_->Get<GameConfig>().GetEngineOptions();
   if (!engineOptions.audioEnabled) return;
 
+  if (!track_cache_) track_cache_ = &registry_->Get<AudioTrackCache>();
+
+  // No sink yet: try to acquire + start a track for this source. Split out to keep this dispatch
+  // small; the existing-sink path (gain refresh / finish) stays inline below.
   if (!registry_->HasComponent<AudioSinkComponent>(entity)) {
-    // Spatial sources are gated by AudioCullingSystem's AudioActiveTag: an out-of-range
-    // emitter has no tag, so even a resume-pending source waits here until it comes back
-    // into the listener radius. Without this gate the resume + cull pair would oscillate
-    // (AudioSystem re-spawns the sink, CullingSystem culls it again next frame).
-    if (source.spatial && !registry_->HasTag<AudioActiveTag>(entity)) return;
-
-    // Resume-from-cull is a second valid play trigger alongside playOnSpawn: when
-    // AudioCullingSystem halts a culled emitter it stashes the frame offset on the
-    // source and removes the sink, so the entity arrives here with a >=0 offset
-    // waiting to be consumed.
-    const bool resumingFromCull = source.playbackOffsetFrames >= 0;
-    if (!source.playOnSpawn && !resumingFromCull) return;
-
-    auto& assetManager = registry_->Get<AssetManager>();
-    MIX_Audio* clip = assetManager.GetAudioClip(source.clipId);
-    if (!clip) {
-      Logger::Warn("AudioSystem: Clip not found: " + source.clipId);
-      // Mark "tried" by attaching a finished sink — prevents per-frame retry without mutating the source.
-      AudioSinkComponent sink;
-      sink.finished = true;
-      cmd_buffer_.AddComponent<AudioSinkComponent>(entity, sink);
-      return;
-    }
-
-    const Acquired acquired = AcquireTrack();
-    if (!acquired.track) return;  // pool full, retry next frame
-
-    if (!MIX_SetTrackAudio(acquired.track, clip)) {
-      Logger::Warn("MIX_SetTrackAudio failed for " + source.clipId + ": " + std::string(SDL_GetError()));
-      return;
-    }
-    const float gain = std::max(0.0F, source.volume);
-    MIX_SetTrackGain(acquired.track, gain);
-
-    // SDL3_mixer: MIX_PlayTrack's second arg is an SDL_PropertiesID, not a loop count.
-    // Encode looping via MIX_PROP_PLAY_LOOPS_NUMBER (-1 = infinite).
-    SDL_PropertiesID props = 0;
-    if (source.loop) {
-      props = SDL_CreateProperties();
-      SDL_SetNumberProperty(props, MIX_PROP_PLAY_LOOPS_NUMBER, -1);
-    }
-    const bool played = MIX_PlayTrack(acquired.track, props);
-    if (props) SDL_DestroyProperties(props);
-    if (!played) {
-      Logger::Warn("MIX_PlayTrack failed for " + source.clipId + ": " + std::string(SDL_GetError()));
-      return;
-    }
-
-    // Seek AFTER play: SDL_mixer accepts position changes on a playing track and the
-    // seek-then-play path skips an extra paused-state transition.
-    if (resumingFromCull) {
-      MIX_SetTrackPlaybackPosition(acquired.track, source.playbackOffsetFrames);
-      source.playbackOffsetFrames = -1;
-    }
-    cmd_buffer_.AddComponent<AudioSinkComponent>(entity, AudioSinkComponent(acquired.track, acquired.generation));
+    SpawnSinkForSource(entity, source);
     return;
   }
 
   auto& sink = registry_->GetComponent<AudioSinkComponent>(entity);
-  if (sink.finished || !sink.track) return;
+  if (sink.finished) return;
 
-  // Validate the sink still owns its track — generation guards against pool reuse stealing it
+  const AudioTrackCache::Entry* entry = track_cache_->Lookup(entity);
+  if (!entry || !entry->track) return;
+
+  // Validate the cached track is still ours — generation guards against pool reuse stealing it
   // after our clip stopped. Treat a stolen track the same as a natural finish.
-  const bool stillOwns = SinkOwnsTrack(sink);
-  if (stillOwns && MIX_TrackPlaying(sink.track)) {
+  const bool stillOwns = SinkOwnsTrack(*entry);
+  if (stillOwns && MIX_TrackPlaying(entry->track)) {
     const float gain = std::max(0.0F, source.volume);
-    MIX_SetTrackGain(sink.track, gain);
+    MIX_SetTrackGain(entry->track, gain);
     return;
   }
 
   sink.finished = true;
-  sink.track = nullptr;
+  track_cache_->Forget(entity);
 
   if (source.despawnOnFinish) {
     cmd_buffer_.EmplaceBlam(entity);
   }
+}
+
+void AudioSystem::SpawnSinkForSource(Entity entity, AudioSourceComponent& source) {
+  // Spatial sources are gated by AudioCullingSystem's AudioActiveTag: an out-of-range
+  // emitter has no tag, so even a resume-pending source waits here until it comes back
+  // into the listener radius. Without this gate the resume + cull pair would oscillate
+  // (AudioSystem re-spawns the sink, CullingSystem culls it again next frame).
+  if (source.spatial && !registry_->HasTag<AudioActiveTag>(entity)) return;
+
+  // Resume-from-cull is a second valid play trigger alongside playOnSpawn: when
+  // AudioCullingSystem halts a culled emitter it stashes the frame offset on the
+  // source and removes the sink, so the entity arrives here with a >=0 offset
+  // waiting to be consumed.
+  const bool resumingFromCull = source.playbackOffsetFrames >= 0;
+  if (!source.playOnSpawn && !resumingFromCull) return;
+
+  auto& assetManager = registry_->Get<AssetManager>();
+  MIX_Audio* clip = assetManager.GetAudioClip(source.clipId);
+  if (!clip) {
+    Logger::Warn("AudioSystem: Clip not found: " + source.clipId);
+    // Mark "tried" by attaching a finished sink — prevents per-frame retry without mutating the source.
+    AudioSinkComponent sink;
+    sink.finished = true;
+    cmd_buffer_.AddComponent<AudioSinkComponent>(entity, sink);
+    return;
+  }
+
+  const Acquired acquired = AcquireTrack();
+  if (!acquired.track) return;  // pool full, retry next frame
+
+  if (!MIX_SetTrackAudio(acquired.track, clip)) {
+    Logger::Warn("MIX_SetTrackAudio failed for " + source.clipId + ": " + std::string(SDL_GetError()));
+    return;
+  }
+  const float gain = std::max(0.0F, source.volume);
+  MIX_SetTrackGain(acquired.track, gain);
+
+  // SDL3_mixer: MIX_PlayTrack's second arg is an SDL_PropertiesID, not a loop count.
+  // Encode looping via MIX_PROP_PLAY_LOOPS_NUMBER (-1 = infinite).
+  SDL_PropertiesID props = 0;
+  if (source.loop) {
+    props = SDL_CreateProperties();
+    SDL_SetNumberProperty(props, MIX_PROP_PLAY_LOOPS_NUMBER, -1);
+  }
+  const bool played = MIX_PlayTrack(acquired.track, props);
+  if (props) SDL_DestroyProperties(props);
+  if (!played) {
+    Logger::Warn("MIX_PlayTrack failed for " + source.clipId + ": " + std::string(SDL_GetError()));
+    return;
+  }
+
+  // Seek AFTER play: SDL_mixer accepts position changes on a playing track and the
+  // seek-then-play path skips an extra paused-state transition.
+  if (resumingFromCull) {
+    MIX_SetTrackPlaybackPosition(acquired.track, source.playbackOffsetFrames);
+    source.playbackOffsetFrames = -1;
+  }
+  // The MIX_Track* lives in AudioTrackCache (keyed by entity), not on the POD sink component.
+  track_cache_->Store(entity, acquired.track, acquired.generation);
+  cmd_buffer_.AddComponent<AudioSinkComponent>(entity, AudioSinkComponent{});
 }

--- a/src/Systems/AudioSystem.h
+++ b/src/Systems/AudioSystem.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include <vector>
 
+#include "Audio/AudioTrackCache.h"
 #include "Components/AudioSinkComponent.h"
 #include "Components/AudioSourceComponent.h"
 #include "ECS/CommandBuffer.h"
@@ -55,12 +56,20 @@ class AudioSystem {
   };
   Acquired AcquireTrack();
 
-  // True if the sink's (track, generation) pair still matches the pool slot — guards against
+  // Per-entity helper for operator(): acquire a pool track, start the clip (honoring loop +
+  // resume-from-cull), cache the MIX_Track* in AudioTrackCache, and attach a POD AudioSinkComponent.
+  // Split from operator() so each stays a single, readable responsibility.
+  void SpawnSinkForSource(Entity entity, AudioSourceComponent& source);
+
+  // True if the cached (track, generation) pair still matches the pool slot — guards against
   // a pool slot being reissued to a different emitter after a track stops.
-  [[nodiscard]] bool SinkOwnsTrack(const AudioSinkComponent& sink) const;
+  [[nodiscard]] bool SinkOwnsTrack(const AudioTrackCache::Entry& entry) const;
 
   Registry* registry_ = nullptr;
   std::shared_ptr<AudioSystemState> state_;
   CommandBuffer cmd_buffer_;
   EventBus::SubscriptionHandle audio_subscription_;
+  // Resolved lazily on first per-entity tick; the cache singleton is Set during bootstrap and
+  // never reseated, so the pointer is stable for the registry's lifetime.
+  AudioTrackCache* track_cache_ = nullptr;
 };

--- a/src/Systems/DopplerSystem.h
+++ b/src/Systems/DopplerSystem.h
@@ -6,6 +6,7 @@
 #include <cmath>
 #include <glm/glm.hpp>
 
+#include "Audio/AudioTrackCache.h"
 #include "Components/AudioListenerComponent.h"
 #include "Components/AudioSinkComponent.h"
 #include "Components/AudioSourceComponent.h"
@@ -31,16 +32,24 @@
 // sink.lastRatio so an unchanged ratio (the steady-state case) costs zero mixer calls.
 class DopplerSystem {
  public:
-  void operator()(const ContextFacade& ctx, const GlobalTransformComponent& transform,
+  void operator()(const ContextFacade& ctx, Entity entity, const GlobalTransformComponent& transform,
                   const RigidBodyComponent& rigidBody, AudioSourceComponent& source, AudioSinkComponent& sink) {
-    if (sink.finished || !sink.track) return;
+    if (sink.finished) return;
 
-    if (!cache_) cache_ = &ctx.GetRegistry()->Get<AudioListenerCache>();
+    // Resolve both singleton caches together on the first tick (Set once at bootstrap, never
+    // reseated), mirroring SpatialAudioSystem.
+    if (!cache_) {
+      cache_ = &ctx.GetRegistry()->Get<AudioListenerCache>();
+      track_cache_ = &ctx.GetRegistry()->Get<AudioTrackCache>();
+    }
     const auto& cache = *cache_;
+
+    MIX_Track* track = track_cache_->Track(entity);
+    if (!track) return;
 
     const float ratio = ComputeRatio(transform, rigidBody, source, cache);
     if (ratio != sink.lastRatio) {
-      MIX_SetTrackFrequencyRatio(sink.track, ratio);
+      MIX_SetTrackFrequencyRatio(track, ratio);
       sink.lastRatio = ratio;
     }
   }
@@ -73,4 +82,5 @@ class DopplerSystem {
   }
 
   const AudioListenerCache* cache_ = nullptr;
+  AudioTrackCache* track_cache_ = nullptr;
 };

--- a/src/Systems/SpatialAudioSystem.h
+++ b/src/Systems/SpatialAudioSystem.h
@@ -6,6 +6,7 @@
 #include <cmath>
 #include <glm/glm.hpp>
 
+#include "Audio/AudioTrackCache.h"
 #include "Components/AudioListenerComponent.h"
 #include "Components/AudioSinkComponent.h"
 #include "Components/AudioSourceComponent.h"
@@ -25,27 +26,23 @@
 // the pointer is stable for the registry's lifetime.
 class SpatialAudioSystem {
  public:
-  void operator()(const ContextFacade& ctx, const GlobalTransformComponent& transform, AudioSourceComponent& source,
-                  AudioSinkComponent& sink) {
-    if (sink.finished || !sink.track) return;
+  void operator()(const ContextFacade& ctx, Entity entity, const GlobalTransformComponent& transform,
+                  AudioSourceComponent& source, AudioSinkComponent& sink) {
+    if (sink.finished) return;
 
-    if (!cache_) cache_ = &ctx.GetRegistry()->Get<AudioListenerCache>();
+    // cache_ and track_cache_ are both Set once during bootstrap and never reseated, so resolving
+    // them together on the first tick keeps the pointers stable for the registry's lifetime.
+    if (!cache_) {
+      cache_ = &ctx.GetRegistry()->Get<AudioListenerCache>();
+      track_cache_ = &ctx.GetRegistry()->Get<AudioTrackCache>();
+    }
     const auto& cache = *cache_;
 
+    MIX_Track* track = track_cache_->Track(entity);
+    if (!track) return;
+
     if (!source.spatial || !cache.valid) {
-      // Source isn't (or no longer is) spatial: clear any prior stereo override once on
-      // the transition and let the gain reflect raw source.volume. Subsequent frames
-      // skip both calls when nothing changed.
-      if (sink.stereoApplied) {
-        MIX_SetTrackStereo(sink.track, nullptr);
-        sink.stereoApplied = false;
-        sink.lastPan = 2.0f;
-      }
-      const float gain = std::max(0.0f, source.volume);
-      if (gain != sink.lastGain) {
-        MIX_SetTrackGain(sink.track, gain);
-        sink.lastGain = gain;
-      }
+      ApplyNonSpatial(track, source, sink);
       return;
     }
 
@@ -69,7 +66,7 @@ class SpatialAudioSystem {
 
     const float gain = baseVolume * std::clamp(attenuation, 0.0f, 1.0f);
     if (gain != sink.lastGain) {
-      MIX_SetTrackGain(sink.track, gain);
+      MIX_SetTrackGain(track, gain);
       sink.lastGain = gain;
     }
 
@@ -87,12 +84,28 @@ class SpatialAudioSystem {
       MIX_StereoGains gains{};
       gains.left = std::clamp(1.0f - pan, 0.0f, 1.0f);
       gains.right = std::clamp(1.0f + pan, 0.0f, 1.0f);
-      MIX_SetTrackStereo(sink.track, &gains);
+      MIX_SetTrackStereo(track, &gains);
       sink.stereoApplied = true;
       sink.lastPan = pan;
     }
   }
 
  private:
+  // Source isn't (or no longer is) spatial: clear any prior stereo override once on the transition
+  // and let the gain reflect raw source.volume. Subsequent frames skip both calls when unchanged.
+  static void ApplyNonSpatial(MIX_Track* track, const AudioSourceComponent& source, AudioSinkComponent& sink) {
+    if (sink.stereoApplied) {
+      MIX_SetTrackStereo(track, nullptr);
+      sink.stereoApplied = false;
+      sink.lastPan = AudioSinkComponent::kPanSentinel;
+    }
+    const float gain = std::max(0.0f, source.volume);
+    if (gain != sink.lastGain) {
+      MIX_SetTrackGain(track, gain);
+      sink.lastGain = gain;
+    }
+  }
+
   const AudioListenerCache* cache_ = nullptr;
+  AudioTrackCache* track_cache_ = nullptr;
 };

--- a/tests/benchmarks/.clang-tidy
+++ b/tests/benchmarks/.clang-tidy
@@ -1,0 +1,11 @@
+# Benchmark harness code. Synthetic magic numbers (test geometry, frame deltas, listener params)
+# and hand-rolled RAII fixtures (e.g. AudioBenchEnv: delete-copy + a teardown dtor, no move needed)
+# are expected here and are not production-code smells, so they shouldn't trip the blocking
+# changed-lines clang-tidy gate. Inherit the project's check set, then drop the ones that only add
+# noise for micro-benchmarks.
+InheritParentConfig: true
+Checks: >
+  -readability-magic-numbers,
+  -cppcoreguidelines-special-member-functions,
+  -readability-function-cognitive-complexity,
+  -readability-function-size

--- a/tests/benchmarks/SpatialAudioBenchmark.cpp
+++ b/tests/benchmarks/SpatialAudioBenchmark.cpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <vector>
 
+#include "Audio/AudioTrackCache.h"
 #include "Components/AudioListenerComponent.h"
 #include "Components/AudioSinkComponent.h"
 #include "Components/AudioSourceComponent.h"
@@ -28,183 +29,165 @@
 // Transition-cost benches (in/out culling) are out of scope here; they'd profile SDL_mixer's
 // internal state machine more than our systems.
 
-namespace
-{
-    class StubContext final : public AnyContext
-    {
-    public:
-        explicit StubContext(Registry* r) : registry_(r) {}
-        [[nodiscard]] Entity GetEntity() const override { return Entity{}; }
-        [[nodiscard]] Registry* GetRegistry() const override { return registry_; }
-        [[nodiscard]] float GetDeltaTime() const override { return 0.016f; }
-        void* GetComponentPtr(EntityID) override { return nullptr; }
+namespace {
+class StubContext final : public AnyContext {
+ public:
+  explicit StubContext(Registry* r) : registry_(r) {}
+  [[nodiscard]] Entity GetEntity() const override { return Entity{}; }
+  [[nodiscard]] Registry* GetRegistry() const override { return registry_; }
+  [[nodiscard]] float GetDeltaTime() const override { return 0.016f; }
+  void* GetComponentPtr(EntityID) override { return nullptr; }
 
-    private:
-        Registry* registry_;
-    };
+ private:
+  Registry* registry_;
+};
 
-    // RAII helper: initializes SDL audio with the "dummy" driver + SDL_mixer once for the
-    // bench process. Skip the benchmark when init fails (CI containers without an audio
-    // device should still produce a clean skip rather than a crash).
-    struct AudioBenchEnv
-    {
-        AudioBenchEnv()
-        {
-            SDL_SetHint(SDL_HINT_AUDIO_DRIVER, "dummy");
-            if (!SDL_Init(SDL_INIT_AUDIO) || !MIX_Init()) return;
-            mixer_ = MIX_CreateMixerDevice(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, nullptr);
-            initOk_ = mixer_ != nullptr;
-        }
+// RAII helper: initializes SDL audio with the "dummy" driver + SDL_mixer once for the
+// bench process. Skip the benchmark when init fails (CI containers without an audio
+// device should still produce a clean skip rather than a crash).
+struct AudioBenchEnv {
+  AudioBenchEnv() {
+    SDL_SetHint(SDL_HINT_AUDIO_DRIVER, "dummy");
+    if (!SDL_Init(SDL_INIT_AUDIO) || !MIX_Init()) return;
+    mixer_ = MIX_CreateMixerDevice(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, nullptr);
+    initOk_ = mixer_ != nullptr;
+  }
 
-        ~AudioBenchEnv()
-        {
-            for (MIX_Track* t : tracks_)
-            {
-                if (t) MIX_DestroyTrack(t);
-            }
-            if (mixer_) MIX_DestroyMixer(mixer_);
-            MIX_Quit();
-            SDL_Quit();
-        }
-
-        AudioBenchEnv(const AudioBenchEnv&) = delete;
-        AudioBenchEnv& operator=(const AudioBenchEnv&) = delete;
-
-        [[nodiscard]] bool valid() const { return initOk_; }
-
-        MIX_Track* AcquireTrack()
-        {
-            MIX_Track* t = MIX_CreateTrack(mixer_);
-            if (t) tracks_.push_back(t);
-            return t;
-        }
-
-    private:
-        bool initOk_ = false;
-        MIX_Mixer* mixer_ = nullptr;
-        std::vector<MIX_Track*> tracks_;
-    };
-
-    struct BenchScene
-    {
-        Registry registry;
-        std::unique_ptr<ComponentQuery<GlobalTransformComponent, AudioSourceComponent, AudioSinkComponent>>
-        spatialQuery;
-        std::unique_ptr<ComponentQuery<GlobalTransformComponent, RigidBodyComponent, AudioSourceComponent,
-                                       AudioSinkComponent>>
-        dopplerQuery;
-        std::vector<Entity> emitters;
-    };
-
-    // Place N emitters in a square grid centered on the listener at (0,0). Spacing is sized
-    // so every emitter sits inside the 1000-unit maxDistance — i.e. on the attenuation +
-    // pan branch, the more expensive code path, rather than the early-out beyond maxDist.
-    void BuildSceneCommon(BenchScene& scene, AudioBenchEnv& env, int n, bool withRigidBody)
-    {
-        AudioListenerCache cache{};
-        cache.valid = true;
-        cache.position = glm::vec2(0.0f, 0.0f);
-        cache.velocity = glm::vec2(0.0f, 0.0f);
-        cache.right = glm::vec2(1.0f, 0.0f);
-        cache.forward = glm::vec2(0.0f, 1.0f);
-        cache.maxDistance = 1000.0f;
-        cache.rolloff = 1.0f;
-        cache.dopplerFactor = 1.0f;
-        cache.speedOfSound = 343.0f;
-        scene.registry.Set<AudioListenerCache>(cache);
-
-        const int side = static_cast<int>(std::sqrt(static_cast<double>(n))) + 1;
-        const float spacing = 800.0f / static_cast<float>(side);
-        scene.emitters.reserve(static_cast<std::size_t>(n));
-        int placed = 0;
-        for (int row = 0; row < side && placed < n; ++row)
-        {
-            for (int col = 0; col < side && placed < n; ++col)
-            {
-                const float x = (static_cast<float>(col) - static_cast<float>(side) / 2.0f) * spacing;
-                const float y = (static_cast<float>(row) - static_cast<float>(side) / 2.0f) * spacing;
-
-                Entity e = scene.registry.CreateEntity();
-                scene.registry.AddComponent(e, GlobalTransformComponent{glm::vec2(x, y), glm::vec2(1.0f, 1.0f), 0.0});
-                scene.registry.AddComponent(
-                    e, AudioSourceComponent("synthetic", 0.8f, 1.0f, true, false, false, true, 50.0f, 1000.0f, true));
-                if (withRigidBody)
-                {
-                    scene.registry.AddComponent(e, RigidBodyComponent{glm::vec2(10.0f, 0.0f)});
-                }
-                MIX_Track* track = env.AcquireTrack();
-                scene.registry.AddComponent(e, AudioSinkComponent(track, 1));
-                scene.emitters.push_back(e);
-                ++placed;
-            }
-        }
-
-        scene.spatialQuery = scene.registry
-                                  .CreateQuery<GlobalTransformComponent, AudioSourceComponent, AudioSinkComponent>();
-        scene.dopplerQuery = scene.registry
-                                  .CreateQuery<GlobalTransformComponent, RigidBodyComponent, AudioSourceComponent,
-                                               AudioSinkComponent>();
+  ~AudioBenchEnv() {
+    for (MIX_Track* t : tracks_) {
+      if (t) MIX_DestroyTrack(t);
     }
-} // namespace
+    if (mixer_) MIX_DestroyMixer(mixer_);
+    MIX_Quit();
+    SDL_Quit();
+  }
 
-static void BM_SpatialAudio_SteadyState(benchmark::State& state)
-{
-    AudioBenchEnv env;
-    if (!env.valid())
-    {
-        state.SkipWithError("SDL3_mixer dummy-driver init failed");
-        return;
+  AudioBenchEnv(const AudioBenchEnv&) = delete;
+  AudioBenchEnv& operator=(const AudioBenchEnv&) = delete;
+
+  [[nodiscard]] bool valid() const { return initOk_; }
+
+  MIX_Track* AcquireTrack() {
+    MIX_Track* t = MIX_CreateTrack(mixer_);
+    if (t) tracks_.push_back(t);
+    return t;
+  }
+
+ private:
+  bool initOk_ = false;
+  MIX_Mixer* mixer_ = nullptr;
+  std::vector<MIX_Track*> tracks_;
+};
+
+struct BenchScene {
+  Registry registry;
+  std::unique_ptr<ComponentQuery<GlobalTransformComponent, AudioSourceComponent, AudioSinkComponent>> spatialQuery;
+  std::unique_ptr<
+      ComponentQuery<GlobalTransformComponent, RigidBodyComponent, AudioSourceComponent, AudioSinkComponent>>
+      dopplerQuery;
+  std::vector<Entity> emitters;
+};
+
+// Place N emitters in a square grid centered on the listener at (0,0). Spacing is sized
+// so every emitter sits inside the 1000-unit maxDistance — i.e. on the attenuation +
+// pan branch, the more expensive code path, rather than the early-out beyond maxDist.
+void BuildSceneCommon(BenchScene& scene, AudioBenchEnv& env, int n, bool withRigidBody) {
+  AudioListenerCache cache{};
+  cache.valid = true;
+  cache.position = glm::vec2(0.0f, 0.0f);
+  cache.velocity = glm::vec2(0.0f, 0.0f);
+  cache.right = glm::vec2(1.0f, 0.0f);
+  cache.forward = glm::vec2(0.0f, 1.0f);
+  cache.maxDistance = 1000.0f;
+  cache.rolloff = 1.0f;
+  cache.dopplerFactor = 1.0f;
+  cache.speedOfSound = 343.0f;
+  scene.registry.Set<AudioListenerCache>(cache);
+  // The MIX_Track* lives in AudioTrackCache (keyed by entity), mirroring the engine; the
+  // POD AudioSinkComponent only carries the per-frame dedup state the systems read/write.
+  auto& trackCache = scene.registry.Set<AudioTrackCache>(AudioTrackCache());
+
+  const int side = static_cast<int>(std::sqrt(static_cast<double>(n))) + 1;
+  const float spacing = 800.0f / static_cast<float>(side);
+  scene.emitters.reserve(static_cast<std::size_t>(n));
+  int placed = 0;
+  for (int row = 0; row < side && placed < n; ++row) {
+    for (int col = 0; col < side && placed < n; ++col) {
+      const float x = (static_cast<float>(col) - static_cast<float>(side) / 2.0f) * spacing;
+      const float y = (static_cast<float>(row) - static_cast<float>(side) / 2.0f) * spacing;
+
+      Entity e = scene.registry.CreateEntity();
+      scene.registry.AddComponent(e, GlobalTransformComponent{glm::vec2(x, y), glm::vec2(1.0f, 1.0f), 0.0});
+      scene.registry.AddComponent(
+          e, AudioSourceComponent("synthetic", 0.8f, 1.0f, true, false, false, true, 50.0f, 1000.0f, true));
+      if (withRigidBody) {
+        scene.registry.AddComponent(e, RigidBodyComponent{glm::vec2(10.0f, 0.0f)});
+      }
+      MIX_Track* track = env.AcquireTrack();
+      scene.registry.AddComponent(e, AudioSinkComponent{});
+      trackCache.Store(e, track, 1);
+      scene.emitters.push_back(e);
+      ++placed;
     }
+  }
 
-    BenchScene scene;
-    BuildSceneCommon(scene, env, static_cast<int>(state.range(0)), /*withRigidBody=*/false);
-    SpatialAudioSystem system;
-    StubContext impl(&scene.registry);
-    const ContextFacade ctx(&impl);
+  scene.spatialQuery = scene.registry.CreateQuery<GlobalTransformComponent, AudioSourceComponent, AudioSinkComponent>();
+  scene.dopplerQuery =
+      scene.registry
+          .CreateQuery<GlobalTransformComponent, RigidBodyComponent, AudioSourceComponent, AudioSinkComponent>();
+}
+}  // namespace
 
-    // Warm-up frame populates sink.lastGain / lastPan / stereoApplied so the timed iters
-    // exercise the dedup short-circuit (the realistic steady-state path).
-    scene.spatialQuery->ForEach(
-        [&](const Entity, const GlobalTransformComponent& tf, AudioSourceComponent& src,
-            AudioSinkComponent& sink) { system(ctx, tf, src, sink); });
+static void BM_SpatialAudio_SteadyState(benchmark::State& state) {
+  AudioBenchEnv env;
+  if (!env.valid()) {
+    state.SkipWithError("SDL3_mixer dummy-driver init failed");
+    return;
+  }
 
-    for (auto _ : state)
-    {
-        scene.spatialQuery->ForEach(
-            [&](const Entity, const GlobalTransformComponent& tf, AudioSourceComponent& src,
-                AudioSinkComponent& sink) { system(ctx, tf, src, sink); });
-    }
-    state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) * state.range(0));
+  BenchScene scene;
+  BuildSceneCommon(scene, env, static_cast<int>(state.range(0)), /*withRigidBody=*/false);
+  SpatialAudioSystem system;
+  StubContext impl(&scene.registry);
+  const ContextFacade ctx(&impl);
+
+  // Warm-up frame populates sink.lastGain / lastPan / stereoApplied so the timed iters
+  // exercise the dedup short-circuit (the realistic steady-state path).
+  scene.spatialQuery->ForEach([&](const Entity e, const GlobalTransformComponent& tf, AudioSourceComponent& src,
+                                  AudioSinkComponent& sink) { system(ctx, e, tf, src, sink); });
+
+  for (auto _ : state) {
+    scene.spatialQuery->ForEach([&](const Entity e, const GlobalTransformComponent& tf, AudioSourceComponent& src,
+                                    AudioSinkComponent& sink) { system(ctx, e, tf, src, sink); });
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) * state.range(0));
 }
 
 BENCHMARK(BM_SpatialAudio_SteadyState)->Range(8, 1024);
 
-static void BM_Doppler_SteadyState(benchmark::State& state)
-{
-    AudioBenchEnv env;
-    if (!env.valid())
-    {
-        state.SkipWithError("SDL3_mixer dummy-driver init failed");
-        return;
-    }
+static void BM_Doppler_SteadyState(benchmark::State& state) {
+  AudioBenchEnv env;
+  if (!env.valid()) {
+    state.SkipWithError("SDL3_mixer dummy-driver init failed");
+    return;
+  }
 
-    BenchScene scene;
-    BuildSceneCommon(scene, env, static_cast<int>(state.range(0)), /*withRigidBody=*/true);
-    DopplerSystem system;
-    StubContext impl(&scene.registry);
-    const ContextFacade ctx(&impl);
+  BenchScene scene;
+  BuildSceneCommon(scene, env, static_cast<int>(state.range(0)), /*withRigidBody=*/true);
+  DopplerSystem system;
+  StubContext impl(&scene.registry);
+  const ContextFacade ctx(&impl);
 
-    scene.dopplerQuery->ForEach(
-        [&](const Entity, const GlobalTransformComponent& tf, const RigidBodyComponent& rb, AudioSourceComponent& src,
-            AudioSinkComponent& sink) { system(ctx, tf, rb, src, sink); });
+  scene.dopplerQuery->ForEach([&](const Entity e, const GlobalTransformComponent& tf, const RigidBodyComponent& rb,
+                                  AudioSourceComponent& src,
+                                  AudioSinkComponent& sink) { system(ctx, e, tf, rb, src, sink); });
 
-    for (auto _ : state)
-    {
-        scene.dopplerQuery->ForEach(
-            [&](const Entity, const GlobalTransformComponent& tf, const RigidBodyComponent& rb,
-                AudioSourceComponent& src, AudioSinkComponent& sink) { system(ctx, tf, rb, src, sink); });
-    }
-    state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) * state.range(0));
+  for (auto _ : state) {
+    scene.dopplerQuery->ForEach([&](const Entity e, const GlobalTransformComponent& tf, const RigidBodyComponent& rb,
+                                    AudioSourceComponent& src,
+                                    AudioSinkComponent& sink) { system(ctx, e, tf, rb, src, sink); });
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) * state.range(0));
 }
 
 BENCHMARK(BM_Doppler_SteadyState)->Range(8, 1024);


### PR DESCRIPTION
## Summary

Closes the **last Stage-2 POD leak** from the architecture-cleanup plan. `AudioSinkComponent`
carried a raw `MIX_Track*` (plus its pool generation), forcing `src/Components/` to include
SDL_mixer. The handle now lives in a new **`AudioTrackCache`** (`src/Audio/`) — an entity-keyed
Registry singleton that mirrors `Renderer/SpriteRenderCache` — so the component is plain data.

After this, `grep -E 'SDL_|MIX_|TTF_' src/Components/` is type-clean (only doc comments remain;
I also dropped a stray `Sint64` → `std::int64_t` in `AudioSourceComponent`).

## Design

- **`AudioSinkComponent`** → POD: `finished` + the `lastGain/lastPan/lastRatio/stereoApplied`
  per-frame dedup state. No SDL/MIX types.
- **`AudioTrackCache`** (`src/Audio/AudioTrackCache.h`): `Store/Track/Lookup/Forget/Clear` keyed by
  `Entity`. Set on the live-frame path in `EngineBootstrap` (param renamed
  `withSpriteRenderCache` → `withFramePathCaches`, now gating both frame caches), `Clear()`ed on
  scene unload in `SceneLoader`. Single-threaded, like `SpriteRenderCache`.
- **AudioSystem** stores the track on creation, `Forget`s on finish; `SinkOwnsTrack` now takes the
  cache entry. **AudioCullingSystem** forgets on cull. **Spatial/Doppler** gain a leading `Entity`
  param (the dispatch already supports it — `AudioCullingSystem` used that form) and resolve the
  track from the cache each frame.

## Lifetime / correctness

The cache is forgotten when a sink finishes or is culled, and `Clear()`ed on scene unload. A
despawned-while-playing emitter's track plays out and the pool reclaims it via `MIX_TrackPlaying`
(unchanged from before); a recycled entity overwrites any stale entry on its next `Store` — same
discipline as `SpriteRenderCache`.

## Lint notes

- Adding the `Entity` param changed the Spatial/Doppler `operator()` signature line. To keep
  `SpatialAudioSystem::operator()` under the cognitive-complexity gate on that now-changed line, I
  extracted the non-spatial branch into a helper and combined the two lazy cache lookups; named the
  `lastPan` sentinel (`kPanSentinel`) so it isn't a magic number. Same lazy-lookup combine applied
  to Doppler/Culling.
- `SpatialAudioBenchmark` was reformatted to project clang-format style (it predated the format
  gate; touching it triggers a whole-file check).

## Test plan

- [x] editor-debug builds clean; `ctest` 12/12
- [x] `OctarineBenchmarks` (Spatial/Doppler) builds + runs under the dummy audio driver (~2M items/s,
      comparable — the extra per-emitter cache hash is the documented tradeoff)
- [x] clang-format (18.1.8) + catalog drift + include-style gates clean
- [x] no clang-tidy findings on changed lines
- [ ] CI green