### PR TITLE
Consume sol2_ImGui_Bindings as a prebuilt vcpkg port

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "libs/sol2_ImGui_Bindings"]
-	path = libs/sol2_ImGui_Bindings
-	url = https://github.com/mblackman/sol2_ImGui_Bindings

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,10 +149,12 @@ if (OCTARINE_SHIPPED)
     message(STATUS "Octarine: SHIPPED build — asset catalog loads baked manifest (no scan)")
 endif ()
 
-# Vendored ImGui binding lib lives outside src/ so it stays untouched by the layer split. Only
-# meaningful when ImGui is on; pulled in PUBLIC by octarine_editor.
+# sol2 ImGui binding lib: consumed as a prebuilt, binary-cached vcpkg port
+# (vcpkg-overlay-ports/sol2-imgui-bindings) instead of an in-tree submodule + add_subdirectory, so
+# a clean build restores it from the vcpkg binary cache rather than recompiling the heavy generated
+# TUs. Only meaningful when ImGui is on; pulled in PUBLIC by octarine_editor.
 if (OCTARINE_WITH_IMGUI)
-    add_subdirectory(libs/sol2_ImGui_Bindings)
+    find_package(sol2_ImGui_Bindings CONFIG REQUIRED)
 endif ()
 
 # Standard compile flags + warnings, packaged as one helper so every static lib + the exe pick up

--- a/cmake/octarine-licenses.cmake
+++ b/cmake/octarine-licenses.cmake
@@ -82,6 +82,12 @@ function(_octarine_licenses_required_from_vcpkg OUT_VAR ENGINE_ROOT)
                     set(_plat_matches FALSE)
                 elseif (_plat STREQUAL "osx" AND NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
                     set(_plat_matches FALSE)
+                elseif (_plat STREQUAL "android" AND NOT CMAKE_SYSTEM_NAME STREQUAL "Android")
+                    set(_plat_matches FALSE)
+                elseif (_plat STREQUAL "!android" AND CMAKE_SYSTEM_NAME STREQUAL "Android")
+                    # sol2-imgui-bindings is excluded from Android (ImGui is forced off there), so
+                    # its license must not be required on the Android leg.
+                    set(_plat_matches FALSE)
                 endif ()
                 if (NOT _plat_matches)
                     continue()

--- a/cmake/octarine-licenses.cmake
+++ b/cmake/octarine-licenses.cmake
@@ -48,7 +48,7 @@ set(_OCTARINE_LICENSES_SKIP_REQUIRED
 #     features so this loop is a no-op — wired ahead of time to stay drift-free.
 #
 # Sets <OUT_VAR> in PARENT_SCOPE.
-function(_octarine_licenses_required_from_vcpkg OUT_VAR ENGINE_ROOT)
+function(_octarine_licenses_required_from_vcpkg OUT_VAR ENGINE_ROOT TRIPLET)
     set(_manifest "${ENGINE_ROOT}/vcpkg.json")
     if (NOT EXISTS "${_manifest}")
         message(FATAL_ERROR "octarine_collect_licenses: vcpkg.json not found at ${_manifest}; "
@@ -73,6 +73,11 @@ function(_octarine_licenses_required_from_vcpkg OUT_VAR ENGINE_ROOT)
             # triplet, so requiring its license here would falsely fail packaging on macOS /
             # Windows. Only the qualifiers this manifest actually uses are evaluated; an
             # unrecognized expression falls through as "required" (the safe default).
+            #
+            # linux/windows/osx are matched on CMAKE_SYSTEM_NAME (set at desktop configure time).
+            # android/!android are matched on the vcpkg TRIPLET instead: this aggregator also runs
+            # under `cmake -P scripts/run-licenses.cmake` (the Android/iOS path), where CMAKE_SYSTEM_NAME
+            # is not the target — but the triplet (e.g. arm64-android) always is.
             string(JSON _plat ERROR_VARIABLE _plat_err GET "${_manifest_json}" dependencies ${_i} platform)
             if (NOT _plat_err AND _plat)
                 set(_plat_matches TRUE)
@@ -82,9 +87,9 @@ function(_octarine_licenses_required_from_vcpkg OUT_VAR ENGINE_ROOT)
                     set(_plat_matches FALSE)
                 elseif (_plat STREQUAL "osx" AND NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
                     set(_plat_matches FALSE)
-                elseif (_plat STREQUAL "android" AND NOT CMAKE_SYSTEM_NAME STREQUAL "Android")
+                elseif (_plat STREQUAL "android" AND NOT TRIPLET MATCHES "android")
                     set(_plat_matches FALSE)
-                elseif (_plat STREQUAL "!android" AND CMAKE_SYSTEM_NAME STREQUAL "Android")
+                elseif (_plat STREQUAL "!android" AND TRIPLET MATCHES "android")
                     # sol2-imgui-bindings is excluded from Android (ImGui is forced off there), so
                     # its license must not be required on the Android leg.
                     set(_plat_matches FALSE)
@@ -177,7 +182,7 @@ function(octarine_collect_licenses OUT_FILE)
         get_filename_component(OCL_ENGINE_ROOT "${_OCTARINE_LICENSES_SCRIPT_DIR}/.." ABSOLUTE)
     endif ()
     if (NOT OCL_REQUIRED_PORTS)
-        _octarine_licenses_required_from_vcpkg(OCL_REQUIRED_PORTS "${OCL_ENGINE_ROOT}")
+        _octarine_licenses_required_from_vcpkg(OCL_REQUIRED_PORTS "${OCL_ENGINE_ROOT}" "${OCL_TRIPLET}")
     endif ()
 
     if (NOT OCL_TRIPLET)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -198,7 +198,7 @@ if (OCTARINE_WITH_IMGUI OR OCTARINE_WITH_EDITOR)
             octarine_systems
     )
     if (OCTARINE_WITH_IMGUI)
-        target_link_libraries(octarine_editor PUBLIC imgui::imgui sol2_ImGui_Bindings)
+        target_link_libraries(octarine_editor PUBLIC imgui::imgui sol2_ImGui_Bindings::sol2_ImGui_Bindings)
     endif ()
     # SecretStore backend libs. Crypt32 ships DPAPI's CryptProtectData/CryptUnprotectData on
     # Windows; Security.framework ships SecItem* on macOS. Linux backend is a stub and needs no

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -3,5 +3,8 @@
     "kind": "git",
     "baseline": "cf9b6f1a47898a888f9e86e346a9adfa68357380",
     "repository": "https://github.com/microsoft/vcpkg"
-  }
+  },
+  "overlay-ports": [
+    "vcpkg-overlay-ports"
+  ]
 }

--- a/vcpkg-overlay-ports/sol2-imgui-bindings/portfile.cmake
+++ b/vcpkg-overlay-ports/sol2-imgui-bindings/portfile.cmake
@@ -1,0 +1,28 @@
+# Octarine overlay port: the engine's own sol2 ImGui bindings, consumed as a
+# prebuilt (binary-cached) static lib instead of an in-tree submodule + add_subdirectory.
+# Pinned to a tagged release (vX.Y.Z-<rev>; see the bindings repo CONTRIBUTING.md).
+# To bump: change REF to the new tag and update SHA512 to the matching
+# https://github.com/mblackman/sol2_ImGui_Bindings/archive/<tag>.tar.gz hash
+# (run `vcpkg install` once with a wrong hash and paste the "Actual hash" it prints).
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO mblackman/sol2_ImGui_Bindings
+    REF v1.92.7-1   # X.Y.Z = targeted Dear ImGui version (== this port's version); -<rev> = binding revision
+    SHA512 12bda9c9c05d9eca1eab329f37835cc2ef73b2b867e1e140238f3b9c4c6fe08548c6febcb8efa34e159dc428d77d4e0721e1c14fff87bc4a04285b805d0cd1d1
+    HEAD_REF main
+)
+
+# The bindings' CMake ships install() + EXPORT + a find_package config (gated by
+# SOL2_IMGUI_BINDINGS_INSTALL, on by default when standalone). Tests stay off.
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DSOL2_IMGUI_BINDINGS_INSTALL=ON
+        -DSOL2_IMGUI_BINDINGS_BUILD_TESTS=OFF
+)
+vcpkg_cmake_install()
+
+# Bindings install their config to lib/cmake/sol2_ImGui_Bindings; relocate to share/.
+vcpkg_cmake_config_fixup(PACKAGE_NAME sol2_ImGui_Bindings CONFIG_PATH lib/cmake/sol2_ImGui_Bindings)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/vcpkg-overlay-ports/sol2-imgui-bindings/vcpkg.json
+++ b/vcpkg-overlay-ports/sol2-imgui-bindings/vcpkg.json
@@ -1,0 +1,25 @@
+{
+  "name": "sol2-imgui-bindings",
+  "version": "1.92.7",
+  "description": "sol2 Lua bindings for Dear ImGui, generated from ImGui metadata.",
+  "homepage": "https://github.com/mblackman/sol2_ImGui_Bindings",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "imgui",
+      "features": [
+        "docking-experimental"
+      ]
+    },
+    "sol2",
+    "lua",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -70,6 +70,10 @@
       "version>=": "3.5.0"
     },
     {
+      "name": "sol2-imgui-bindings",
+      "platform": "!android"
+    },
+    {
       "name": "spdlog",
       "version>=": "1.15.3"
     }


### PR DESCRIPTION
## Why

The sol2 ImGui bindings are heavy sol2 template instantiations (the generated `sol_ImGui_gen_*.cpp` TUs). Consumed via `add_subdirectory(libs/sol2_ImGui_Bindings)`, they were recompiled on every clean build. This switches the engine to consume them as a **binary-cached vcpkg port** pinned to a tagged release, so a clean configure restores the cached static lib instead of rebuilding it.

vcpkg keys the binary cache on an ABI hash (compiler, flags, and the resolved imgui/sol2/lua versions), so bumping any of those auto-invalidates the cache — no stale-ABI risk, which is the property hand-distributed prebuilt `.a` files can't give.

Depends on the bindings release **`v1.92.7-1`** (mblackman/sol2_ImGui_Bindings), created via that repo's new tag-driven release workflow.

## Changes

- **`vcpkg-overlay-ports/sol2-imgui-bindings/`** — new overlay port. `portfile.cmake` pins the release tarball (`vcpkg_from_github REF v1.92.7-1`, SHA512 verified) and reuses the bindings' own `install()`/`EXPORT` config. Build-time deps: `imgui[docking-experimental]`, `sol2`, `lua` (headers only — the lua lib is linked by the engine).
- **`vcpkg-configuration.json`** — register the `vcpkg-overlay-ports` dir so the port resolves in every build (presets, CLion, CI).
- **`vcpkg.json`** — add the `sol2-imgui-bindings` dep, gated `!android` (ImGui is forced off on Android).
- **`CMakeLists.txt` / `src/CMakeLists.txt`** — `find_package(sol2_ImGui_Bindings CONFIG REQUIRED)` + the namespaced target `sol2_ImGui_Bindings::sol2_ImGui_Bindings` replace `add_subdirectory` + the plain target. The submodule and `.gitmodules` are removed.
- **`cmake/octarine-licenses.cmake`** — honor `android`/`!android` platform qualifiers so the license-required gate matches where the port is actually installed (avoids a false failure on the Android leg).

## Verification (local)

- The port builds + installs against the engine's vcpkg baseline: static lib (debug+release), headers, relocated `find_package` config, and `copyright` (license gate satisfied).
- A `find_package` consumer compiles a bare `#include "sol_ImGui.h"` TU and **links `sol_ImGui::Init` against the prebuilt static lib** into a working executable.
- Full multi-platform engine build is left to CI.

## Trade-off

The in-tree edit→rebuild loop for the bindings is gone; iterating on a binding change now means cutting a new `vX.Y.Z-<rev>` release and bumping the port's `REF`/`SHA512` (documented in the portfile). Worth it for not recompiling the bindings on every clean build.