### PR TITLE
Move bulk auto-fire from per-entity Lua into ProjectileEmitSystem (perf W1)

### DIFF
--- a/src/Components/ProjectileEmitterComponent.h
+++ b/src/Components/ProjectileEmitterComponent.h
@@ -22,8 +22,11 @@ struct ProjectileEmitterComponent {
   // leaves the pooled projectile's existing name in place (default-constructed empty).
   std::string projectileName;
 
+  // t_frequency defaults to 0 == auto-fire OFF. The engine ProjectileEmitSystem tick only fires
+  // emitters with frequency > 0; a positive value opts an emitter into engine-driven auto-fire
+  // (interval in seconds). Scenes that drive firing manually via fire_projectile leave it at 0.
   explicit ProjectileEmitterComponent(const glm::vec2 t_velocity = glm::vec2(0, 0), const float t_duration = 1.0f,
-                                      const float t_frequency = 1.0f, const int t_damage = 10,
+                                      const float t_frequency = 0.0f, const int t_damage = 10,
                                       const EntityMask t_collisionMask = Constants::kDefaultEntityMask,
                                       const EntityMask t_projectileMask = EntityMask{},
                                       std::string t_projectileName = {})

--- a/src/Game/Game.cpp
+++ b/src/Game/Game.cpp
@@ -70,6 +70,7 @@
 #include "Systems/InputSystem.h"
 #include "Systems/ObstacleBounceSystem.h"
 #include "Systems/OffScreenDespawnSystem.h"
+#include "Systems/ProjectileEmitSystem.h"
 #include "Systems/ProjectileLifecycleSystem.h"
 #include "Systems/RenderPrimitiveSystem.h"
 #include "Systems/RenderSpriteSystem.h"
@@ -552,10 +553,20 @@ void Game::Setup() {
   }
 
   registry_->RegisterParallelSystem<SpriteComponent, AnimationComponent>(AnimationSystem());
-  // ProjectileEmitSystem has no per-frame system pass anymore — gameplay drives shots via
-  // fire_projectile(...) in Lua. The instance is Set + Init'd earlier in Setup so GameModule
-  // can bind fire_projectile against it during module install.
   registry_->RegisterParallelSystem<ProjectileComponent>(ProjectileLifecycleSystem());
+
+  // Engine-side auto-fire: tick emitters whose frequency > 0 and spawn a projectile on expiry.
+  // This re-introduces the fixed-interval emit that auto_fire.lua had moved into per-entity Lua;
+  // running it in C++ removes one sol2 call per shooter per frame (ScriptSystem was ~56% of Update
+  // at stress scale). fire_projectile(...) from Lua still works for scripted/aimed firing — those
+  // emitters keep frequency 0 and are skipped here, so the two paths never double-fire one emitter.
+  //
+  // Serial (RegisterSystem, not parallel): the tick spawns into the registry. It is registered
+  // here, after InstallPoolAndProjectile Set + Init'd the canonical ProjectileEmitSystem, so the
+  // copy stored by the system list carries the initialized pool id. Placed before
+  // VelocityIntegrationSystem so freshly-spawned projectiles integrate/transform/collide this same
+  // frame — matching the spawn-timing the old ScriptSystem-driven Lua path had.
+  registry_->RegisterSystem<ProjectileEmitterComponent, PositionComponent>(registry_->Get<ProjectileEmitSystem>());
 
   // Integrate velocity into local position. Must run before TransformSystem so the hierarchy
   // resolves with the latest positions, and before CollisionSystem reads the global transforms.

--- a/src/Lua/Bindings/ProjectileEmitterComponentLuaBinding.h
+++ b/src/Lua/Bindings/ProjectileEmitterComponentLuaBinding.h
@@ -15,7 +15,10 @@ struct LuaBinding<ProjectileEmitterComponent> {
     const auto t = data.as<sol::table>();
     using namespace LuaComponentHelpers;
     const glm::vec2 projectileVelocity = SafeGetVec2(t, "projectile_velocity");
-    const auto repeatFrequency = SafeGetOptionalValue<float>(t, "repeat_frequency", 1.0f);
+    // repeat_frequency drives the engine ProjectileEmitSystem auto-fire tick (interval in seconds).
+    // Defaults to 0 == no auto-fire, so an emitter only auto-fires when a scene opts in with a
+    // positive value; omitting it leaves firing to manual fire_projectile / scripted logic.
+    const auto repeatFrequency = SafeGetOptionalValue<float>(t, "repeat_frequency", 0.0f);
     const auto projectileDuration = SafeGetOptionalValue<float>(t, "projectile_duration", 1.0f);
     const int projectileDamage = SafeGetOptionalValue<int>(t, "hit_damage", 10);
     const auto collisionMask = SafeGetOptionalValue<int>(t, "collision_mask", Constants::kDefaultEntityMask);

--- a/src/Systems/ProjectileEmitSystem.h
+++ b/src/Systems/ProjectileEmitSystem.h
@@ -13,6 +13,7 @@
 #include "Components/RotationComponent.h"
 #include "Components/ScaleComponent.h"
 #include "Components/SpriteComponent.h"
+#include "ECS/Context.h"
 #include "ECS/ECS.h"
 #include "ECS/Registry.h"
 #include "EntityPoolSystem.h"
@@ -50,6 +51,32 @@ class ProjectileEmitSystem {
       velocity = glm::normalize(direction) * emitterComp.velocity;
     }
     SpawnProjectile(registry, emitter, position.value, emitterComp, velocity);
+  }
+
+  // Per-frame auto-fire tick. Registered as a serial system over
+  // <ProjectileEmitterComponent, PositionComponent>; ticks each emitter's countDownTimer and
+  // spawns a projectile (along the emitter's configured velocity) when it expires, reloading the
+  // timer. This is the C++ re-introduction of the auto-fire loop that auto_fire.lua had taken over
+  // per entity — it removes one sol2 round-trip per shooter per frame, the dominant cost at scale.
+  //
+  // Opt-in: emitters with frequency <= 0 are skipped, so manual fire_projectile-driven emitters
+  // (player, scripted/aimed firing) are untouched. countDownTimer hard-resets to frequency
+  // (matching auto_fire.lua's `timer = interval`, not a drift-free accumulate), so a per-entity
+  // countDownTimer seed staggers the first shot exactly as the Lua initial_delay did.
+  //
+  // Serial, not parallel: SpawnProjectile mutates the registry (pool spawn) — the same reason
+  // ScriptSystem's fire path runs serially. Spawned projectiles land in a different (pooled)
+  // archetype, so iterating the emitter archetype here is not invalidated by the spawn.
+  void operator()(const ContextFacade& context, ProjectileEmitterComponent& emitter,
+                  const PositionComponent& position) const {
+    if (emitter.frequency <= 0.0f) {
+      return;
+    }
+    emitter.countDownTimer -= context.GetDeltaTime();
+    if (emitter.countDownTimer <= 0.0f) {
+      SpawnProjectile(*context.GetRegistry(), context.GetEntity(), position.value, emitter, emitter.velocity);
+      emitter.countDownTimer = emitter.frequency;
+    }
   }
 
  private:


### PR DESCRIPTION
First workstream (**W1**) of the performance plan: per-entity Lua auto-fire was the dominant CPU cost at scale (`ScriptSystem` ~56% of `Update` with 2k+ shooters), all of it `auto_fire.lua` crossing the C++→Lua boundary every frame just to decrement a timer. This moves that fixed-interval emit back into a C++ system.

## Changes
- **`ProjectileEmitSystem`** gains a serial per-entity `operator()` tick over `<ProjectileEmitterComponent, PositionComponent>` — decrements `countDownTimer`, spawns on expiry, reloads the timer. Registered in `Game::Setup` before `VelocityIntegrationSystem` so spawned projectiles integrate/transform/collide the same frame (matching the old Lua spawn timing). Serial, not parallel, because the spawn mutates the registry — the same reason `ScriptSystem`'s fire path runs serially.
- **`frequency` / `repeat_frequency` default flips `1.0 → 0` (auto-fire opt-in).** These fields were dead at runtime before this PR (only the editor inspector read them), so the flip is behaviour-preserving and prevents the engine tick from double-firing emitters that drive shots manually via `fire_projectile` (e.g. the player).

## Results (player-profile, headless stress scene, ~2074 shooters, warmup 3s)
Same binary, scene-data-only A/B (before = original Lua scene with the new tick idle; after = converted scene):

| metric | before | after | Δ |
|---|---|---|---|
| `Game::Update` mean | 2.41 ms | 1.52 ms | **−37%** |
| `Game::Update` p99 | 12.9 ms | 2.06 ms | **−84%** |
| `Game::Update` max | 36.5 ms | 2.40 ms | **−93%** (Lua-GC frame drops eliminated) |
| `ScriptSystem` mean | 1.29 ms | ~0 | eliminated |
| `ProjectileEmitSystem` mean | 0.12 ms (idle) | 0.38 ms (active) | +0.26 ms |

Pooling intact (factory spawns 0, ~347 reused/frame); headless frame capture confirms visual parity (full tank grid + bullets in flight). `clang-format` (18.1.8) clean; no tests reference the changed defaults.

## Companion change (separate repo)
Requires the matching `Octarine-Engine-Example` scene edits to exercise it: stress-test.lua / level1.lua drop their `auto_fire.lua` scripts and set `repeat_frequency` (+ `countdown_timer` for the stress stagger). `auto_fire.lua` is kept for any title that still wants a Lua-driven fire loop. Until that lands, existing scenes keep working unchanged (auto-fire defaults off).