### PR TITLE
docs: bindings are a vcpkg port, not a submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ reserved. FreeType is used under the terms of the FreeType License (FTL); see th
 
 - **CMake:** Version 3.15+
 - **C++ Compiler:** C++20 compliant (GCC 11+, Clang 13+, MSVC 2022+)
-- **vcpkg:** For managing dependencies.
-- **Git:** To clone the repo and submodules.
+- **vcpkg:** For managing dependencies (manifest mode — all deps, including the
+  sol2 ImGui bindings, are fetched and built by vcpkg on first configure).
+- **Git:** To clone the repository.
 
 ---
 

--- a/docs/device-builds.md
+++ b/docs/device-builds.md
@@ -488,7 +488,14 @@ overrides the stock `sol2` port. The NDK r28 clang (19.0.1) hits
 sol2 usertype member variables, failing the whole scripting surface. The
 overlay re-installs sol2 with the (optimization-only) `noexcept(…)` stripped
 from 10 call sites. One-time sol2 rebuild on first configure; nothing else
-changes. Desktop builds don't use the overlay.
+changes. This sol2 override is Android-only (it lives in
+`android/vcpkg-overlay-ports/sol2`); desktop builds don't apply it.
+
+Note this is separate from the top-level `vcpkg-overlay-ports/sol2-imgui-bindings`
+port, which *every* build (desktop included) pulls in via the `overlay-ports`
+entry in `vcpkg-configuration.json` — that's the engine's own sol2 ImGui bindings,
+consumed as a binary-cached vcpkg port pinned to a tagged release rather than an
+in-tree submodule.
 
 Do **not** toggle `SOL_NOEXCEPT_FUNCTION_TYPE=0` instead — desyncs sol2's
 traits from `__cpp_noexcept_function_type` and breaks differently.


### PR DESCRIPTION
Follow-up to #123. Brings the docs in line with the bindings now being consumed as a prebuilt vcpkg overlay port (submodule removed).

- **README.md** — Prerequisites no longer say to clone submodules; note that vcpkg (manifest mode) fetches/builds all deps, including the sol2 ImGui bindings, on first configure.
- **docs/device-builds.md** — Clarify that the Android sol2 `noexcept` overlay is Android-only and distinct from the top-level `vcpkg-overlay-ports/sol2-imgui-bindings` port, which every build (desktop included) now uses via `vcpkg-configuration.json`.

No code changes. Verified there are no other stale `submodule`/`--recurse-submodules` references in docs (QUICKSTART, CONTRIBUTING, android/README all clean; the only remaining "submodule" mention is the new device-builds text contrasting the port with the old in-tree submodule).