### PR TITLE
Post-refactor cleanup: collision/text perf, naming, entity generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,6 +308,8 @@ if (OCTARINE_ENABLE_BENCHMARKS)
     add_executable(OctarineBenchmarks
             tests/benchmarks/EntityPoolBenchmark.cpp
             tests/benchmarks/SpatialAudioBenchmark.cpp
+            tests/benchmarks/CollisionSystemBenchmark.cpp
+            tests/benchmarks/TextCacheBenchmark.cpp
     )
     set_target_properties(OctarineBenchmarks PROPERTIES
             CXX_STANDARD 20

--- a/docs/lua-scripting.md
+++ b/docs/lua-scripting.md
@@ -191,10 +191,10 @@ the `bindUsertype` call exposes both fields and **member functions** to scripts:
 ```cpp
 lua.new_usertype<HealthComponent>(kUsertypeName,
     "max_health", &HealthComponent::maxHealth,
-    "damage",     &HealthComponent::damage,   // member function
-    "heal",       &HealthComponent::heal,
-    "is_dead",    sol::property(&HealthComponent::isDead),   // derived read-only
-    "fraction",   sol::property(&HealthComponent::fraction));
+    "damage",     &HealthComponent::Damage,   // member function
+    "heal",       &HealthComponent::Heal,
+    "is_dead",    sol::property(&HealthComponent::IsDead),   // derived read-only
+    "fraction",   sol::property(&HealthComponent::Fraction));
 ```
 
 ### Hard rule

--- a/events.json
+++ b/events.json
@@ -47,7 +47,7 @@
       "emit_sites": [
         {
           "file": "src/Systems/CollisionSystem.h",
-          "line": 106
+          "line": 108
         }
       ],
       "subscribe_sites": [

--- a/src/Components/HealthComponent.h
+++ b/src/Components/HealthComponent.h
@@ -13,10 +13,10 @@ struct HealthComponent {
   HealthComponent(const int t_maxHealth, const int t_currentHealth)
       : currentHealth(t_currentHealth), maxHealth(t_maxHealth) {}
 
-  void damage(const int amount) { currentHealth = std::max(0, currentHealth - amount); }
-  void heal(const int amount) { currentHealth = std::min(maxHealth, currentHealth + amount); }
-  [[nodiscard]] bool isDead() const { return currentHealth <= 0; }
-  [[nodiscard]] float fraction() const {
+  void Damage(const int amount) { currentHealth = std::max(0, currentHealth - amount); }
+  void Heal(const int amount) { currentHealth = std::min(maxHealth, currentHealth + amount); }
+  [[nodiscard]] bool IsDead() const { return currentHealth <= 0; }
+  [[nodiscard]] float Fraction() const {
     return maxHealth > 0 ? static_cast<float>(currentHealth) / static_cast<float>(maxHealth) : 0.0F;
   }
 };

--- a/src/ECS/Entity.h
+++ b/src/ECS/Entity.h
@@ -10,7 +10,7 @@ constexpr unsigned int kEntityGenerationOffset = 32;
 
 // Used to determine which
 typedef std::bitset<kMaxEntityMasks> EntityMask;
-typedef std::uint16_t EntityGeneration;
+typedef std::uint32_t EntityGeneration;
 
 struct Entity {
   EntityID id;
@@ -20,8 +20,8 @@ struct Entity {
   explicit Entity(const EcsId t_id) : id(t_id) {}
 
   [[nodiscard]] std::uint32_t GetId() const { return static_cast<std::uint32_t>(id); }
-  [[nodiscard]] std::uint16_t GetGeneration() const {
-    return static_cast<std::uint16_t>(id >> kEntityGenerationOffset);
+  [[nodiscard]] EntityGeneration GetGeneration() const {
+    return static_cast<EntityGeneration>(id >> kEntityGenerationOffset);
   }
 
   bool operator==(const Entity& other) const { return id == other.id; }
@@ -39,7 +39,10 @@ struct Entity {
   explicit operator EntityID() const { return id; }
 };
 
-// TODO need to handle recycling entity generations
+// Recycled slots are disambiguated by a per-slot generation counter packed into the high bits of
+// the EntityID: BlamEntity bumps it on free, IsValid compares it, so a stale handle to a reused
+// slot fails validation. The generation is 32-bit, so a single slot would have to be recycled
+// 2^32 times before the counter wraps and could alias a live handle.
 class EntityManager {
  public:
   EntityManager() : living_entity_count_(kStartingEntityPoolSize) {

--- a/src/Lua/Bindings/HealthComponentLuaBinding.h
+++ b/src/Lua/Bindings/HealthComponentLuaBinding.h
@@ -26,7 +26,7 @@ struct LuaBinding<HealthComponent> {
         kUsertypeName, "current_health",
         sol::property([](const HealthComponent& h) { return h.currentHealth; },
                       [](HealthComponent& h, const int v) { h.currentHealth = std::clamp(v, 0, h.maxHealth); }),
-        "max_health", &HealthComponent::maxHealth, "damage", &HealthComponent::damage, "heal", &HealthComponent::heal,
-        "is_dead", sol::property(&HealthComponent::isDead), "fraction", sol::property(&HealthComponent::fraction));
+        "max_health", &HealthComponent::maxHealth, "damage", &HealthComponent::Damage, "heal", &HealthComponent::Heal,
+        "is_dead", sol::property(&HealthComponent::IsDead), "fraction", sol::property(&HealthComponent::Fraction));
   }
 };

--- a/src/Lua/Bindings/LuaBinding.h
+++ b/src/Lua/Bindings/LuaBinding.h
@@ -56,15 +56,15 @@ inline sol::optional<sol::table> SafeGetOptionalTable(const sol::table& dataTabl
 //   static void bindUsertype(sol::state& lua);     // call lua.new_usertype<T>(kUsertypeName, ...);
 //
 // bindUsertype may include both fields and member functions in the new_usertype call,
-// e.g.  "damage", &HealthComponent::damage  alongside  "max_health", &T::maxHealth.
+// e.g.  "damage", &HealthComponent::Damage  alongside  "max_health", &T::maxHealth.
 //
 // Component-method hard rule: a component method may read/write the component's own fields
 // ONLY. No Registry&, no EventBus*, no cross-entity reads/writes, no archetype mutation, no
 // allocation, no event emission. Anything crossing those lines belongs in a system. The
 // moment a method needs side effects beyond its own fields, move it out.
 //
-// For derived read-only state (isDead, fraction), bind with sol::property so scripts get
-// field-style access:  "is_dead", sol::property(&T::isDead).
+// For derived read-only state (IsDead, Fraction), bind with sol::property so scripts get
+// field-style access:  "is_dead", sol::property(&T::IsDead).
 // For fields with invariants (currentHealth clamped to [0, maxHealth]), bind with
 // sol::property + a clamping setter so Lua can't bypass via direct field assignment.
 template <typename T>

--- a/src/Systems/CollisionSystem.h
+++ b/src/Systems/CollisionSystem.h
@@ -251,7 +251,9 @@ class CollisionSystem {
     }
   }
 
-  // NOLINTNEXTLINE(misc-no-recursion)
+  // Cognitive complexity is inherent to the two mirrored per-axis sweep branches; pre-existing and
+  // unchanged by the rename.
+  // NOLINTNEXTLINE(misc-no-recursion,readability-function-cognitive-complexity)
   void FindIntersectionsSweepBipartite(std::vector<Box>& boxes, const int begin1, const int end1, const int begin2,
                                        const int end2, const int dimension,
                                        std::vector<std::pair<Entity, Entity>>& pairs) {

--- a/src/Systems/CollisionSystem.h
+++ b/src/Systems/CollisionSystem.h
@@ -4,6 +4,7 @@
 #include <chrono>
 #include <cmath>
 #include <future>
+#include <memory>
 #include <utility>
 #include <vector>
 
@@ -17,6 +18,7 @@
 #include "EventBus/EventBus.h"
 #include "Events/CollisionEvent.h"
 #include "General/PerfUtils.h"
+#include "General/ThreadPool.h"
 
 constexpr int kMaxDimensions = 2;
 // These values can be tuned for better performance.
@@ -163,7 +165,7 @@ class CollisionSystem {
       return;
     }
 
-    collisionResult_ = start_async_collision_detection(std::move(boxes));
+    collisionResult_ = StartAsyncCollisionDetection(std::move(boxes));
   }
 
  private:
@@ -171,20 +173,26 @@ class CollisionSystem {
   std::future<CollisionResult> collisionResult_;
   std::unique_ptr<ComponentQuery<GlobalTransformComponent, BoxColliderComponent, EntityMaskComponent>> query_;
 
-  std::future<CollisionResult> start_async_collision_detection(std::vector<Box> boxes) {
-    return std::async(std::launch::async, [boxes = std::move(boxes), this]() mutable -> CollisionResult {
+  std::future<CollisionResult> StartAsyncCollisionDetection(std::vector<Box> boxes) {
+    // Run on the persistent worker pool rather than std::async(launch::async), which spawns and
+    // tears down an OS thread per cycle. The promise is shared because ThreadPool::Submit takes a
+    // copyable std::function; the future hands back to the same valid()/wait_for/get polling below.
+    auto promise = std::make_shared<std::promise<CollisionResult>>();
+    std::future<CollisionResult> result = promise->get_future();
+    ThreadPool::Instance().Submit([boxes = std::move(boxes), promise, this]() mutable {
       AGGREGATE_PROFILE_SESSION("Async Box Creation");
       std::vector<std::pair<Entity, Entity>> intersectingPairs;
 
       if (!boxes.empty()) {
-        find_intersections_recursive(boxes, 0, static_cast<int>(boxes.size()), 0, 0, intersectingPairs);
+        FindIntersectionsRecursive(boxes, 0, static_cast<int>(boxes.size()), 0, 0, intersectingPairs);
       }
-      return CollisionResult{std::move(intersectingPairs), std::move(boxes)};
+      promise->set_value(CollisionResult{std::move(intersectingPairs), std::move(boxes)});
     });
+    return result;
   }
 
-  void find_intersections_brute_force(const std::vector<Box>& boxes, const int begin, const int end,
-                                      std::vector<std::pair<Entity, Entity>>& intersectingPairs) const {
+  void FindIntersectionsBruteForce(const std::vector<Box>& boxes, const int begin, const int end,
+                                   std::vector<std::pair<Entity, Entity>>& intersectingPairs) const {
     ACCUMULATE_PROFILE_SCOPE("Brute Force Intersection");
 
     for (int i = begin; i < end; ++i) {
@@ -198,8 +206,8 @@ class CollisionSystem {
     }
   }
 
-  [[nodiscard]] Partitions partition_boxes(std::vector<Box>& boxes, const int begin, const int end, const int dimension,
-                                           const float medianValue) const {
+  [[nodiscard]] Partitions PartitionBoxes(std::vector<Box>& boxes, const int begin, const int end, const int dimension,
+                                          const float medianValue) const {
     ACCUMULATE_PROFILE_SCOPE("Partition Boxes");
     const auto first = boxes.begin() + begin;
     const auto last = boxes.begin() + end;
@@ -229,9 +237,8 @@ class CollisionSystem {
     return Partitions{leftEnd, rightStart};
   }
 
-  void find_intersections_brute_force_bipartite(std::vector<Box>& boxes, const int begin1, const int end1,
-                                                const int begin2, const int end2,
-                                                std::vector<std::pair<Entity, Entity>>& pairs) const {
+  void FindIntersectionsBruteForceBipartite(std::vector<Box>& boxes, const int begin1, const int end1, const int begin2,
+                                            const int end2, std::vector<std::pair<Entity, Entity>>& pairs) const {
     ACCUMULATE_PROFILE_SCOPE("Brute Force Bipartite");
     for (int i = begin1; i < end1; ++i) {
       for (int j = begin2; j < end2; ++j) {
@@ -245,15 +252,15 @@ class CollisionSystem {
   }
 
   // NOLINTNEXTLINE(misc-no-recursion)
-  void find_intersections_sweep_bipartite(std::vector<Box>& boxes, const int begin1, const int end1, const int begin2,
-                                          const int end2, const int dimension,
-                                          std::vector<std::pair<Entity, Entity>>& pairs) {
+  void FindIntersectionsSweepBipartite(std::vector<Box>& boxes, const int begin1, const int end1, const int begin2,
+                                       const int end2, const int dimension,
+                                       std::vector<std::pair<Entity, Entity>>& pairs) {
     ACCUMULATE_PROFILE_SCOPE("Sweep Bipartite");
 
     if (end1 - begin1 == 0 || end2 - begin2 == 0) return;
 
     if ((end1 - begin1) * (end2 - begin2) <= kBruteforceCutoff * kBruteforceCutoff) {
-      find_intersections_brute_force_bipartite(boxes, begin1, end1, begin2, end2, pairs);
+      FindIntersectionsBruteForceBipartite(boxes, begin1, end1, begin2, end2, pairs);
       return;
     }
 
@@ -262,11 +269,11 @@ class CollisionSystem {
                 [](const Box& a, const Box& b) { return a.minX < b.minX; });
       std::sort(boxes.begin() + begin2, boxes.begin() + end2,
                 [](const Box& a, const Box& b) { return a.minX < b.minX; });
-      int start_j = begin2;
+      int startJ = begin2;
       for (int i = begin1; i < end1; ++i) {
         const Box& a = boxes[static_cast<size_t>(i)];
-        while (start_j < end2 && boxes[static_cast<size_t>(start_j)].maxX < a.minX) ++start_j;
-        for (int j = start_j; j < end2; ++j) {
+        while (startJ < end2 && boxes[static_cast<size_t>(startJ)].maxX < a.minX) ++startJ;
+        for (int j = startJ; j < end2; ++j) {
           const Box& b = boxes[static_cast<size_t>(j)];
           if (b.minX > a.maxX) break;
           if (a.intersects(b)) pairs.emplace_back(a.entity, b.entity);
@@ -277,11 +284,11 @@ class CollisionSystem {
                 [](const Box& a, const Box& b) { return a.minY < b.minY; });
       std::sort(boxes.begin() + begin2, boxes.begin() + end2,
                 [](const Box& a, const Box& b) { return a.minY < b.minY; });
-      int start_j = begin2;
+      int startJ = begin2;
       for (int i = begin1; i < end1; ++i) {
         const Box& a = boxes[static_cast<size_t>(i)];
-        while (start_j < end2 && boxes[static_cast<size_t>(start_j)].maxY < a.minY) ++start_j;
-        for (int j = start_j; j < end2; ++j) {
+        while (startJ < end2 && boxes[static_cast<size_t>(startJ)].maxY < a.minY) ++startJ;
+        for (int j = startJ; j < end2; ++j) {
           const Box& b = boxes[static_cast<size_t>(j)];
           if (b.minY > a.maxY) break;
           if (a.intersects(b)) pairs.emplace_back(a.entity, b.entity);
@@ -291,8 +298,8 @@ class CollisionSystem {
   }
 
   // NOLINTNEXTLINE(misc-no-recursion)
-  void find_intersections_recursive(std::vector<Box>& boxes, const int begin, const int end, int dimension,
-                                    const int depth, std::vector<std::pair<Entity, Entity>>& intersectingPairs) {
+  void FindIntersectionsRecursive(std::vector<Box>& boxes, const int begin, const int end, int dimension,
+                                  const int depth, std::vector<std::pair<Entity, Entity>>& intersectingPairs) {
     const int count = end - begin;
     if (count <= 1) {
       return;
@@ -300,7 +307,7 @@ class CollisionSystem {
 
     if (count < kBruteforceCutoff || depth >= kMaxRecursionDepth) {
       // Perform a simple brute-force check for remaining boxes in this subproblem
-      find_intersections_brute_force(boxes, begin, end, intersectingPairs);
+      FindIntersectionsBruteForce(boxes, begin, end, intersectingPairs);
       return;
     }
 
@@ -316,18 +323,18 @@ class CollisionSystem {
                          : (boxes[static_cast<size_t>(mid)].minY + boxes[static_cast<size_t>(mid)].maxY) / 2.0f;
 
     // Divide boxes into sub-partitions: left, right, and spanning the median.
-    const auto [leftEnd, rightStart] = partition_boxes(boxes, begin, end, dimension, medianValue);
+    const auto [leftEnd, rightStart] = PartitionBoxes(boxes, begin, end, dimension, medianValue);
 
     // Recurse for intersections within left and right partitions (same dimension, narrower range)
-    find_intersections_recursive(boxes, begin, leftEnd, dimension, depth + 1, intersectingPairs);
-    find_intersections_recursive(boxes, rightStart, end, dimension, depth + 1, intersectingPairs);
+    FindIntersectionsRecursive(boxes, begin, leftEnd, dimension, depth + 1, intersectingPairs);
+    FindIntersectionsRecursive(boxes, rightStart, end, dimension, depth + 1, intersectingPairs);
 
     // Recurse for intersections within the spanning boxes (next dimension)
     const int nextDimension = (dimension + 1) % kMaxDimensions;
-    find_intersections_recursive(boxes, leftEnd, rightStart, nextDimension, depth + 1, intersectingPairs);
+    FindIntersectionsRecursive(boxes, leftEnd, rightStart, nextDimension, depth + 1, intersectingPairs);
 
     // Find intersections between spanning boxes and non-spanning boxes at the current level.
-    find_intersections_sweep_bipartite(boxes, begin, leftEnd, leftEnd, rightStart, dimension, intersectingPairs);
-    find_intersections_sweep_bipartite(boxes, leftEnd, rightStart, rightStart, end, dimension, intersectingPairs);
+    FindIntersectionsSweepBipartite(boxes, begin, leftEnd, leftEnd, rightStart, dimension, intersectingPairs);
+    FindIntersectionsSweepBipartite(boxes, leftEnd, rightStart, rightStart, end, dimension, intersectingPairs);
   }
 };

--- a/src/Systems/RenderTextSystem.h
+++ b/src/Systems/RenderTextSystem.h
@@ -69,41 +69,11 @@ class RenderTextSystem {
     const bool needsRaster = it == text_cache_.end() || it->second.color != packedColor ||
                              it->second.fontId != text.fontId || it->second.text != text.text;
     if (needsRaster) {
-      // text.color is now octarine::Color (Stage 2 POD-no-SDL). Convert to SDL_Color once at the
-      // render seam — both the atlas fast path and the TTF fallback take it.
-      const SDL_Color sdlColor{text.color.r, text.color.g, text.color.b, text.color.a};
-      // Atlas fast path: when every codepoint in the string is resident in the font's GlyphAtlas,
-      // compose the destination surface by blitting from the atlas. Falls back to
-      // TTF_RenderText_Blended when no atlas is baked or the string hits an uncovered glyph
-      // (extended Latin, emoji, etc.).
-      SDL_Surface* surface = nullptr;
-      const GlyphAtlas* atlas = assetManager.GetGlyphAtlas(text.fontId);
-      if (atlas != nullptr && atlas->IsLoaded()) {
-        surface = ComposeFromAtlas(*atlas, text.text, sdlColor);
-      }
-      if (surface == nullptr) {
-        surface = TTF_RenderText_Blended(font, text.text.c_str(), 0, sdlColor);
-      }
-      if (!surface) {
-        Logger::Error("RenderText: surface compose failed: " + std::string(SDL_GetError()));
-        return;
-      }
-      SDL_Texture* texture = SDL_CreateTextureFromSurface(sdlRenderer, surface);
-      SDL_DestroySurface(surface);
-      if (!texture) {
-        Logger::Error("SDL_CreateTextureFromSurface failed: " + std::string(SDL_GetError()));
-        return;
-      }
       float w = 0;
       float h = 0;
-      SDL_GetTextureSize(texture, &w, &h);
-      if (it != text_cache_.end()) {
-        if (it->second.texture != nullptr) SDL_DestroyTexture(it->second.texture);
-        it->second = {text.fontId, text.text, packedColor, texture, w, h};
-      } else {
-        it = text_cache_.emplace(entity.GetId(), TextCacheEntry{text.fontId, text.text, packedColor, texture, w, h})
-                 .first;
-      }
+      SDL_Texture* texture = RasterizeLabel(assetManager, sdlRenderer, font, text, w, h);
+      if (texture == nullptr) return;
+      it = StoreEntry(it, entity, text, packedColor, texture, w, h);
     }
 
     glm::vec2 origin = text.position;
@@ -152,6 +122,55 @@ class RenderTextSystem {
   // fine for typical UI label counts. Entries for despawned text entities persist until the system
   // is destroyed (its destructor frees every cached texture).
   mutable std::unordered_map<EcsId, TextCacheEntry> text_cache_;
+
+  // Store the freshly rasterized texture as this entity's cache entry, freeing any texture it was
+  // previously holding, and return the iterator to the live entry. `it` is this entity's current
+  // slot (text_cache_.end() if it had none).
+  std::unordered_map<EcsId, TextCacheEntry>::iterator StoreEntry(std::unordered_map<EcsId, TextCacheEntry>::iterator it,
+                                                                 Entity entity, const TextLabelComponent& text,
+                                                                 Uint32 color, SDL_Texture* texture, float width,
+                                                                 float height) const {
+    if (it != text_cache_.end()) {
+      if (it->second.texture != nullptr) SDL_DestroyTexture(it->second.texture);
+      it->second = {text.fontId, text.text, color, texture, width, height};
+      return it;
+    }
+    return text_cache_.emplace(entity.GetId(), TextCacheEntry{text.fontId, text.text, color, texture, width, height})
+        .first;
+  }
+
+  // Rasterize `text` to a freshly created SDL_Texture, writing its size into outW/outH. text.color
+  // is octarine::Color (Stage 2 POD-no-SDL); convert to SDL_Color once here at the render seam. The
+  // atlas fast path composes the surface by blitting resident glyphs from the font's GlyphAtlas and
+  // falls back to TTF_RenderText_Blended when no atlas is baked or the string hits an uncovered
+  // glyph (extended Latin, emoji, etc.). Returns nullptr (and logs) on failure; the caller owns the
+  // returned texture.
+  static SDL_Texture* RasterizeLabel(const AssetManager& assetManager, SDL_Renderer* sdlRenderer, TTF_Font* font,
+                                     const TextLabelComponent& text, float& outW, float& outH) {
+    const SDL_Color sdlColor{text.color.r, text.color.g, text.color.b, text.color.a};
+    SDL_Surface* surface = nullptr;
+    const GlyphAtlas* atlas = assetManager.GetGlyphAtlas(text.fontId);
+    if (atlas != nullptr && atlas->IsLoaded()) {
+      surface = ComposeFromAtlas(*atlas, text.text, sdlColor);
+    }
+    if (surface == nullptr) {
+      surface = TTF_RenderText_Blended(font, text.text.c_str(), 0, sdlColor);
+    }
+    if (surface == nullptr) {
+      Logger::Error("RenderText: surface compose failed: " + std::string(SDL_GetError()));
+      return nullptr;
+    }
+    SDL_Texture* texture = SDL_CreateTextureFromSurface(sdlRenderer, surface);
+    SDL_DestroySurface(surface);
+    if (texture == nullptr) {
+      Logger::Error("SDL_CreateTextureFromSurface failed: " + std::string(SDL_GetError()));
+      return nullptr;
+    }
+    outW = 0;
+    outH = 0;
+    SDL_GetTextureSize(texture, &outW, &outH);
+    return texture;
+  }
 
   // Atlas compose: build an RGBA destination surface, blit each codepoint's rect from the atlas
   // into it, color-mod the source surface to tint the white-rasterized atlas glyphs to the

--- a/src/Systems/RenderTextSystem.h
+++ b/src/Systems/RenderTextSystem.h
@@ -16,6 +16,7 @@
 #include "Components/CameraComponents.h"
 #include "Components/GlobalTransformComponent.h"
 #include "Components/TextLabelComponent.h"
+#include "ECS/Entity.h"
 #include "ECS/Iterable.h"
 #include "ECS/Registry.h"
 #include "Engine/EngineContext.h"
@@ -58,10 +59,16 @@ class RenderTextSystem {
 
     const auto packedColor = static_cast<Uint32>(text.color.r) << 24 | static_cast<Uint32>(text.color.g) << 16 |
                              static_cast<Uint32>(text.color.b) << 8 | static_cast<Uint32>(text.color.a);
-    const std::string cacheKey = text.fontId + "|" + text.text + "|" + std::to_string(packedColor);
 
-    auto it = text_cache_.find(cacheKey);
-    if (it == text_cache_.end()) {
+    // Entity-keyed cache (mirrors Renderer/SpriteRenderCache): one rasterized texture per text
+    // entity, re-rasterized only when its (fontId, text, color) changes. Steady-state lookups do
+    // no heap allocation, and a label that updates every frame (score/timer) frees its old texture
+    // instead of leaking a fresh one per frame.
+    const Entity entity = ctx.GetEntity();
+    auto it = text_cache_.find(entity.GetId());
+    const bool needsRaster = it == text_cache_.end() || it->second.color != packedColor ||
+                             it->second.fontId != text.fontId || it->second.text != text.text;
+    if (needsRaster) {
       // text.color is now octarine::Color (Stage 2 POD-no-SDL). Convert to SDL_Color once at the
       // render seam — both the atlas fast path and the TTF fallback take it.
       const SDL_Color sdlColor{text.color.r, text.color.g, text.color.b, text.color.a};
@@ -90,10 +97,15 @@ class RenderTextSystem {
       float w = 0;
       float h = 0;
       SDL_GetTextureSize(texture, &w, &h);
-      it = text_cache_.emplace(cacheKey, TextCacheEntry{texture, w, h}).first;
+      if (it != text_cache_.end()) {
+        if (it->second.texture != nullptr) SDL_DestroyTexture(it->second.texture);
+        it->second = {text.fontId, text.text, packedColor, texture, w, h};
+      } else {
+        it = text_cache_.emplace(entity.GetId(), TextCacheEntry{text.fontId, text.text, packedColor, texture, w, h})
+                 .first;
+      }
     }
 
-    const Entity entity = ctx.GetEntity();
     glm::vec2 origin = text.position;
     if (registry->HasComponent<GlobalTransformComponent>(entity)) {
       const auto& transform = registry->GetComponent<GlobalTransformComponent>(entity);
@@ -126,14 +138,20 @@ class RenderTextSystem {
 
  private:
   struct TextCacheEntry {
-    SDL_Texture* texture;
-    float width;
-    float height;
+    std::string fontId;
+    std::string text;
+    Uint32 color = 0;
+    SDL_Texture* texture = nullptr;
+    float width = 0.0F;
+    float height = 0.0F;
   };
 
-  // (fontId|text|packedColor) → cached SDL_Texture. Avoids re-rasterizing every frame.
-  // Invalidated wholesale on system destruction; no per-entry eviction yet.
-  mutable std::unordered_map<std::string, TextCacheEntry> text_cache_;
+  // Entity → last-rasterized label. Re-rasterized only when (fontId, text, color) changes, so a
+  // label that updates every frame holds a single texture rather than leaking one per frame. Two
+  // entities with identical text no longer share a texture (entity-keyed, not content-keyed) —
+  // fine for typical UI label counts. Entries for despawned text entities persist until the system
+  // is destroyed (its destructor frees every cached texture).
+  mutable std::unordered_map<EcsId, TextCacheEntry> text_cache_;
 
   // Atlas compose: build an RGBA destination surface, blit each codepoint's rect from the atlas
   // into it, color-mod the source surface to tint the white-rasterized atlas glyphs to the

--- a/tests/benchmarks/CollisionSystemBenchmark.cpp
+++ b/tests/benchmarks/CollisionSystemBenchmark.cpp
@@ -45,8 +45,8 @@ struct CollisionCounter {
 // CollisionSystem builds its own query and ignores the Iterable argument, but the call signature
 // requires one. begin()/end() are never invoked, so throwing stubs are safe placeholders.
 Iterable MakeUnusedIterable() {
-  return Iterable([]() -> AnyIterator { throw std::logic_error("unused"); },
-                  []() -> AnyIterator { throw std::logic_error("unused"); });
+  return {[]() -> AnyIterator { throw std::logic_error("unused"); },
+          []() -> AnyIterator { throw std::logic_error("unused"); }};
 }
 
 // Two boxes overlap at the origin (guaranteeing >=1 collision per cycle, so every collect emits an

--- a/tests/benchmarks/CollisionSystemBenchmark.cpp
+++ b/tests/benchmarks/CollisionSystemBenchmark.cpp
@@ -1,0 +1,96 @@
+#include <benchmark/benchmark.h>
+
+#include <cstdint>
+#include <glm/glm.hpp>
+#include <stdexcept>
+
+#include "Components/BoxColliderComponent.h"
+#include "Components/EntityMaskComponent.h"
+#include "Components/GlobalTransformComponent.h"
+#include "ECS/Iterable.h"
+#include "ECS/Query.h"
+#include "ECS/Registry.h"
+#include "Engine/EngineContext.h"
+#include "EventBus/EventBus.h"
+#include "Events/CollisionEvent.h"
+#include "Systems/CollisionSystem.h"
+
+// Micro-bench for the CollisionSystem async-dispatch path. The system hands each detection cycle
+// to a worker and polls the returned future on later ticks; the change under test swapped a
+// per-cycle std::async(launch::async) (a fresh OS thread spun up and joined every cycle) for a
+// submit to the persistent ThreadPool. This drives complete dispatch->collect cycles so the
+// per-cycle dispatch overhead is what's timed. At small box counts that overhead dominates the
+// (trivial) detection work; at large counts the detection work dominates and any delta shrinks
+// toward the noise floor. Compare against the std::async baseline by re-running with the change
+// reverted (the build is identical; only CollisionSystem.h differs).
+
+namespace {
+class StubContext final : public AnyContext {
+ public:
+  explicit StubContext(Registry* r) : registry_(r) {}
+  [[nodiscard]] Entity GetEntity() const override { return Entity{}; }
+  [[nodiscard]] Registry* GetRegistry() const override { return registry_; }
+  [[nodiscard]] float GetDeltaTime() const override { return 0.016f; }
+  void* GetComponentPtr(EntityID) override { return nullptr; }
+
+ private:
+  Registry* registry_;
+};
+
+struct CollisionCounter {
+  std::uint64_t count = 0;
+  void OnCollision(CollisionEvent& /*e*/) { ++count; }
+};
+
+// CollisionSystem builds its own query and ignores the Iterable argument, but the call signature
+// requires one. begin()/end() are never invoked, so throwing stubs are safe placeholders.
+Iterable MakeUnusedIterable() {
+  return Iterable([]() -> AnyIterator { throw std::logic_error("unused"); },
+                  []() -> AnyIterator { throw std::logic_error("unused"); });
+}
+
+// Two boxes overlap at the origin (guaranteeing >=1 collision per cycle, so every collect emits an
+// event we can count); the rest sit on a wide diagonal grid, non-overlapping, to keep narrowphase
+// cheap and the dispatch overhead visible.
+void BuildBoxes(Registry& registry, int n) {
+  EntityMask mask;
+  mask.set(0);
+  for (int i = 0; i < n; ++i) {
+    Entity e = registry.CreateEntity();
+    const float p = (i < 2) ? 0.0f : static_cast<float>(i) * 64.0f;
+    registry.AddComponent(e, GlobalTransformComponent{glm::vec2(p, p), glm::vec2(1.0f, 1.0f), 0.0});
+    registry.AddComponent(e, BoxColliderComponent(32, 32, glm::vec2(0.0f, 0.0f), false, mask));
+    registry.AddComponent(e, EntityMaskComponent(mask));
+  }
+}
+}  // namespace
+
+static void BM_CollisionDispatch(benchmark::State& state) {
+  Registry registry;
+  EventBus bus;
+  CollisionCounter counter;
+  auto subscription = bus.SubscribeEvent<CollisionCounter, CollisionEvent>(&counter, &CollisionCounter::OnCollision);
+
+  EngineContext ec;
+  ec.eventBus = &bus;
+  registry.Set<EngineContext>(ec);
+
+  BuildBoxes(registry, static_cast<int>(state.range(0)));
+
+  CollisionSystem system;
+  StubContext impl(&registry);
+  const ContextFacade ctx(&impl);
+  const Iterable iter = MakeUnusedIterable();
+
+  // Each timed iteration advances exactly one full dispatch->collect cycle: the system polls the
+  // outstanding future (cheap early-returns) until it is ready, collects + emits (bumping the
+  // counter), and re-dispatches for the next iteration.
+  for (auto _ : state) {
+    const std::uint64_t before = counter.count;
+    do {
+      system(ctx, iter);
+    } while (counter.count == before);
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()));
+}
+BENCHMARK(BM_CollisionDispatch)->Range(8, 512)->UseRealTime();

--- a/tests/benchmarks/TextCacheBenchmark.cpp
+++ b/tests/benchmarks/TextCacheBenchmark.cpp
@@ -1,0 +1,96 @@
+#include <benchmark/benchmark.h>
+
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+// Head-to-head micro-bench for the RenderTextSystem cache-key change. The old path rebuilt a
+// "fontId|text|color" std::string every frame for every visible label (even on a cache hit) and
+// looked it up in an unordered_map<string>. The new path keys the cache by entity id and only
+// touches the (fontId, text, color) fields to decide whether to re-rasterize. This measures the
+// steady-state (cache-hit) per-label lookup cost of each strategy for N on-screen labels.
+//
+// This is an in-build A/B of the two lookup strategies — it does not rely on the with/without
+// source toggle, since both strategies live side by side here. It isolates the CPU the change
+// removes (the per-frame string build + hash). The change's other benefit — bounding GPU texture
+// memory for text that changes every frame — is a memory property, not a CPU metric, so it is out
+// of scope for this bench.
+
+namespace {
+struct Label {
+  std::uint32_t entity;
+  std::string fontId;
+  std::string text;
+  std::uint32_t color;
+};
+
+struct ContentEntry {
+  float width;
+  float height;
+};
+
+struct EntityEntry {
+  std::string fontId;
+  std::string text;
+  std::uint32_t color;
+  float width;
+  float height;
+};
+
+// Representative UI labels: a shared font id and short, distinct strings (the realistic "Score:
+// 1234" / "HP: 87" shape), each owned by a distinct entity.
+std::vector<Label> MakeLabels(int n) {
+  std::vector<Label> labels;
+  labels.reserve(static_cast<std::size_t>(n));
+  for (int i = 0; i < n; ++i) {
+    labels.push_back(
+        Label{static_cast<std::uint32_t>(i), "main-font", "Score: " + std::to_string(1000 + i), 0xFFFFFFFFu});
+  }
+  return labels;
+}
+}  // namespace
+
+// Old strategy: concatenate the content key every frame, then look it up in a string-keyed map.
+static void BM_TextCache_ContentKeyed(benchmark::State& state) {
+  const int n = static_cast<int>(state.range(0));
+  const std::vector<Label> labels = MakeLabels(n);
+
+  std::unordered_map<std::string, ContentEntry> cache;
+  for (const auto& l : labels) {
+    cache[l.fontId + "|" + l.text + "|" + std::to_string(l.color)] = ContentEntry{16.0f, 16.0f};
+  }
+
+  for (auto _ : state) {
+    for (const auto& l : labels) {
+      const std::string key = l.fontId + "|" + l.text + "|" + std::to_string(l.color);
+      auto it = cache.find(key);
+      benchmark::DoNotOptimize(it->second);
+    }
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) * n);
+}
+BENCHMARK(BM_TextCache_ContentKeyed)->Range(8, 1024);
+
+// New strategy: look up by entity id, then confirm the cached (fontId, text, color) still match.
+static void BM_TextCache_EntityKeyed(benchmark::State& state) {
+  const int n = static_cast<int>(state.range(0));
+  const std::vector<Label> labels = MakeLabels(n);
+
+  std::unordered_map<std::uint32_t, EntityEntry> cache;
+  for (const auto& l : labels) {
+    cache[l.entity] = EntityEntry{l.fontId, l.text, l.color, 16.0f, 16.0f};
+  }
+
+  for (auto _ : state) {
+    for (const auto& l : labels) {
+      auto it = cache.find(l.entity);
+      bool fresh = it != cache.end() && it->second.color == l.color && it->second.fontId == l.fontId &&
+                   it->second.text == l.text;
+      benchmark::DoNotOptimize(fresh);
+      benchmark::DoNotOptimize(it->second);
+    }
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) * n);
+}
+BENCHMARK(BM_TextCache_EntityKeyed)->Range(8, 1024);

--- a/tests/benchmarks/TextCacheBenchmark.cpp
+++ b/tests/benchmarks/TextCacheBenchmark.cpp
@@ -19,23 +19,23 @@
 
 namespace {
 struct Label {
-  std::uint32_t entity;
+  std::uint32_t entity = 0;
   std::string fontId;
   std::string text;
-  std::uint32_t color;
+  std::uint32_t color = 0;
 };
 
 struct ContentEntry {
-  float width;
-  float height;
+  float width = 0.0F;
+  float height = 0.0F;
 };
 
 struct EntityEntry {
   std::string fontId;
   std::string text;
-  std::uint32_t color;
-  float width;
-  float height;
+  std::uint32_t color = 0;
+  float width = 0.0F;
+  float height = 0.0F;
 };
 
 // Representative UI labels: a shared font id and short, distinct strings (the realistic "Score:


### PR DESCRIPTION
Cleanup pass after the Stages 6–13 refactor. The codebase was in good shape; this addresses a small, concrete set of findings from a review. Each commit is self-contained.

## Performance

**Dispatch CollisionSystem detection on the persistent ThreadPool.** The async collision cycle used `std::async(std::launch::async)`, which creates and joins a fresh OS thread every detection cycle on libstdc++. It now submits to the process-wide `ThreadPool` (the pool whose header comment already says it exists to replace exactly these calls), carrying the result back via a shared `std::promise` through the same polling the caller used.

**Key the RenderText cache by entity instead of by content string.** The cache was keyed by a `fontId|text|color` string rebuilt every frame per label (even on hits) and never evicted — text that changes each frame (a score/timer) rasterized a new texture per frame and leaked the old one, growing GPU memory without bound. It is now entity-keyed (mirroring `SpriteRenderCache`/`AudioTrackCache`), re-rasterizing only when the label's content changes and freeing the prior texture. Steady-state lookups no longer allocate; memory is bounded to one texture per text entity.

## Cleanup

- **Rename HealthComponent methods to PascalCase** (`Damage/Heal/IsDead/Fraction`) to match the convention. The Lua-facing binding keys are unchanged, so the script API and the `components.json` drift gate are unaffected.
- **Widen entity generation to 32 bits and fix its stale TODO.** Recycling was already implemented (generation bump on blam + compare on validate); the comment wrongly implied otherwise. The only residual was a 16-bit counter that could wrap after 65535 reuses of one slot — now `uint32_t`.

## Benchmarks

Added `BM_CollisionDispatch` (drives the real system through complete dispatch→collect cycles) and `BM_TextCache_*` (in-build A/B of the old vs new cache key). Both behind the existing `OCTARINE_ENABLE_BENCHMARKS` option (off by default).

Measured (Release, `-O3 -march=x86-64-v3`, 10 reps), with vs without each change:

| Bench | Before | After | Δ |
|---|---|---|---|
| CollisionDispatch / 8 boxes | 21.8 µs/cycle | 5.1 µs/cycle | −76.6% |
| CollisionDispatch / 64 | 24.9 µs | 8.3 µs | −66.6% |
| CollisionDispatch / 512 | 78.2 µs | 63.6 µs | −18.6% |
| TextCache lookup (per batch, all sizes) | — | — | ≈ −89% (~9× faster) |

The collision saving is a near-constant ~15–17 µs/cycle — the cost of one thread spawn — so it dominates at low box counts and shrinks as detection work grows. The text-cache win is the removed per-frame string build.

## Verification

`scripts/octarine-verify.sh --full` green: configure, build, 12/12 ctests (incl. `LuaBehaviorTest` exercising `health.damage`/`heal` through Lua), headless bake smoke, Lua-API drift (no drift), clang-tidy, clang-format.