### PR TITLE
Batch collision response into one event per frame (perf W2.3)

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -22,12 +22,12 @@ API:
 
 ```cpp
 // Subscribe (typically in a system's Init/SubscribeToEvents) — store the handle as a member:
-subscription_ = eventBus->SubscribeEvent<DamageSystem, CollisionEvent>(this, &DamageSystem::OnCollision);
+subscription_ = eventBus->SubscribeEvent<DamageSystem, CollisionBatchEvent>(this, &DamageSystem::OnCollisionBatch);
 // ...where the class declares:  EventBus::SubscriptionHandle subscription_;
 // (use a std::vector<EventBus::SubscriptionHandle> when a system subscribes to several events).
 
 // Emit (from wherever the thing happens):
-eventBus->EmitEvent<CollisionEvent>(entityA, entityB);
+eventBus->EmitEvent<CollisionBatchEvent>(intersectingPairs);
 ```
 
 Subscriptions are wired once during startup (`Game::Setup`, each system's `Init` /
@@ -45,7 +45,7 @@ Subscriptions are wired once during startup (`Game::Setup`, each system's `Init`
 | Event | Payload | Emitted by | Subscribed by |
 |-------|---------|------------|---------------|
 | `AudioPlayEvent` | `clipId: string`, `volume: float` | Lua `play_sound()` (`AudioModuleLuaBinding.cpp`) | `AudioSystem::OnAudioPlay` |
-| `CollisionEvent` | `entityA: Entity`, `entityB: Entity` | `CollisionSystem` (narrowphase) | `DamageSystem::OnCollision`, `ObstacleBounceSystem::OnCollision` |
+| `CollisionBatchEvent` | `pairs: const std::vector<std::pair<Entity, Entity>>&` (the whole frame's overlapping pairs) | `CollisionSystem` (narrowphase) | `DamageSystem::OnCollisionBatch`, `ObstacleBounceSystem::OnCollisionBatch` |
 | `KeyInputEvent` | `inputKey: SDL_Keycode`, `inputModifier: SDL_Keymod`, `isPressed: bool` | `Game::ProcessInput` (SDL key events) | `InputSystem::OnKeyInput`, `FrameLoop::OnKeyInputEvent` |
 | `MouseInputEvent` | `event: SDL_MouseButtonEvent` | `Game::ProcessInput` (SDL mouse-button events) | `InputSystem::OnMouseInput`, `UIButtonSystem::OnMouseInput` |
 | `MouseWheelEvent` | `dx: float`, `dy: float` | `Game::ProcessInput` (SDL wheel events) | `InputSystem::OnMouseWheel` |
@@ -57,8 +57,10 @@ Event types live in `src/Events/`.
 - **Input:** SDL events → `Game::ProcessInput` emits `KeyInputEvent` / `MouseInputEvent` /
   `MouseWheelEvent` → `InputSystem` folds them into per-frame state (also `FrameLoop` for engine
   hotkeys, `UIButtonSystem` for clicks).
-- **Collision:** `CollisionSystem` detects overlaps and emits `CollisionEvent` → `DamageSystem` and
-  `ObstacleBounceSystem` react.
+- **Collision:** `CollisionSystem` detects overlaps and emits a single `CollisionBatchEvent` carrying
+  the whole frame's overlapping pairs → `DamageSystem` and `ObstacleBounceSystem` iterate the batch and
+  react. (One batched event per frame rather than one event per pair keeps the per-pair dispatch cost
+  off the bus at high collision density.)
 - **Audio:** Lua `play_sound(clip, volume)` emits `AudioPlayEvent` → `AudioSystem` plays the clip.
 
 ## Adding an event

--- a/docs/systems.md
+++ b/docs/systems.md
@@ -37,7 +37,7 @@ sections).
 | 5 | `VelocityIntegrationSystem` | parallel · `PositionComponent, RigidBodyComponent` | Integrates velocity into local position. Runs **before** transform resolution. |
 | 6 | `OffScreenDespawnSystem` | parallel · `PositionComponent, SpriteComponent` | Despawns non-player entities that leave the playable bounds. |
 | 7 | `TransformSystem` | bulk · `GlobalTransformComponent` (+ optional position/scale/rotation) | Resolves the entity hierarchy into world-space `GlobalTransformComponent`. Fast path when no `ChildOf` relationships exist. |
-| 8 | `CollisionSystem` | bulk · `GlobalTransformComponent, BoxColliderComponent, EntityMaskComponent` | Broadphase + OBB narrowphase; **emits `CollisionEvent`** for each overlapping pair. |
+| 8 | `CollisionSystem` | bulk · `GlobalTransformComponent, BoxColliderComponent, EntityMaskComponent` | Broadphase + OBB narrowphase; **emits one `CollisionBatchEvent`** carrying all overlapping pairs. |
 | 9 | `UpdateListenerTransformSystem` | bulk · `GlobalTransformComponent, AudioListenerComponent` | Snapshots the active listener's position/velocity for the spatial-audio chain. |
 | 10 | `AudioCullingSystem` | serial · `GlobalTransformComponent, AudioSourceComponent` | Gates spatial sources by listener radius (adds/removes the active tag + sink). |
 | 11 | `SpatialAudioSystem` | serial · `GlobalTransformComponent, AudioSourceComponent, AudioSinkComponent` | Distance attenuation + stereo pan for active spatial sources. |
@@ -65,8 +65,8 @@ events on the [event bus](events.md):
 
 | System | Reacts to | What it does |
 |--------|-----------|--------------|
-| `DamageSystem` | `CollisionEvent` | Applies projectile damage / health deduction and despawns. |
-| `ObstacleBounceSystem` | `CollisionEvent` | Bounces an entity off an obstacle and flips its sprite. |
+| `DamageSystem` | `CollisionBatchEvent` | Applies projectile damage / health deduction and despawns. |
+| `ObstacleBounceSystem` | `CollisionBatchEvent` | Bounces an entity off an obstacle and flips its sprite. |
 | `UIButtonSystem` | `MouseInputEvent` | Hit-tests clicks against button colliders and invokes callbacks. |
 
 ## Services and on-demand systems

--- a/events.json
+++ b/events.json
@@ -31,23 +31,14 @@
       ]
     },
     {
-      "name": "CollisionEvent",
+      "name": "CollisionBatchEvent",
       "kind": "class",
-      "source": "src/Events/CollisionEvent.h",
-      "fields": [
-        {
-          "type": "Entity",
-          "name": "entityA"
-        },
-        {
-          "type": "Entity",
-          "name": "entityB"
-        }
-      ],
+      "source": "src/Events/CollisionBatchEvent.h",
+      "fields": [],
       "emit_sites": [
         {
           "file": "src/Systems/CollisionSystem.h",
-          "line": 108
+          "line": 109
         }
       ],
       "subscribe_sites": [
@@ -58,7 +49,7 @@
         },
         {
           "file": "src/Systems/ObstacleBounceSystem.h",
-          "line": 20,
+          "line": 19,
           "owner": "ObstacleBounceSystem"
         }
       ]

--- a/src/Events/CollisionBatchEvent.h
+++ b/src/Events/CollisionBatchEvent.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "ECS/Entity.h"
+#include "EventBus/Event.h"
+
+// One event carrying the whole frame's intersecting-pair list, so collision-response subscribers
+// (DamageSystem, ObstacleBounceSystem) iterate the batch directly instead of paying per-pair
+// event-bus dispatch — a std::map<type_index> lookup + std::function indirection for *every* pair,
+// which dominated CollisionSystem at scale (~7.4 ms / frame at ~126k pairs).
+//
+// `pairs` is borrowed from the CollisionSystem result and is only valid for the duration of the
+// EmitEvent dispatch; subscribers must consume it synchronously and must not store the reference.
+class CollisionBatchEvent : public Event {
+ public:
+  const std::vector<std::pair<Entity, Entity>>& pairs;
+
+  explicit CollisionBatchEvent(const std::vector<std::pair<Entity, Entity>>& collisionPairs) : pairs(collisionPairs) {}
+};

--- a/src/Events/CollisionEvent.h
+++ b/src/Events/CollisionEvent.h
@@ -1,9 +1,0 @@
-#pragma once
-
-class CollisionEvent : public Event {
- public:
-  Entity entityA;
-  Entity entityB;
-
-  CollisionEvent(Entity a, Entity b) : entityA(a), entityB(b) {}
-};

--- a/src/Systems/CollisionSystem.h
+++ b/src/Systems/CollisionSystem.h
@@ -16,7 +16,7 @@
 #include "ECS/Registry.h"
 #include "Engine/EngineContext.h"
 #include "EventBus/EventBus.h"
-#include "Events/CollisionEvent.h"
+#include "Events/CollisionBatchEvent.h"
 #include "General/PerfUtils.h"
 #include "General/ThreadPool.h"
 
@@ -104,9 +104,9 @@ class CollisionSystem {
       PROFILE_NAMED_SCOPE("Emit Events");
       CollisionResult result = collisionResult_.get();
       PROFILE_COUNTER_SET("Collision: Intersecting pairs", static_cast<long long>(result.intersectingPairs.size()));
-      for (const auto& [fst, snd] : result.intersectingPairs) {
-        eventBus->EmitEvent<CollisionEvent>(fst, snd);
-      }
+      // One batched event instead of one EmitEvent per pair: subscribers iterate the vector
+      // directly, dropping a std::map lookup + std::function indirection for every pair (W2.3).
+      eventBus->EmitEvent<CollisionBatchEvent>(result.intersectingPairs);
       cachedBoxes_ = std::move(result.boxes);
       cachedBoxes_.clear();
     }

--- a/src/Systems/DamageSystem.h
+++ b/src/Systems/DamageSystem.h
@@ -4,7 +4,7 @@
 #include "Components/ProjectileComponent.h"
 #include "ECS/Iterable.h"
 #include "EventBus/EventBus.h"
-#include "Events/CollisionEvent.h"
+#include "Events/CollisionBatchEvent.h"
 
 class DamageSystem {
  public:
@@ -13,19 +13,20 @@ class DamageSystem {
     projectiles_ = registry_->Tag<ProjectileTag>();
     enemies_ = registry_->TagId("enemies");
     player_ = registry_->TagId("player");
-    subscription_ = eventBus->SubscribeEvent<DamageSystem, CollisionEvent>(this, &DamageSystem::OnCollision);
+    subscription_ = eventBus->SubscribeEvent<DamageSystem, CollisionBatchEvent>(this, &DamageSystem::OnCollisionBatch);
   }
 
-  void OnCollision(const CollisionEvent& event) {
-    const auto a = event.entityA;
-    const auto b = event.entityB;
+  // Process the whole frame's collision pairs in one call (W2.3): the per-pair tag logic is
+  // unchanged, but it no longer rides the event bus once per pair.
+  void OnCollisionBatch(const CollisionBatchEvent& event) {
+    for (const auto& [a, b] : event.pairs) {
+      if (registry_->HasTag(a, projectiles_) && (registry_->HasTag(b, player_) || registry_->HasTag(b, enemies_))) {
+        OnProjectileHit(a, b);
+      }
 
-    if (registry_->HasTag(a, projectiles_) && (registry_->HasTag(b, player_) || registry_->HasTag(b, enemies_))) {
-      OnProjectileHit(a, b);
-    }
-
-    if (registry_->HasTag(b, projectiles_) && (registry_->HasTag(a, player_) || registry_->HasTag(a, enemies_))) {
-      OnProjectileHit(b, a);
+      if (registry_->HasTag(b, projectiles_) && (registry_->HasTag(a, player_) || registry_->HasTag(a, enemies_))) {
+        OnProjectileHit(b, a);
+      }
     }
   }
 

--- a/src/Systems/ObstacleBounceSystem.h
+++ b/src/Systems/ObstacleBounceSystem.h
@@ -7,7 +7,7 @@
 #include "ECS/Entity.h"
 #include "ECS/Registry.h"
 #include "EventBus/EventBus.h"
-#include "Events/CollisionEvent.h"
+#include "Events/CollisionBatchEvent.h"
 #include "General/SpriteFlip.h"
 
 class ObstacleBounceSystem {
@@ -16,19 +16,19 @@ class ObstacleBounceSystem {
     registry_ = registry;
     enemies_ = registry_->TagId("enemies");
     obstacles_ = registry_->TagId("obstacles");
-    subscription_ =
-        eventBus->SubscribeEvent<ObstacleBounceSystem, CollisionEvent>(this, &ObstacleBounceSystem::OnCollision);
+    subscription_ = eventBus->SubscribeEvent<ObstacleBounceSystem, CollisionBatchEvent>(
+        this, &ObstacleBounceSystem::OnCollisionBatch);
   }
 
-  void OnCollision(const CollisionEvent& event) {
-    const Entity a = event.entityA;
-    const Entity b = event.entityB;
-
-    if (registry_->HasTag(a, enemies_) && registry_->HasTag(b, obstacles_)) {
-      OnObstacleCollision(a);
-    }
-    if (registry_->HasTag(b, enemies_) && registry_->HasTag(a, obstacles_)) {
-      OnObstacleCollision(b);
+  // Process the whole frame's collision pairs in one call (W2.3); per-pair logic unchanged.
+  void OnCollisionBatch(const CollisionBatchEvent& event) {
+    for (const auto& [a, b] : event.pairs) {
+      if (registry_->HasTag(a, enemies_) && registry_->HasTag(b, obstacles_)) {
+        OnObstacleCollision(a);
+      }
+      if (registry_->HasTag(b, enemies_) && registry_->HasTag(a, obstacles_)) {
+        OnObstacleCollision(b);
+      }
     }
   }
 

--- a/systems.json
+++ b/systems.json
@@ -62,7 +62,7 @@
       "setup_order": 7,
       "queried_components": [],
       "emits": [
-        "CollisionEvent"
+        "CollisionBatchEvent"
       ],
       "subscribes": [],
       "lua_surface": false
@@ -75,7 +75,7 @@
       "queried_components": [],
       "emits": [],
       "subscribes": [
-        "CollisionEvent"
+        "CollisionBatchEvent"
       ],
       "lua_surface": false
     },
@@ -136,7 +136,7 @@
       "queried_components": [],
       "emits": [],
       "subscribes": [
-        "CollisionEvent"
+        "CollisionBatchEvent"
       ],
       "lua_surface": false
     },

--- a/tests/benchmarks/CollisionSystemBenchmark.cpp
+++ b/tests/benchmarks/CollisionSystemBenchmark.cpp
@@ -12,7 +12,7 @@
 #include "ECS/Registry.h"
 #include "Engine/EngineContext.h"
 #include "EventBus/EventBus.h"
-#include "Events/CollisionEvent.h"
+#include "Events/CollisionBatchEvent.h"
 #include "Systems/CollisionSystem.h"
 
 // Micro-bench for the CollisionSystem async-dispatch path. The system hands each detection cycle
@@ -39,7 +39,9 @@ class StubContext final : public AnyContext {
 
 struct CollisionCounter {
   std::uint64_t count = 0;
-  void OnCollision(CollisionEvent& /*e*/) { ++count; }
+  // CollisionSystem emits one batched event per collect cycle; the overlapping pair guarantees
+  // pairs is non-empty, so count advances once per cycle (what the timing loop below keys on).
+  void OnCollisionBatch(const CollisionBatchEvent& e) { count += e.pairs.size(); }
 };
 
 // CollisionSystem builds its own query and ignores the Iterable argument, but the call signature
@@ -69,7 +71,8 @@ static void BM_CollisionDispatch(benchmark::State& state) {
   Registry registry;
   EventBus bus;
   CollisionCounter counter;
-  auto subscription = bus.SubscribeEvent<CollisionCounter, CollisionEvent>(&counter, &CollisionCounter::OnCollision);
+  auto subscription =
+      bus.SubscribeEvent<CollisionCounter, CollisionBatchEvent>(&counter, &CollisionCounter::OnCollisionBatch);
 
   EngineContext ec;
   ec.eventBus = &bus;


### PR DESCRIPTION
Collision workstream **W2.3** from the performance plan. `CollisionSystem` emitted one `CollisionEvent` *per intersecting pair*, and every `EmitEvent` paid a `std::map<type_index>` lookup + a `std::function` indirection into each subscriber. At collision-dense scale that per-pair bus dispatch is the dominant cost — **~7.4 ms/frame of `Emit Events` at ~126k pairs**.

> Note on the rest of W2: **W2.1 (mask pruning) was already implemented** (the `canInteract` gate in `Box::intersects`), and **review item D (inline broadphase) was measured as a regression** and dropped — see the plan doc. This PR is the genuine, measured collision win.

## Change
- New `CollisionBatchEvent` carries the whole frame's pair vector by `const&`. `CollisionSystem` emits it **once** instead of looping `EmitEvent` per pair.
- `DamageSystem` / `ObstacleBounceSystem` subscribe to it and iterate the batch in `OnCollisionBatch`. Their per-pair tag/damage/bounce logic is **unchanged**, so behavior is identical.
- `CollisionEvent` is now unused → removed. `systems.json`/`events.json` regenerated (the static drift gate), and the collision micro-benchmark + `docs/events.md`/`docs/systems.md` updated to match.

## Results (player-profile, headless, dense stress ~120k pairs)
| metric | before | after | Δ |
|---|---|---|---|
| `Emit Events` mean | 7.39 ms | 6.18 ms | **−16%** |
| `CollisionSystem` mean | 8.02 ms | 6.95 ms | −13% |

The residual ~6 ms is the handler `HasTag` work (per pair) — irreducible short of **parallelizing** the response, which is unsafe here (multiple pairs mutate the same entity's health / queue despawns). That's a possible future follow-up, not this PR.

## Correctness
Behavior-preserving and verified headless: normal stress (step 32) max intersecting pairs **639** and pool park/spawn match the pre-change run; level1 main mode runs clean (projectiles still hit/despawn), **no errors**. The migrated `BM_CollisionDispatch` benchmark builds and runs. `clang-format` (18.1.8) clean on all changed files.