### PR TITLE
Add dev-only headless frame capture for bench screenshots

### DIFF
--- a/events.json
+++ b/events.json
@@ -84,13 +84,13 @@
       "emit_sites": [
         {
           "file": "src/Engine/FrameLoop.cpp",
-          "line": 72
+          "line": 103
         }
       ],
       "subscribe_sites": [
         {
           "file": "src/Engine/FrameLoop.cpp",
-          "line": 44,
+          "line": 75,
           "owner": "FrameLoop"
         },
         {
@@ -113,7 +113,7 @@
       "emit_sites": [
         {
           "file": "src/Engine/FrameLoop.cpp",
-          "line": 78
+          "line": 109
         }
       ],
       "subscribe_sites": [
@@ -146,7 +146,7 @@
       "emit_sites": [
         {
           "file": "src/Engine/FrameLoop.cpp",
-          "line": 82
+          "line": 113
         }
       ],
       "subscribe_sites": [

--- a/src/Engine/FrameLoop.cpp
+++ b/src/Engine/FrameLoop.cpp
@@ -4,6 +4,7 @@
 #include <SDL3_mixer/SDL_mixer.h>
 
 #include <algorithm>
+#include <cstdlib>
 
 #include "Components/ViewportInfo.h"
 #include "ECS/Registry.h"
@@ -16,6 +17,7 @@
 #include "Game/Game.h"
 #include "Game/GameConfig.h"
 #include "General/Constants.h"
+#include "General/Logger.h"
 #include "General/PerfUtils.h"
 #include "Lua/HotReload/ScriptHotReload.h"
 #include "Renderer/RenderQueue.h"
@@ -33,11 +35,40 @@
 #include "imgui_impl_sdl3.h"
 #endif
 
+#ifndef OCTARINE_SHIPPED
+namespace {
+// Portable env read. MSVC deprecates std::getenv (C4996) and the build treats warnings as errors,
+// so use _dupenv_s there — mirrors the split in Lua/LuaApiManifest.cpp. Returns "" when unset.
+std::string GetEnvVar(const char* name) {
+#ifdef _MSC_VER
+  char* value = nullptr;
+  size_t len = 0;
+  const bool ok = _dupenv_s(&value, &len, name) == 0 && value != nullptr;
+  const std::string result = ok ? std::string(value) : std::string();
+  free(value);
+  return result;
+#else
+  const char* value = std::getenv(name);
+  return value ? std::string(value) : std::string();
+#endif
+}
+}  // namespace
+#endif
+
 FrameLoop::FrameLoop(Game* game, Registry* registry, EventBus* eventBus, Renderer* renderer, EngineRuntime* runtime,
                      sol::state& lua)
     : game_(game), registry_(registry), event_bus_(eventBus), renderer_(renderer), runtime_(runtime), lua_(lua) {
   // Pre-build the debug-collider query once so we don't allocate per render frame.
   collider_query_ = registry_->CreateQuery<GlobalTransformComponent, BoxColliderComponent>();
+
+#ifndef OCTARINE_SHIPPED
+  if (const std::string path = GetEnvVar("OCTARINE_CAPTURE_PATH"); !path.empty()) {
+    capture_path_ = path;
+    if (const std::string frame = GetEnvVar("OCTARINE_CAPTURE_FRAME"); !frame.empty()) {
+      capture_frame_ = std::stol(frame);
+    }
+  }
+#endif
 }
 
 void FrameLoop::SubscribeToEvents() {
@@ -226,6 +257,20 @@ void FrameLoop::Render([[maybe_unused]] const float deltaTime) {
   // alongside TIMER lines. All systems for this frame have already written their values.
   PROFILE_COUNTERS_REPORT();
   renderQueue.Clear();
+
+#ifndef OCTARINE_SHIPPED
+  // Headless capture: once the target frame is reached, write the rendered scene to disk and quit.
+  if (!capture_path_.empty() && !capture_done_) {
+    if (frame_index_ >= capture_frame_) {
+      if (renderer_->CaptureScene(runtime_->SdlRenderer(), capture_path_)) {
+        Logger::Info("FrameLoop: captured frame " + std::to_string(frame_index_) + " to " + capture_path_);
+      }
+      capture_done_ = true;
+      Game::Quit();
+    }
+    ++frame_index_;
+  }
+#endif
 }
 
 float FrameLoop::WaitTime() {

--- a/src/Engine/FrameLoop.h
+++ b/src/Engine/FrameLoop.h
@@ -4,6 +4,7 @@
 
 #include <memory>
 #include <sol/sol.hpp>
+#include <string>
 
 #include "Components/BoxColliderComponent.h"
 #include "Components/GlobalTransformComponent.h"
@@ -67,4 +68,16 @@ class FrameLoop {
   Uint64 milliseconds_previous_frame_ = 0;
   std::unique_ptr<ComponentQuery<GlobalTransformComponent, BoxColliderComponent>> collider_query_;
   EventBus::SubscriptionHandle key_input_subscription_;
+
+#ifndef OCTARINE_SHIPPED
+  // Headless frame-capture (env-driven, dev/bench only). When OCTARINE_CAPTURE_PATH is set, the
+  // loop renders up to OCTARINE_CAPTURE_FRAME (default 180 ≈ 3s @60fps, past the stress warmup),
+  // writes that frame's scene texture to the path as BMP, then quits. Lets a headless run produce
+  // a viewable rendered frame.
+  static constexpr long kDefaultCaptureFrame = 180;  // ≈3s @60fps, past the stress warmup
+  std::string capture_path_;
+  long capture_frame_ = kDefaultCaptureFrame;
+  long frame_index_ = 0;
+  bool capture_done_ = false;
+#endif
 };

--- a/src/Renderer/Renderer.cpp
+++ b/src/Renderer/Renderer.cpp
@@ -48,6 +48,31 @@ void Renderer::CompositeSceneToWindow(SDL_Renderer* sdlRenderer) const {
 
 void Renderer::Present(SDL_Renderer* sdlRenderer) const { SDL_RenderPresent(sdlRenderer); }
 
+#ifndef OCTARINE_SHIPPED
+bool Renderer::CaptureScene(SDL_Renderer* sdlRenderer, const std::string& path) const {
+  if (scene_texture_ == nullptr) {
+    Logger::Error("Renderer::CaptureScene: no scene texture to capture");
+    return false;
+  }
+  // Read back from the scene target (the off-screen texture the frame was drawn into). In bench
+  // mode the window backbuffer is never composited, so the scene texture is the only place the
+  // rendered frame lives.
+  SDL_SetRenderTarget(sdlRenderer, scene_texture_);
+  SDL_Surface* surface = SDL_RenderReadPixels(sdlRenderer, nullptr);
+  SDL_SetRenderTarget(sdlRenderer, nullptr);
+  if (surface == nullptr) {
+    Logger::Error("Renderer::CaptureScene SDL_RenderReadPixels failed: " + std::string(SDL_GetError()));
+    return false;
+  }
+  const bool ok = SDL_SaveBMP(surface, path.c_str());
+  if (!ok) {
+    Logger::Error("Renderer::CaptureScene SDL_SaveBMP failed: " + std::string(SDL_GetError()));
+  }
+  SDL_DestroySurface(surface);
+  return ok;
+}
+#endif
+
 void Renderer::DrawQueue(const RenderQueue& renderQueue, SDL_Renderer* renderer) const {
   for (const RenderKey& key : renderQueue) {
     switch (key.type) {

--- a/src/Renderer/Renderer.h
+++ b/src/Renderer/Renderer.h
@@ -2,6 +2,8 @@
 
 #include <SDL3/SDL.h>
 
+#include <string>
+
 #include "./RenderQueue.h"
 #include "AssetManager/AssetManager.h"
 
@@ -59,6 +61,14 @@ class Renderer {
   // Hand the editor / RenderDebugGUI access to the texture they composite into the Scene
   // window. Returns nullptr when CreateScene never ran (headless / bake / pre-Init paths).
   [[nodiscard]] SDL_Texture* GetSceneTexture() const { return scene_texture_; }
+
+#ifndef OCTARINE_SHIPPED
+  // Dev/headless capture: read the scene texture back to a surface and write it to `path` as a
+  // BMP. Lets a headless run (SDL_VIDEODRIVER=dummy, software renderer) produce a viewable frame
+  // of what was rendered. Returns false (and logs) if there's no scene texture, the readback
+  // fails, or the write fails. Not compiled into shipped builds.
+  bool CaptureScene(SDL_Renderer* sdlRenderer, const std::string& path) const;
+#endif
 
  private:
   SDL_Texture* scene_texture_ = nullptr;


### PR DESCRIPTION
## What

Adds a dev/bench-only headless frame capture so a display-less run can produce a viewable image of what was rendered.

- `Renderer::CaptureScene` — `SDL_RenderReadPixels` of the scene render target → `SDL_SaveBMP`.
- `FrameLoop` drives it via env vars `OCTARINE_CAPTURE_PATH` and `OCTARINE_CAPTURE_FRAME` (default frame 180): render up to the target frame, write the scene texture to disk, then quit.
- Gated `#ifndef OCTARINE_SHIPPED` — never compiled into shipped builds.

## Why

Under `SDL_VIDEODRIVER=dummy` the engine still rasterizes via SDL's software renderer, but there was no way to see the result. This makes headless stress/benchmark runs inspectable — e.g. confirming a stress scene actually renders thousands of sprites on CI or in a container.

## Usage

```bash
SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy \
  OCTARINE_CAPTURE_PATH=/tmp/frame.bmp OCTARINE_CAPTURE_FRAME=240 \
  build/player-profile/bin/relwithdebinfo/OctarineEngine-player <game-dir> --startup-mode stress
```

## Testing

- `scripts/octarine-verify.sh --full`: editor-release configure/build green, **ctest 12/12**, bake smoke OK, Lua-API drift clean, clang-tidy + clang-format clean.
- Compiles in both `player-profile` (ImGui off) and `editor-release` (ImGui on).
- Verified end-to-end: captured a rendered ~2700-entity stress frame headlessly.

One concern per PR: this is just the engine capability. The example-project scene wiring that exercises it is tracked separately.