### PR TITLE
Parallelize the collision-response pass above a density threshold

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -454,6 +454,7 @@ if (OCTARINE_ENABLE_TESTS)
     octarine_add_core_test(OctarineEcsTest EcsRegistryTest tests/EcsRegistryTest.cpp)
     octarine_add_core_test(OctarineEcsHierarchyTest EcsHierarchyTest tests/EcsHierarchyTest.cpp)
     octarine_add_core_test(OctarineSystemLogicTest SystemLogicTest tests/SystemLogicTest.cpp)
+    octarine_add_core_test(OctarineCollisionResponseTest CollisionResponseTest tests/CollisionResponseTest.cpp)
 
     # EventBus is header-only; it needs Logger for its construction log lines, nothing else.
     add_executable(OctarineEventBusTest

--- a/events.json
+++ b/events.json
@@ -44,12 +44,12 @@
       "subscribe_sites": [
         {
           "file": "src/Systems/DamageSystem.h",
-          "line": 16,
+          "line": 21,
           "owner": "DamageSystem"
         },
         {
           "file": "src/Systems/ObstacleBounceSystem.h",
-          "line": 19,
+          "line": 22,
           "owner": "ObstacleBounceSystem"
         }
       ]

--- a/src/General/Constants.h
+++ b/src/General/Constants.h
@@ -14,6 +14,12 @@ static constexpr int kDefaultEntityMask = 1;
 
 static constexpr size_t kSystemCommandBufferSize = 1024;
 
+// Below this collision-pair count, the collision-response classify pass (DamageSystem /
+// ObstacleBounceSystem) runs serially. ThreadPool dispatch overhead outweighs the per-pair tag
+// classification until a few thousand pairs; realistic scenes (~hundreds of pairs) stay serial,
+// while pathological density (tens of thousands) takes the parallel path. Tunable.
+static constexpr size_t kCollisionResponseParallelThreshold = 2048;
+
 // Sized to comfortably hold a frame's worth of render keys per parallel render system without
 // hitting Channel<RenderKey>::overflow_buffer (which serializes on a mutex).
 static constexpr size_t kRenderCommandBufferSize = 256 * 1024;

--- a/src/General/ThreadPool.h
+++ b/src/General/ThreadPool.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <algorithm>
 #include <condition_variable>
+#include <cstddef>
 #include <functional>
 #include <mutex>
 #include <queue>
@@ -19,6 +21,67 @@ class ThreadPool {
   }
 
   [[nodiscard]] size_t Size() const { return workers_.size(); }
+
+  // Run `fn(batchIndex, begin, end)` over contiguous sub-ranges that together cover [0, count), in
+  // parallel across the pool. The range is split into numBatches = min(count, Size()) batches indexed
+  // 0..numBatches-1; all but one are dispatched to workers and the last runs inline on the calling
+  // thread, which then blocks until the rest finish (mirrors ArchetypeQuery::ParallelForEach's
+  // chunk/barrier structure). batchIndex lets callers write to a disjoint per-batch output slot.
+  //
+  // CONTRACT:
+  //  - `fn` must be safe to call concurrently from multiple threads: read shared state only, or
+  //    write to storage that is disjoint per batchIndex. It must not mutate shared structures.
+  //  - `fn` must not throw — an escaping exception terminates, same as the existing pool path.
+  //  - Must NOT be called from a pool worker thread: it submits to the pool and blocks on it, which
+  //    could starve. All current callers run on the main thread.
+  //  - count == 0 is a no-op; a single batch (Size() <= 1 or count == 1) runs fn(0, 0, count) inline.
+  template <typename Fn>
+  static void ParallelChunks(size_t count, Fn&& fn) {
+    if (count == 0) return;
+
+    const size_t numBatches = std::min(count, Instance().Size());
+    if (numBatches <= 1) {
+      fn(static_cast<size_t>(0), static_cast<size_t>(0), count);
+      return;
+    }
+
+    // Counts down the (numBatches - 1) dispatched completions. Decrement + notify happen under the
+    // mutex so Wait() — and therefore the Barrier's destruction — cannot occur before the final
+    // Signal() has released the lock (the same correctness argument as ArchetypeQuery::BatchBarrier).
+    struct Barrier {
+      size_t remaining;
+      std::mutex mutex;
+      std::condition_variable cv;
+      explicit Barrier(size_t n) : remaining(n) {}
+      void Signal() {
+        std::lock_guard<std::mutex> lk(mutex);
+        if (--remaining == 0) cv.notify_one();
+      }
+      void Wait() {
+        std::unique_lock<std::mutex> lk(mutex);
+        cv.wait(lk, [this] { return remaining == 0; });
+      }
+    } barrier(numBatches - 1);
+
+    const size_t per = (count + numBatches - 1) / numBatches;
+    for (size_t b = 0; b < numBatches - 1; ++b) {
+      const size_t begin = b * per;
+      const size_t end = std::min(begin + per, count);
+      Instance().Submit([&fn, &barrier, b, begin, end] {
+        fn(b, begin, end);
+        barrier.Signal();
+      });
+    }
+
+    // Caller runs the final batch inline rather than sitting idle, then waits for the dispatched
+    // ones. The barrier count equals the number of Submits regardless of whether any range is
+    // empty, so there is no deadlock even on a ragged final split.
+    const size_t inlineBegin = (numBatches - 1) * per;
+    if (inlineBegin < count) {
+      fn(numBatches - 1, inlineBegin, count);
+    }
+    barrier.Wait();
+  }
 
   void Submit(std::function<void()> task) {
     {

--- a/src/Systems/CollisionResponseParallel.h
+++ b/src/Systems/CollisionResponseParallel.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "ECS/Entity.h"
+#include "General/ThreadPool.h"
+
+// Shared scaffold for the collision-response systems (DamageSystem, ObstacleBounceSystem). Both
+// iterate the frame's intersecting-pair vector doing per-pair tag CLASSIFICATION (registry reads
+// only) and then a small number of MUTATIONS for the pairs that actually interact. The
+// classification is the cost that scales (a HasTag sweep per pair); the mutations are few.
+//
+// The two phases are split so the expensive one can be parallelised:
+//   * classify(a, b, sink) — append 0..N hit records to `sink` using ONLY registry reads
+//                            (HasTag/HasComponent). Safe to run concurrently across pairs because
+//                            the registry is structurally stable during the response (despawns are
+//                            deferred to Registry::Update; no other system runs concurrently; the
+//                            broadphase async task has already completed and never touched the
+//                            registry).
+//   * apply(hit)           — perform the actual registry mutation for one record. Runs SERIALLY on
+//                            the calling thread, so component writes / QueueDespawnEntity never race.
+//
+// Above `threshold` pairs the classify pass is parallelised across the ThreadPool into per-batch
+// local vectors (no shared mutable state, no atomics); apply() then replays every record serially in
+// batch order. The result is identical to a fully serial classify+apply because apply order does not
+// change the final state for these handlers: damage subtraction commutes and QueueDespawnEntity
+// dedups; each bounce occurrence is replayed exactly once. Below the threshold it is a plain serial
+// loop (avoids ThreadPool dispatch overhead at realistic density).
+template <typename HitT, typename ClassifyFn, typename ApplyFn>
+void RunCollisionResponse(const std::vector<std::pair<Entity, Entity>>& pairs, size_t threshold, ClassifyFn&& classify,
+                          ApplyFn&& apply) {
+  const size_t count = pairs.size();
+  if (count == 0) return;
+
+  if (count <= threshold) {
+    std::vector<HitT> hits;
+    for (const auto& [a, b] : pairs) {
+      classify(a, b, hits);
+    }
+    for (const HitT& hit : hits) {
+      apply(hit);
+    }
+    return;
+  }
+
+  // Per-batch local sinks — sized to the pool width so any ParallelChunks batchIndex is in range
+  // regardless of how the range happens to split. No locks/atomics: each batch owns one sink.
+  std::vector<std::vector<HitT>> perBatch(ThreadPool::Instance().Size());
+  ThreadPool::ParallelChunks(count, [&](size_t batch, size_t begin, size_t end) {
+    std::vector<HitT>& sink = perBatch[batch];
+    for (size_t i = begin; i < end; ++i) {
+      classify(pairs[i].first, pairs[i].second, sink);
+    }
+  });
+
+  for (const std::vector<HitT>& batch : perBatch) {
+    for (const HitT& hit : batch) {
+      apply(hit);
+    }
+  }
+}

--- a/src/Systems/DamageSystem.h
+++ b/src/Systems/DamageSystem.h
@@ -1,10 +1,15 @@
 #pragma once
 
+#include <utility>
+#include <vector>
+
 #include "Components/HealthComponent.h"
 #include "Components/ProjectileComponent.h"
 #include "ECS/Iterable.h"
 #include "EventBus/EventBus.h"
 #include "Events/CollisionBatchEvent.h"
+#include "General/Constants.h"
+#include "Systems/CollisionResponseParallel.h"
 
 class DamageSystem {
  public:
@@ -16,18 +21,23 @@ class DamageSystem {
     subscription_ = eventBus->SubscribeEvent<DamageSystem, CollisionBatchEvent>(this, &DamageSystem::OnCollisionBatch);
   }
 
-  // Process the whole frame's collision pairs in one call (W2.3): the per-pair tag logic is
-  // unchanged, but it no longer rides the event bus once per pair.
+  // Process the whole frame's collision pairs (W2.3), parallelising the per-pair tag classification
+  // above a density threshold (parallel collision response). The classify step does registry reads
+  // only (safe to run across worker threads — the registry is structurally stable during the
+  // response); the damage/despawn mutations run serially in apply(). See CollisionResponseParallel.h.
   void OnCollisionBatch(const CollisionBatchEvent& event) {
-    for (const auto& [a, b] : event.pairs) {
-      if (registry_->HasTag(a, projectiles_) && (registry_->HasTag(b, player_) || registry_->HasTag(b, enemies_))) {
-        OnProjectileHit(a, b);
-      }
-
-      if (registry_->HasTag(b, projectiles_) && (registry_->HasTag(a, player_) || registry_->HasTag(a, enemies_))) {
-        OnProjectileHit(b, a);
-      }
-    }
+    using Hit = std::pair<Entity, Entity>;  // (projectile, target)
+    RunCollisionResponse<Hit>(
+        event.pairs, Constants::kCollisionResponseParallelThreshold,
+        [this](const Entity a, const Entity b, std::vector<Hit>& sink) {
+          if (registry_->HasTag(a, projectiles_) && (registry_->HasTag(b, player_) || registry_->HasTag(b, enemies_))) {
+            sink.emplace_back(a, b);
+          }
+          if (registry_->HasTag(b, projectiles_) && (registry_->HasTag(a, player_) || registry_->HasTag(a, enemies_))) {
+            sink.emplace_back(b, a);
+          }
+        },
+        [this](const Hit& hit) { OnProjectileHit(hit.first, hit.second); });
   }
 
   void OnProjectileHit(const Entity projectile, const Entity target) const {

--- a/src/Systems/ObstacleBounceSystem.h
+++ b/src/Systems/ObstacleBounceSystem.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <vector>
 
 #include "Components/RigidBodyComponent.h"
 #include "Components/SpriteComponent.h"
@@ -8,7 +9,9 @@
 #include "ECS/Registry.h"
 #include "EventBus/EventBus.h"
 #include "Events/CollisionBatchEvent.h"
+#include "General/Constants.h"
 #include "General/SpriteFlip.h"
+#include "Systems/CollisionResponseParallel.h"
 
 class ObstacleBounceSystem {
  public:
@@ -20,16 +23,24 @@ class ObstacleBounceSystem {
         this, &ObstacleBounceSystem::OnCollisionBatch);
   }
 
-  // Process the whole frame's collision pairs in one call (W2.3); per-pair logic unchanged.
+  // Process the whole frame's collision pairs (W2.3), parallelising the per-pair tag classification
+  // above a density threshold. classify does registry reads only; the velocity/sprite flips run
+  // serially in apply(). See CollisionResponseParallel.h.
   void OnCollisionBatch(const CollisionBatchEvent& event) {
-    for (const auto& [a, b] : event.pairs) {
-      if (registry_->HasTag(a, enemies_) && registry_->HasTag(b, obstacles_)) {
-        OnObstacleCollision(a);
-      }
-      if (registry_->HasTag(b, enemies_) && registry_->HasTag(a, obstacles_)) {
-        OnObstacleCollision(b);
-      }
-    }
+    RunCollisionResponse<Entity>(
+        event.pairs, Constants::kCollisionResponseParallelThreshold,
+        // Record EVERY bounce occurrence — do NOT dedup. OnObstacleCollision flips velocity each
+        // call, so an enemy overlapping two obstacles must flip twice (net no-op) to match the
+        // serial behaviour; deduping here would silently change the outcome.
+        [this](const Entity a, const Entity b, std::vector<Entity>& sink) {
+          if (registry_->HasTag(a, enemies_) && registry_->HasTag(b, obstacles_)) {
+            sink.push_back(a);
+          }
+          if (registry_->HasTag(b, enemies_) && registry_->HasTag(a, obstacles_)) {
+            sink.push_back(b);
+          }
+        },
+        [this](const Entity enemy) { OnObstacleCollision(enemy); });
   }
 
  private:

--- a/systems.json
+++ b/systems.json
@@ -56,6 +56,16 @@
       "lua_surface": false
     },
     {
+      "name": "CollisionResponseParallel",
+      "source": "src/Systems/CollisionResponseParallel.h",
+      "tier": null,
+      "setup_order": null,
+      "queried_components": [],
+      "emits": [],
+      "subscribes": [],
+      "lua_surface": false
+    },
+    {
       "name": "CollisionSystem",
       "source": "src/Systems/CollisionSystem.h",
       "tier": "bulk",

--- a/tests/.clang-tidy
+++ b/tests/.clang-tidy
@@ -1,0 +1,10 @@
+# Engine unit/integration test code. Synthetic magic numbers (entity counts, health/damage values,
+# test geometry) and hand-rolled fixtures are expected here and are not production-code smells, so
+# they shouldn't trip the blocking changed-lines clang-tidy gate. Mirrors tests/benchmarks/.clang-tidy:
+# inherit the project's check set, then drop the ones that only add noise for test code.
+InheritParentConfig: true
+Checks: >
+  -readability-magic-numbers,
+  -cppcoreguidelines-special-member-functions,
+  -readability-function-cognitive-complexity,
+  -readability-function-size

--- a/tests/CollisionResponseTest.cpp
+++ b/tests/CollisionResponseTest.cpp
@@ -1,0 +1,220 @@
+// Parity + correctness tests for the parallel collision-response path (RunCollisionResponse +
+// ThreadPool::ParallelChunks, wired into DamageSystem / ObstacleBounceSystem).
+//
+// Part 1 drives the shared scaffold directly with the threshold knob: every scenario runs once
+// forced-serial (threshold = SIZE_MAX) and once forced-parallel (threshold = 0) over IDENTICAL
+// input, and asserts identical final state — the core race/parity guarantee. Part 2 exercises the
+// REAL systems' OnCollisionBatch (fixed threshold) against an independent analytic expectation,
+// covering both the serial and parallel sides of the real threshold and the no-dedup bounce parity.
+// gtest-free; exit code = failed-check count. Links the ECS core only.
+
+#include <cstdint>
+#include <glm/glm.hpp>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "Components/HealthComponent.h"
+#include "Components/ProjectileComponent.h"
+#include "Components/RigidBodyComponent.h"
+#include "ECS/Registry.h"
+#include "EventBus/EventBus.h"
+#include "Events/CollisionBatchEvent.h"
+#include "Systems/CollisionResponseParallel.h"
+#include "Systems/DamageSystem.h"
+#include "Systems/ObstacleBounceSystem.h"
+#include "TestHarness.h"
+
+using octarine::test::Check;
+using octarine::test::CheckEq;
+
+namespace {
+using Pairs = std::vector<std::pair<Entity, Entity>>;
+
+struct DamageOutcome {
+  int health = 0;  // target's currentHealth after the run (0 if it was despawned)
+  bool targetAlive = false;
+  int projectilesAlive = 0;
+};
+
+// K projectiles (each damage=dmg) all paired with one shared target (maxHealth=hp). Runs them
+// through RunCollisionResponse at the given threshold (SIZE_MAX => serial, 0 => parallel), using the
+// REAL DamageSystem::OnProjectileHit as the apply step and a classify mirroring DamageSystem. If
+// `reversed`, pairs are emitted as (target, projectile) to exercise the symmetric classify branch.
+DamageOutcome RunDamageScenario(size_t threshold, int hp, int dmg, int k, bool reversed) {
+  Registry reg;
+  auto bus = std::make_unique<EventBus>();
+  DamageSystem damage;
+  damage.Init(&reg, bus);
+
+  const Entity projTag = reg.Tag<ProjectileTag>();
+  const Entity enemyTag = reg.TagId("enemies");
+
+  const Entity target = reg.CreateEntity();
+  reg.AddComponent(target, HealthComponent(hp, hp));
+  reg.AddTag(target, enemyTag);
+
+  Pairs pairs;
+  std::vector<Entity> projectiles;
+  pairs.reserve(static_cast<size_t>(k));
+  projectiles.reserve(static_cast<size_t>(k));
+  for (int i = 0; i < k; ++i) {
+    const Entity p = reg.CreateEntity();
+    reg.AddComponent(p, ProjectileComponent{dmg});
+    reg.AddTag(p, projTag);
+    projectiles.push_back(p);
+    if (reversed) {
+      pairs.emplace_back(target, p);
+    } else {
+      pairs.emplace_back(p, target);
+    }
+  }
+
+  using Hit = std::pair<Entity, Entity>;
+  RunCollisionResponse<Hit>(
+      pairs, threshold,
+      [&](const Entity a, const Entity b, std::vector<Hit>& sink) {
+        if (reg.HasTag(a, projTag) && reg.HasTag(b, enemyTag)) sink.emplace_back(a, b);
+        if (reg.HasTag(b, projTag) && reg.HasTag(a, enemyTag)) sink.emplace_back(b, a);
+      },
+      [&](const Hit& h) { damage.OnProjectileHit(h.first, h.second); });
+
+  reg.Update(1.0F / 60.0F);  // play back deferred despawns
+
+  int alive = 0;
+  for (const Entity p : projectiles) {
+    if (reg.IsAlive(p)) ++alive;
+  }
+  const bool targetAlive = reg.IsAlive(target);
+  return {targetAlive ? reg.GetComponent<HealthComponent>(target).currentHealth : 0, targetAlive, alive};
+}
+
+// Real DamageSystem end-to-end: k projectiles vs one (effectively invulnerable) target; returns the
+// target's currentHealth after OnCollisionBatch. Picks serial/parallel by k vs the fixed threshold.
+int RealDamageHealth(int k) {
+  Registry reg;
+  auto bus = std::make_unique<EventBus>();
+  DamageSystem damage;
+  damage.Init(&reg, bus);
+  const Entity projTag = reg.Tag<ProjectileTag>();
+  const Entity enemyTag = reg.TagId("enemies");
+  const Entity target = reg.CreateEntity();
+  reg.AddComponent(target, HealthComponent(1'000'000, 1'000'000));
+  reg.AddTag(target, enemyTag);
+  Pairs pairs;
+  pairs.reserve(static_cast<size_t>(k));
+  for (int i = 0; i < k; ++i) {
+    const Entity p = reg.CreateEntity();
+    reg.AddComponent(p, ProjectileComponent{1});
+    reg.AddTag(p, projTag);
+    pairs.emplace_back(p, target);
+  }
+  damage.OnCollisionBatch(CollisionBatchEvent{pairs});
+  return reg.GetComponent<HealthComponent>(target).currentHealth;
+}
+
+// Real ObstacleBounceSystem end-to-end: one enemy paired with k distinct obstacles; returns the
+// enemy's velocity after OnCollisionBatch. velocity flips once per occurrence (no dedup), so the net
+// is the original for even k and negated for odd k — on both the serial and parallel sides of k.
+glm::vec2 RealBounceVelocity(int k) {
+  Registry reg;
+  auto bus = std::make_unique<EventBus>();
+  ObstacleBounceSystem bounce;
+  bounce.Init(&reg, bus);
+  const Entity enemyTag = reg.TagId("enemies");
+  const Entity obstacleTag = reg.TagId("obstacles");
+  const Entity enemy = reg.CreateEntity();
+  reg.AddComponent(enemy, RigidBodyComponent(glm::vec2(3.0F, 4.0F)));
+  reg.AddTag(enemy, enemyTag);
+  Pairs pairs;
+  pairs.reserve(static_cast<size_t>(k));
+  for (int i = 0; i < k; ++i) {
+    const Entity obstacle = reg.CreateEntity();
+    reg.AddTag(obstacle, obstacleTag);
+    pairs.emplace_back(enemy, obstacle);
+  }
+  bounce.OnCollisionBatch(CollisionBatchEvent{pairs});
+  return reg.GetComponent<RigidBodyComponent>(enemy).velocity;
+}
+}  // namespace
+
+int main() {
+  // --- Part 1: scaffold parity — serial (threshold=MAX) vs parallel (threshold=0), identical input.
+  // Counts span the realistic threshold boundary (2048), a ragged non-multiple of the pool width
+  // (1001, 2503), and tiny sizes that still split when forced parallel.
+  for (const int k : {1, 2, 2047, 2048, 2049, 1001, 2503, 3000}) {
+    const std::string tag = "damage k=" + std::to_string(k);
+    const DamageOutcome serial = RunDamageScenario(SIZE_MAX, 1'000'000, 1, k, false);
+    const DamageOutcome parallel = RunDamageScenario(0, 1'000'000, 1, k, false);
+    CheckEq(parallel.health, serial.health, tag + ": parallel health == serial");
+    CheckEq(parallel.projectilesAlive, serial.projectilesAlive, tag + ": parallel despawns == serial");
+    CheckEq(serial.health, 1'000'000 - k, tag + ": serial health matches analytic (commutative)");
+    CheckEq(parallel.projectilesAlive, 0, tag + ": every projectile despawned (parallel)");
+  }
+
+  // Symmetric classify branch: pairs given as (target, projectile).
+  {
+    const DamageOutcome serial = RunDamageScenario(SIZE_MAX, 1'000'000, 1, 3000, true);
+    const DamageOutcome parallel = RunDamageScenario(0, 1'000'000, 1, 3000, true);
+    CheckEq(parallel.health, serial.health, "damage reversed-order: parallel == serial");
+    CheckEq(serial.health, 1'000'000 - 3000, "damage reversed-order: hits found via the b/a branch");
+  }
+
+  // Death + despawn dedup across chunk boundaries: total damage exceeds health.
+  {
+    const DamageOutcome serial = RunDamageScenario(SIZE_MAX, 2000, 1, 3000, false);
+    const DamageOutcome parallel = RunDamageScenario(0, 2000, 1, 3000, false);
+    Check(!serial.targetAlive, "damage death: target despawned (serial)");
+    Check(!parallel.targetAlive, "damage death: target despawned (parallel)");
+    CheckEq(parallel.projectilesAlive, 0, "damage death: every projectile despawned (parallel)");
+    // No crash here implies the target was queued/blammed exactly once despite 3000 hits.
+  }
+
+  // --- Part 2: real systems, fixed threshold, vs analytic truth.
+  CheckEq(RealDamageHealth(100), 1'000'000 - 100, "real DamageSystem serial path (k=100)");
+  CheckEq(RealDamageHealth(3000), 1'000'000 - 3000, "real DamageSystem parallel path (k=3000)");
+
+  // Interleaved no-op pairs (untagged) so chunk boundaries land on non-hits; only real hits apply.
+  {
+    Registry reg;
+    auto bus = std::make_unique<EventBus>();
+    DamageSystem damage;
+    damage.Init(&reg, bus);
+    const Entity projTag = reg.Tag<ProjectileTag>();
+    const Entity enemyTag = reg.TagId("enemies");
+    const Entity target = reg.CreateEntity();
+    reg.AddComponent(target, HealthComponent(1'000'000, 1'000'000));
+    reg.AddTag(target, enemyTag);
+    Pairs pairs;
+    int realHits = 0;
+    for (int i = 0; i < 3000; ++i) {
+      if (i % 3 == 0) {
+        const Entity p = reg.CreateEntity();
+        reg.AddComponent(p, ProjectileComponent{1});
+        reg.AddTag(p, projTag);
+        pairs.emplace_back(p, target);
+        ++realHits;
+      } else {
+        pairs.emplace_back(reg.CreateEntity(), reg.CreateEntity());  // untagged — no-op
+      }
+    }
+    damage.OnCollisionBatch(CollisionBatchEvent{pairs});
+    CheckEq(reg.GetComponent<HealthComponent>(target).currentHealth, 1'000'000 - realHits,
+            "interleaved no-op pairs: only real hits applied (real system, parallel)");
+  }
+
+  // Bounce no-dedup parity: even occurrence count is a net no-op, odd negates — serial and parallel.
+  {
+    const glm::vec2 even2 = RealBounceVelocity(2);
+    Check(even2.x == 3.0F && even2.y == 4.0F, "bounce k=2 (serial, even): velocity unchanged");
+    const glm::vec2 odd3 = RealBounceVelocity(3);
+    Check(odd3.x == -3.0F && odd3.y == -4.0F, "bounce k=3 (serial, odd): velocity negated");
+    const glm::vec2 even3000 = RealBounceVelocity(3000);
+    Check(even3000.x == 3.0F && even3000.y == 4.0F, "bounce k=3000 (parallel, even): velocity unchanged");
+    const glm::vec2 odd3001 = RealBounceVelocity(3001);
+    Check(odd3001.x == -3.0F && odd3001.y == -4.0F, "bounce k=3001 (parallel, odd): velocity negated");
+  }
+
+  return octarine::test::Result();
+}


### PR DESCRIPTION
The last lever from the performance plan. After W2.3 (#126), `DamageSystem` and `ObstacleBounceSystem` iterate the `CollisionBatchEvent` pair vector **serially on the main thread**. At high collision density the per-pair `HasTag` classification dominates — **~7 ms/frame at ~140k pairs**. This parallelizes it.

> **Scope:** a no-op at realistic density by design. The parallel path is gated behind a 2048-pair threshold; normal scenes (~hundreds of pairs) stay on the **untouched serial path** with zero added overhead/risk. This raises the ceiling at pathological density (scenes well past the ~25k-entity 60 FPS cliff), it doesn't speed up normal play.

## Design: parallel classify (reads only) → serial apply (mutations)
- **`ThreadPool::ParallelChunks(count, fn)`** — a reusable chunk-parallel-with-barrier helper, mirroring `ArchetypeQuery::ParallelForEach` (dispatch N-1 batches, run the last inline, wait).
- **`RunCollisionResponse<HitT>(pairs, threshold, classify, apply)`** (`src/Systems/CollisionResponseParallel.h`) — below the threshold runs the old serial loop unchanged; above it, `classify` (`HasTag`/`HasComponent` reads only) runs across the pool into **per-batch local vectors** (no shared state, no atomics), then `apply` replays the mutations **serially** on the main thread.
- Both systems keep `OnProjectileHit` / `OnObstacleCollision` verbatim as the `apply` step.

### Why it's safe (and identical to serial)
The registry is **structurally stable** during the response — despawns are deferred to `Registry::Update`, and no other system runs concurrently (`CollisionSystem` is a bulk system; `EmitEvent` is inline) — so concurrent `HasTag`/`HasComponent` reads are race-free. The parallel phase does **no** `GetComponent` and **no** despawn. Final state is order-independent: damage subtraction commutes, `QueueDespawnEntity` dedups the target + is idempotent per projectile, and each bounce occurrence is replayed exactly once (so an enemy overlapping N obstacles flips N times — the classify deliberately **does not dedup**).

## Verification
- **`tests/CollisionResponseTest.cpp`** (new core test): runs each scenario forced-serial (`threshold=SIZE_MAX`) and forced-parallel (`threshold=0`) over **identical input** and asserts identical final state — straddle counts (2047/2048/2049), ragged splits (1001/2503), reversed-order pairs, death+despawn-dedup, interleaved no-op pairs, and bounce even/odd parity. Plus real-system checks vs analytic truth. **All pass.**
- **ThreadSanitizer**: the test runs clean (no data races).
- **Same-binary A/B at ~140k pairs (16 cores):** `Emit Events` **7.05 → 5.05 ms (−28%)**, `CollisionSystem` 7.86 → 5.95 ms. The classify is memory-bound on `HasTag`, so it scales sub-linearly (not ×cores) — honest about that.
- **Parity:** step-32 stress (639 pairs < threshold) stays serial/unchanged (0 errors); dense step-11 frame capture renders correctly.
- `clang-format` (18.1.8) clean; full build incl. `OctarineBenchmarks`; `ctest` green.

Two commits: scaffold + `ParallelChunks` + `DamageSystem` + test, then `ObstacleBounceSystem`.