### PR TITLE
Emit only entering collision pairs, not re-emitting on sustained contact (perf W2.2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -456,6 +456,7 @@ if (OCTARINE_ENABLE_TESTS)
     octarine_add_core_test(OctarineSystemLogicTest SystemLogicTest tests/SystemLogicTest.cpp)
     octarine_add_core_test(OctarineCollisionResponseTest CollisionResponseTest tests/CollisionResponseTest.cpp)
     octarine_add_core_test(OctarineCollisionSystemTest CollisionSystemTest tests/CollisionSystemTest.cpp)
+    octarine_add_core_test(OctarineProjectileEmitSystemTest ProjectileEmitSystemTest tests/ProjectileEmitSystemTest.cpp)
 
     # EventBus is header-only; it needs Logger for its construction log lines, nothing else.
     add_executable(OctarineEventBusTest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -455,6 +455,7 @@ if (OCTARINE_ENABLE_TESTS)
     octarine_add_core_test(OctarineEcsHierarchyTest EcsHierarchyTest tests/EcsHierarchyTest.cpp)
     octarine_add_core_test(OctarineSystemLogicTest SystemLogicTest tests/SystemLogicTest.cpp)
     octarine_add_core_test(OctarineCollisionResponseTest CollisionResponseTest tests/CollisionResponseTest.cpp)
+    octarine_add_core_test(OctarineCollisionSystemTest CollisionSystemTest tests/CollisionSystemTest.cpp)
 
     # EventBus is header-only; it needs Logger for its construction log lines, nothing else.
     add_executable(OctarineEventBusTest

--- a/docs/events.md
+++ b/docs/events.md
@@ -45,7 +45,7 @@ Subscriptions are wired once during startup (`Game::Setup`, each system's `Init`
 | Event | Payload | Emitted by | Subscribed by |
 |-------|---------|------------|---------------|
 | `AudioPlayEvent` | `clipId: string`, `volume: float` | Lua `play_sound()` (`AudioModuleLuaBinding.cpp`) | `AudioSystem::OnAudioPlay` |
-| `CollisionBatchEvent` | `pairs: const std::vector<std::pair<Entity, Entity>>&` (the whole frame's overlapping pairs) | `CollisionSystem` (narrowphase) | `DamageSystem::OnCollisionBatch`, `ObstacleBounceSystem::OnCollisionBatch` |
+| `CollisionBatchEvent` | `pairs: const std::vector<std::pair<Entity, Entity>>&` (frame's *entering* pairs — first-contact overlaps not seen last frame) | `CollisionSystem` (narrowphase) | `DamageSystem::OnCollisionBatch`, `ObstacleBounceSystem::OnCollisionBatch` |
 | `KeyInputEvent` | `inputKey: SDL_Keycode`, `inputModifier: SDL_Keymod`, `isPressed: bool` | `Game::ProcessInput` (SDL key events) | `InputSystem::OnKeyInput`, `FrameLoop::OnKeyInputEvent` |
 | `MouseInputEvent` | `event: SDL_MouseButtonEvent` | `Game::ProcessInput` (SDL mouse-button events) | `InputSystem::OnMouseInput`, `UIButtonSystem::OnMouseInput` |
 | `MouseWheelEvent` | `dx: float`, `dy: float` | `Game::ProcessInput` (SDL wheel events) | `InputSystem::OnMouseWheel` |
@@ -58,9 +58,10 @@ Event types live in `src/Events/`.
   `MouseWheelEvent` → `InputSystem` folds them into per-frame state (also `FrameLoop` for engine
   hotkeys, `UIButtonSystem` for clicks).
 - **Collision:** `CollisionSystem` detects overlaps and emits a single `CollisionBatchEvent` carrying
-  the whole frame's overlapping pairs → `DamageSystem` and `ObstacleBounceSystem` iterate the batch and
-  react. (One batched event per frame rather than one event per pair keeps the per-pair dispatch cost
-  off the bus at high collision density.)
+  the frame's *entering* pairs (first-contact overlaps not seen last frame) → `DamageSystem` and
+  `ObstacleBounceSystem` iterate the batch and react. (One batched event per frame rather than one
+  per pair keeps dispatch cost off the bus at high density; enter-only filtering avoids re-firing on
+  every frame of sustained contact.)
 - **Audio:** Lua `play_sound(clip, volume)` emits `AudioPlayEvent` → `AudioSystem` plays the clip.
 
 ## Adding an event

--- a/events.json
+++ b/events.json
@@ -38,7 +38,7 @@
       "emit_sites": [
         {
           "file": "src/Systems/CollisionSystem.h",
-          "line": 109
+          "line": 129
         }
       ],
       "subscribe_sites": [

--- a/src/Components/ProjectileEmitterComponent.h
+++ b/src/Components/ProjectileEmitterComponent.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <utility>
 
+#include "ECS/Entity.h"
 #include "General/Constants.h"
 
 struct ProjectileEmitterComponent {

--- a/src/Events/CollisionBatchEvent.h
+++ b/src/Events/CollisionBatchEvent.h
@@ -6,13 +6,15 @@
 #include "ECS/Entity.h"
 #include "EventBus/Event.h"
 
-// One event carrying the whole frame's intersecting-pair list, so collision-response subscribers
-// (DamageSystem, ObstacleBounceSystem) iterate the batch directly instead of paying per-pair
-// event-bus dispatch — a std::map<type_index> lookup + std::function indirection for *every* pair,
-// which dominated CollisionSystem at scale (~7.4 ms / frame at ~126k pairs).
+// One event carrying the frame's *entering* collision pairs — first-contact overlaps that were not
+// present in the previous frame. Persistent overlaps (entities that remain in contact across frames)
+// are excluded; subscribers only see each contact once, on entry.
 //
-// `pairs` is borrowed from the CollisionSystem result and is only valid for the duration of the
-// EmitEvent dispatch; subscribers must consume it synchronously and must not store the reference.
+// Emitted by CollisionSystem once per frame as a single batch rather than one event per pair
+// (W2.3); the enter/exit filter (W2.2) further reduces the set to new contacts only.
+//
+// `pairs` is borrowed from a CollisionSystem-local vector and is only valid for the duration of
+// the EmitEvent dispatch; subscribers must consume it synchronously and must not store the reference.
 class CollisionBatchEvent : public Event {
  public:
   const std::vector<std::pair<Entity, Entity>>& pairs;

--- a/src/Systems/CollisionSystem.h
+++ b/src/Systems/CollisionSystem.h
@@ -3,8 +3,10 @@
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <functional>
 #include <future>
 #include <memory>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -104,9 +106,27 @@ class CollisionSystem {
       PROFILE_NAMED_SCOPE("Emit Events");
       CollisionResult result = collisionResult_.get();
       PROFILE_COUNTER_SET("Collision: Intersecting pairs", static_cast<long long>(result.intersectingPairs.size()));
-      // One batched event instead of one EmitEvent per pair: subscribers iterate the vector
-      // directly, dropping a std::map lookup + std::function indirection for every pair (W2.3).
-      eventBus->EmitEvent<CollisionBatchEvent>(result.intersectingPairs);
+
+      // W2.2: emit only entering pairs — first-contact overlaps not present last frame.
+      // Persistent overlaps (enemy pinned against a wall, stacked entities) would otherwise
+      // re-fire every frame, causing repeat bounces and redundant damage checks.
+      PairSet currentSet;
+      currentSet.reserve(result.intersectingPairs.size());
+      for (const auto& [a, b] : result.intersectingPairs) {
+        currentSet.emplace(std::min(a.id, b.id), std::max(a.id, b.id));
+      }
+
+      std::vector<std::pair<Entity, Entity>> enteringPairs;
+      enteringPairs.reserve(result.intersectingPairs.size());
+      for (const auto& [a, b] : result.intersectingPairs) {
+        if (!prevPairSet_.count({std::min(a.id, b.id), std::max(a.id, b.id)})) {
+          enteringPairs.emplace_back(a, b);
+        }
+      }
+      prevPairSet_ = std::move(currentSet);
+
+      PROFILE_COUNTER_SET("Collision: Entering pairs", static_cast<long long>(enteringPairs.size()));
+      eventBus->EmitEvent<CollisionBatchEvent>(enteringPairs);
       cachedBoxes_ = std::move(result.boxes);
       cachedBoxes_.clear();
     }
@@ -169,6 +189,16 @@ class CollisionSystem {
   }
 
  private:
+  struct PairHash {
+    size_t operator()(const std::pair<EntityID, EntityID>& p) const noexcept {
+      size_t h = std::hash<EntityID>{}(p.first);
+      h ^= std::hash<EntityID>{}(p.second) + 0x9e3779b9ULL + (h << 6) + (h >> 2);
+      return h;
+    }
+  };
+  using PairSet = std::unordered_set<std::pair<EntityID, EntityID>, PairHash>;
+
+  PairSet prevPairSet_;
   std::vector<Box> cachedBoxes_;
   std::future<CollisionResult> collisionResult_;
   std::unique_ptr<ComponentQuery<GlobalTransformComponent, BoxColliderComponent, EntityMaskComponent>> query_;

--- a/src/Systems/CollisionSystem.h
+++ b/src/Systems/CollisionSystem.h
@@ -191,8 +191,11 @@ class CollisionSystem {
  private:
   struct PairHash {
     size_t operator()(const std::pair<EntityID, EntityID>& p) const noexcept {
+      // Boost-style hash_combine: golden-ratio constant spreads entropy, shifts mix bits.
+      static constexpr size_t kGoldenRatio = 0x9e3779b9ULL;
+      static constexpr int kLeftShift = 6;
       size_t h = std::hash<EntityID>{}(p.first);
-      h ^= std::hash<EntityID>{}(p.second) + 0x9e3779b9ULL + (h << 6) + (h >> 2);
+      h ^= std::hash<EntityID>{}(p.second) + kGoldenRatio + (h << kLeftShift) + (h >> 2);
       return h;
     }
   };

--- a/tests/CollisionSystemTest.cpp
+++ b/tests/CollisionSystemTest.cpp
@@ -1,0 +1,186 @@
+// Integration tests for CollisionSystem's enter/exit filtering (W2.2).
+//
+// CollisionSystem is async: operator() on call N gathers the current entity positions and
+// starts BVH detection; call N+1 consumes that result and emits CollisionBatchEvent. A 20 ms
+// sleep between Update() calls gives the async work time to complete (it finishes in µs for
+// 2-3 entities). Because the detection result is one frame behind the gather, each scenario
+// requires an extra tick to flush the pipeline.
+//
+// gtest-free; exit code = failed-check count. Links the ECS core only.
+
+#include <chrono>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include <glm/glm.hpp>
+
+#include "Components/BoxColliderComponent.h"
+#include "Components/EntityMaskComponent.h"
+#include "Components/GlobalTransformComponent.h"
+#include "ECS/Query.h"  // full ComponentQuery definition for RegisterBulkSystem dispatch
+#include "ECS/Registry.h"
+#include "Engine/EngineContext.h"
+#include "EventBus/EventBus.h"
+#include "Events/CollisionBatchEvent.h"
+#include "Systems/CollisionSystem.h"
+#include "TestHarness.h"
+
+using octarine::test::Check;
+using octarine::test::CheckEq;
+
+namespace {
+
+// Accumulates copies of every CollisionBatchEvent pair list received (pairs is a borrowed ref
+// valid only during dispatch, so it must be copied here).
+struct CollisionCapture {
+  std::vector<std::vector<std::pair<Entity, Entity>>> batches;
+  EventBus::SubscriptionHandle subscription;
+
+  void OnBatch(const CollisionBatchEvent& evt) { batches.emplace_back(evt.pairs); }
+
+  int TotalPairs() const {
+    int n = 0;
+    for (const auto& b : batches) n += static_cast<int>(b.size());
+    return n;
+  }
+
+  bool Contains(const Entity a, const Entity b) const {
+    for (const auto& batch : batches) {
+      for (const auto& [x, y] : batch) {
+        if ((x == a && y == b) || (x == b && y == a)) return true;
+      }
+    }
+    return false;
+  }
+};
+
+struct TestScene {
+  Registry reg;
+  std::unique_ptr<EventBus> bus;
+  CollisionCapture capture;
+
+  TestScene() : bus(std::make_unique<EventBus>()) {
+    EngineContext ctx;
+    ctx.eventBus = bus.get();
+    reg.Set<EngineContext>(ctx);
+    reg.RegisterBulkSystem(CollisionSystem());
+    capture.subscription =
+        bus->SubscribeEvent<CollisionCapture, CollisionBatchEvent>(&capture, &CollisionCapture::OnBatch);
+  }
+
+  // Create a 32×32 AABB at top-left (x, y) with default masks (all entities interact).
+  Entity MakeBox(const float x, const float y) {
+    const Entity e = reg.CreateEntity();
+    reg.AddComponent(e, GlobalTransformComponent{glm::vec2(x, y), glm::vec2(1.0f, 1.0f), 0.0});
+    reg.AddComponent(e, BoxColliderComponent{32, 32});
+    reg.AddComponent(e, EntityMaskComponent{});
+    return e;
+  }
+
+  void MoveTo(const Entity e, const float x, const float y) {
+    reg.GetComponent<GlobalTransformComponent>(e).position = glm::vec2(x, y);
+  }
+
+  // Advance one engine tick. CollisionSystem starts async detection this call;
+  // the resulting pairs are emitted on the NEXT call, so most scenarios need an
+  // extra trailing tick to flush the pipeline.
+  void Tick() {
+    reg.Update(1.0f / 60.0f);
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  }
+};
+
+}  // namespace
+
+int main() {
+  // --- Entering pair is emitted on first contact.
+  // Boxes at (0,0) and (16,0) with size 32 overlap by 16 px.
+  {
+    TestScene scene;
+    const Entity a = scene.MakeBox(0.0f, 0.0f);
+    const Entity b = scene.MakeBox(16.0f, 0.0f);
+
+    scene.Tick();  // gathers overlapping boxes, starts detection
+    scene.Tick();  // consumes result, emits (a, b) as entering
+
+    CheckEq(scene.capture.TotalPairs(), 1, "entering: overlapping pair emitted on first contact");
+    Check(scene.capture.Contains(a, b), "entering: correct pair (a, b) in the batch");
+  }
+
+  // --- Non-overlapping entities produce no pairs.
+  // Boxes at (0,0) and (64,0): gap between maxX=32 and minX=64.
+  {
+    TestScene scene;
+    scene.MakeBox(0.0f, 0.0f);
+    scene.MakeBox(64.0f, 0.0f);
+
+    scene.Tick();
+    scene.Tick();
+
+    CheckEq(scene.capture.TotalPairs(), 0, "no overlap: no pairs emitted");
+  }
+
+  // --- Sustained overlap is suppressed after the first contact.
+  // Both boxes remain in the same position across three detection cycles; the pair
+  // should appear in exactly one batch (the first).
+  {
+    TestScene scene;
+    const Entity a = scene.MakeBox(0.0f, 0.0f);
+    const Entity b = scene.MakeBox(16.0f, 0.0f);
+
+    scene.Tick();  // gather + start detection_1 (overlap)
+    scene.Tick();  // emit (a,b) entering; gather + start detection_2 (still overlap)
+    scene.Tick();  // emit [] sustained; gather + start detection_3
+
+    CheckEq(scene.capture.TotalPairs(), 1,
+            "sustained: pair emitted exactly once despite two consecutive overlapping cycles");
+  }
+
+  // --- Re-entry fires the pair again after a gap.
+  // Sequence: overlap → separate → overlap. The pair should appear in two separate batches.
+  // Timing: detection_N consumes boxes gathered at call N, emitted at call N+1. Moving b
+  // between calls N and N+1 affects detection_N+1 (gathered at call N+1).
+  {
+    TestScene scene;
+    const Entity a = scene.MakeBox(0.0f, 0.0f);
+    const Entity b = scene.MakeBox(16.0f, 0.0f);
+
+    scene.Tick();                      // detection_1 gathers: a-b overlap
+    scene.Tick();                      // emit (a,b) entering; detection_2 gathers: still overlap
+    scene.MoveTo(b, 64.0f, 0.0f);     // move b apart before detection_3 gathers
+    scene.Tick();                      // emit [] sustained (det_2 result); detection_3 gathers: b at 64 — no overlap
+    scene.MoveTo(b, 16.0f, 0.0f);     // move b back before detection_4 gathers
+    scene.Tick();                      // emit [] (det_3 no-overlap); detection_4 gathers: b at 16 — overlap
+    scene.Tick();                      // emit (a,b) entering again (det_4 result; prevPairSet_ was cleared)
+
+    CheckEq(scene.capture.TotalPairs(), 2, "re-entry: pair emitted on first contact and again after separation");
+    Check(scene.capture.Contains(a, b), "re-entry: (a, b) is in the captured batches");
+  }
+
+  // --- New pair alongside a sustained pair: only the new pair fires.
+  // a and b overlap from the start. c is far away, then moves to overlap a only (not b).
+  // After c enters, only the (a, c) pair should appear — (a, b) must not re-fire.
+  //
+  // Layout: a at (0,0), b at (16,0) [overlaps a], c starts at (200,0), moves to (-20,0).
+  // c at (-20,0): AABB [-20,12] overlaps a [0,32] but not b [16,48].
+  {
+    TestScene scene;
+    const Entity a = scene.MakeBox(0.0f, 0.0f);
+    const Entity b = scene.MakeBox(16.0f, 0.0f);
+    const Entity c = scene.MakeBox(200.0f, 0.0f);
+
+    scene.Tick();                      // detection_1: a-b overlap, a-c no
+    scene.Tick();                      // emit (a,b) entering; detection_2: same positions
+    scene.MoveTo(c, -20.0f, 0.0f);    // c now overlaps a but not b
+    scene.Tick();                      // emit [] (det_2 a-b sustained); detection_3 gathers: a-b + a-c overlap
+    scene.Tick();                      // emit entering pairs from det_3: only (a,c) — (a,b) already in prevPairSet_
+
+    CheckEq(scene.capture.TotalPairs(), 2,
+            "new pair: (a,b) on first entry, (a,c) when c enters — (a,b) not re-emitted");
+    Check(scene.capture.Contains(a, b), "new pair: initial (a,b) entry was captured");
+    Check(scene.capture.Contains(a, c), "new pair: (a,c) entry captured when c moved in");
+  }
+
+  return octarine::test::Result();
+}

--- a/tests/CollisionSystemTest.cpp
+++ b/tests/CollisionSystemTest.cpp
@@ -77,6 +77,15 @@ struct TestScene {
     return e;
   }
 
+  // Create a 32×32 AABB with explicit entity/collision masks for mask-pruning tests.
+  Entity MakeBoxWithMasks(const float x, const float y, const EntityMask entityMask, const EntityMask collisionMask) {
+    const Entity e = reg.CreateEntity();
+    reg.AddComponent(e, GlobalTransformComponent{glm::vec2(x, y), glm::vec2(1.0f, 1.0f), 0.0});
+    reg.AddComponent(e, BoxColliderComponent{32, 32, {}, false, collisionMask});
+    reg.AddComponent(e, EntityMaskComponent{entityMask});
+    return e;
+  }
+
   void MoveTo(const Entity e, const float x, const float y) {
     reg.GetComponent<GlobalTransformComponent>(e).position = glm::vec2(x, y);
   }
@@ -179,6 +188,22 @@ int main() {
             "new pair: (a,b) on first entry, (a,c) when c enters — (a,b) not re-emitted");
     Check(scene.capture.Contains(a, b), "new pair: initial (a,b) entry was captured");
     Check(scene.capture.Contains(a, c), "new pair: (a,c) entry captured when c moved in");
+  }
+
+  // --- Incompatible masks suppress pairs (W2.1 mask-pruning gate).
+  // Two overlapping boxes whose layers do not match either entity's collision mask must produce
+  // no pairs. Box::intersects gates on canInteract before the geometric test.
+  // Both entities carry entityMask=0b01 but collisionMask=0b10: neither can "see" the other's
+  // layer, so (0b10 & 0b01) == 0 on both sides and canInteract is false.
+  {
+    TestScene scene;
+    scene.MakeBoxWithMasks(0.0f, 0.0f, EntityMask(1), EntityMask(2));   // entityMask=1, hits layer 2
+    scene.MakeBoxWithMasks(16.0f, 0.0f, EntityMask(1), EntityMask(2));  // entityMask=1, hits layer 2
+
+    scene.Tick();
+    scene.Tick();
+
+    CheckEq(scene.capture.TotalPairs(), 0, "mask pruning: overlapping boxes with incompatible masks emit no pairs");
   }
 
   return octarine::test::Result();

--- a/tests/CollisionSystemTest.cpp
+++ b/tests/CollisionSystemTest.cpp
@@ -9,11 +9,10 @@
 // gtest-free; exit code = failed-check count. Links the ECS core only.
 
 #include <chrono>
+#include <glm/glm.hpp>
 #include <thread>
 #include <utility>
 #include <vector>
-
-#include <glm/glm.hpp>
 
 #include "Components/BoxColliderComponent.h"
 #include "Components/EntityMaskComponent.h"
@@ -146,13 +145,13 @@ int main() {
     const Entity a = scene.MakeBox(0.0f, 0.0f);
     const Entity b = scene.MakeBox(16.0f, 0.0f);
 
-    scene.Tick();                      // detection_1 gathers: a-b overlap
-    scene.Tick();                      // emit (a,b) entering; detection_2 gathers: still overlap
-    scene.MoveTo(b, 64.0f, 0.0f);     // move b apart before detection_3 gathers
-    scene.Tick();                      // emit [] sustained (det_2 result); detection_3 gathers: b at 64 — no overlap
-    scene.MoveTo(b, 16.0f, 0.0f);     // move b back before detection_4 gathers
-    scene.Tick();                      // emit [] (det_3 no-overlap); detection_4 gathers: b at 16 — overlap
-    scene.Tick();                      // emit (a,b) entering again (det_4 result; prevPairSet_ was cleared)
+    scene.Tick();                  // detection_1 gathers: a-b overlap
+    scene.Tick();                  // emit (a,b) entering; detection_2 gathers: still overlap
+    scene.MoveTo(b, 64.0f, 0.0f);  // move b apart before detection_3 gathers
+    scene.Tick();                  // emit [] sustained (det_2 result); detection_3 gathers: b at 64 — no overlap
+    scene.MoveTo(b, 16.0f, 0.0f);  // move b back before detection_4 gathers
+    scene.Tick();                  // emit [] (det_3 no-overlap); detection_4 gathers: b at 16 — overlap
+    scene.Tick();                  // emit (a,b) entering again (det_4 result; prevPairSet_ was cleared)
 
     CheckEq(scene.capture.TotalPairs(), 2, "re-entry: pair emitted on first contact and again after separation");
     Check(scene.capture.Contains(a, b), "re-entry: (a, b) is in the captured batches");
@@ -170,11 +169,11 @@ int main() {
     const Entity b = scene.MakeBox(16.0f, 0.0f);
     const Entity c = scene.MakeBox(200.0f, 0.0f);
 
-    scene.Tick();                      // detection_1: a-b overlap, a-c no
-    scene.Tick();                      // emit (a,b) entering; detection_2: same positions
-    scene.MoveTo(c, -20.0f, 0.0f);    // c now overlaps a but not b
-    scene.Tick();                      // emit [] (det_2 a-b sustained); detection_3 gathers: a-b + a-c overlap
-    scene.Tick();                      // emit entering pairs from det_3: only (a,c) — (a,b) already in prevPairSet_
+    scene.Tick();                   // detection_1: a-b overlap, a-c no
+    scene.Tick();                   // emit (a,b) entering; detection_2: same positions
+    scene.MoveTo(c, -20.0f, 0.0f);  // c now overlaps a but not b
+    scene.Tick();                   // emit [] (det_2 a-b sustained); detection_3 gathers: a-b + a-c overlap
+    scene.Tick();                   // emit entering pairs from det_3: only (a,c) — (a,b) already in prevPairSet_
 
     CheckEq(scene.capture.TotalPairs(), 2,
             "new pair: (a,b) on first entry, (a,c) when c enters — (a,b) not re-emitted");

--- a/tests/CollisionSystemTest.cpp
+++ b/tests/CollisionSystemTest.cpp
@@ -38,13 +38,13 @@ struct CollisionCapture {
 
   void OnBatch(const CollisionBatchEvent& evt) { batches.emplace_back(evt.pairs); }
 
-  int TotalPairs() const {
+  [[nodiscard]] int TotalPairs() const {
     int n = 0;
     for (const auto& b : batches) n += static_cast<int>(b.size());
     return n;
   }
 
-  bool Contains(const Entity a, const Entity b) const {
+  [[nodiscard]] bool Contains(const Entity a, const Entity b) const {
     for (const auto& batch : batches) {
       for (const auto& [x, y] : batch) {
         if ((x == a && y == b) || (x == b && y == a)) return true;
@@ -86,7 +86,7 @@ struct TestScene {
     return e;
   }
 
-  void MoveTo(const Entity e, const float x, const float y) {
+  void MoveTo(const Entity e, const float x, const float y) const {
     reg.GetComponent<GlobalTransformComponent>(e).position = glm::vec2(x, y);
   }
 

--- a/tests/ProjectileEmitSystemTest.cpp
+++ b/tests/ProjectileEmitSystemTest.cpp
@@ -1,0 +1,160 @@
+// Tests for ProjectileEmitSystem's per-frame auto-fire tick (W1).
+//
+// Part 1 calls operator() directly (no Registry interaction) to verify the timer
+// arithmetic — the same approach as SystemLogicTest for VelocityIntegrationSystem.
+// A minimal TestContext stub is sufficient because the early-return (frequency <= 0)
+// and the decrement-only path (timer still positive) never touch the Registry.
+//
+// Part 2 needs the pool infrastructure (EntityPoolManager + Init) and uses a real
+// Registry to verify spawn-and-reset: when countDownTimer expires, a projectile is
+// spawned from the pool and the timer is hard-reset to frequency.
+//
+// gtest-free; exit code = failed-check count. Links the ECS core only.
+
+#include <glm/glm.hpp>
+
+#include "Components/PositionComponent.h"
+#include "Components/ProjectileEmitterComponent.h"
+#include "ECS/Context.h"  // AnyContext, ContextFacade, Internal::BulkContextImpl
+#include "ECS/Query.h"    // full ComponentQuery for RegisterPool's CreateEntityWithBundle
+#include "ECS/Registry.h"
+#include "Systems/EntityPoolSystem.h"
+#include "Systems/ProjectileEmitSystem.h"
+#include "TestHarness.h"
+
+using octarine::test::Check;
+
+namespace {
+
+// Minimal AnyContext for tests that need a real entity identity (spawn path).
+class TestContext final : public AnyContext {
+ public:
+  TestContext(Registry* reg, const float dt, const Entity entity) : reg_(reg), dt_(dt), entity_(entity) {}
+
+  [[nodiscard]] Entity GetEntity() const override { return entity_; }
+  [[nodiscard]] Registry* GetRegistry() const override { return reg_; }
+  [[nodiscard]] float GetDeltaTime() const override { return dt_; }
+  void* GetComponentPtr(EntityID /*id*/) override { return nullptr; }
+
+ private:
+  Registry* reg_;
+  float dt_;
+  Entity entity_;
+};
+
+}  // namespace
+
+int main() {
+  // --- Part 1: timer arithmetic — no Registry interaction needed.
+
+  // frequency = 0 is a complete no-op: operator returns immediately, timer unchanged.
+  {
+    ProjectileEmitSystem system;
+
+    ProjectileEmitterComponent emitter{};  // frequency=0, countDownTimer=0 by default
+    const PositionComponent pos{};
+
+    Registry reg;
+    Internal::BulkContextImpl implCtx(&reg, 1.0f / 60.0f);
+    ContextFacade ctx(&implCtx);
+
+    system(ctx, emitter, pos);
+
+    Check(emitter.countDownTimer == 0.0f, "frequency=0: timer unchanged (no-op)");
+  }
+
+  // Timer decrements by dt when frequency > 0 and expiry not yet reached.
+  {
+    ProjectileEmitSystem system;
+
+    // frequency=1.0 → countDownTimer initialises to 1.0; dt=0.5 → timer becomes 0.5 (no fire).
+    ProjectileEmitterComponent emitter{{}, 1.0f, 1.0f, 10};
+    const PositionComponent pos{};
+
+    Registry reg;
+    Internal::BulkContextImpl implCtx(&reg, 0.5f);
+    ContextFacade ctx(&implCtx);
+
+    system(ctx, emitter, pos);
+
+    Check(emitter.countDownTimer == 0.5f, "timer decrements by dt when frequency > 0");
+    Check(emitter.countDownTimer > 0.0f, "timer not expired: no spawn triggered");
+  }
+
+  // Negative frequency is also treated as disabled (≤ 0 guard).
+  {
+    ProjectileEmitSystem system;
+
+    ProjectileEmitterComponent emitter{{}, 1.0f, -1.0f, 10};
+    emitter.countDownTimer = -1.0f;
+    const PositionComponent pos{};
+
+    Registry reg;
+    Internal::BulkContextImpl implCtx(&reg, 1.0f / 60.0f);
+    ContextFacade ctx(&implCtx);
+
+    system(ctx, emitter, pos);
+
+    Check(emitter.countDownTimer == -1.0f, "negative frequency: timer unchanged (no-op)");
+  }
+
+  // --- Part 2: spawn path — requires pool infrastructure.
+
+  // Timer expiry triggers SpawnProjectile and resets the timer to frequency.
+  {
+    Registry reg;
+    reg.Set<EntityPoolManager>(EntityPoolManager());
+
+    ProjectileEmitSystem system;
+    system.Init(reg);  // registers the projectile pool archetype
+
+    // Emitter entity: no SpriteComponent, so SpawnProjectile skips the position-center offset.
+    const Entity emitterEntity = reg.CreateEntity();
+    reg.AddComponent(emitterEntity, PositionComponent{glm::vec2(100.0f, 200.0f)});
+
+    // frequency=0.5s, countDownTimer just about to expire.
+    const glm::vec2 velocity{300.0f, 0.0f};
+    ProjectileEmitterComponent emitter{velocity, 1.0f, 0.5f, 15};
+    emitter.countDownTimer = 0.001f;
+    const PositionComponent pos{glm::vec2(100.0f, 200.0f)};
+
+    // dt=0.05 → timer = 0.001 - 0.05 = −0.049 → fires.
+    TestContext testCtx{&reg, 0.05f, emitterEntity};
+    ContextFacade ctx{&testCtx};
+
+    system(ctx, emitter, pos);
+
+    Check(emitter.countDownTimer == 0.5f, "timer hard-reset to frequency after firing");
+  }
+
+  // Timer counts down across partial ticks and fires only once on expiry.
+  // Uses frequency=1.0 and dt=0.5 — both exactly representable in IEEE 754 — so
+  // the countdown 1.0→0.5→0.0 hits zero exactly without floating-point drift.
+  {
+    Registry reg;
+    reg.Set<EntityPoolManager>(EntityPoolManager());
+
+    ProjectileEmitSystem system;
+    system.Init(reg);
+
+    const Entity emitterEntity = reg.CreateEntity();
+    reg.AddComponent(emitterEntity, PositionComponent{});
+
+    ProjectileEmitterComponent emitter{{100.0f, 0.0f}, 1.0f, 1.0f, 10};  // frequency=1.0
+    const PositionComponent pos{};
+
+    TestContext testCtx{&reg, 0.5f, emitterEntity};
+    ContextFacade ctx{&testCtx};
+
+    system(ctx, emitter, pos);  // timer 1.0 → 0.5, no fire
+    Check(emitter.countDownTimer > 0.0f, "tick 1: timer at 0.5, no fire yet");
+
+    system(ctx, emitter, pos);  // timer 0.5 → 0.0 → fires, reset to 1.0
+    Check(emitter.countDownTimer == 1.0f, "tick 2: timer expired, reset to frequency (fired)");
+
+    system(ctx, emitter, pos);  // timer 1.0 → 0.5, no second fire
+    Check(emitter.countDownTimer > 0.0f, "tick 3: timer counting down again after reset");
+  }
+
+  return octarine::test::Result();
+}


### PR DESCRIPTION
## Summary

- `CollisionSystem` now tracks the previous frame's pair set (`prevPairSet_`) and filters the `CollisionBatchEvent` to first-contact pairs only — persistent overlaps no longer re-fire every frame
- Eliminates repeat bounces from `ObstacleBounceSystem` (enemy pinned against a wall would flip velocity every frame) and redundant damage checks from `DamageSystem`
- Entity IDs carry a generation counter in the upper 32 bits, so recycled entity slots cannot alias stale entries in `prevPairSet_`
- Added `"Collision: Entering pairs"` perf counter alongside the existing "Intersecting pairs" counter
- `CollisionBatchEvent` comment and `docs/events.md` updated to document the enter-only semantics

## Implementation

`PairSet` is an `unordered_set<pair<EntityID, EntityID>, PairHash>` where each pair is stored in canonical order (`min(a.id, b.id), max(a.id, b.id)`). `PairHash` uses a Boost-style hash_combine over both 64-bit IDs. Each frame:

1. Build `currentSet` from all detected pairs
2. Filter `intersectingPairs` → `enteringPairs` (those not in `prevPairSet_`)
3. `prevPairSet_ = std::move(currentSet)`
4. Emit only `enteringPairs`

## Performance notes

For scenes dominated by short-lived projectile hits (stress scene: ~639 max pairs, all one-shot) the entering-pair count ≈ total count, so the net change is a small hash-set build overhead with ~0 reduction in emitted pairs. The win is for sustained-contact scenes where entities remain overlapping across frames.

## Test plan

- [x] All 13 `octarine-verify.sh` tests pass (including `OctarineCollisionResponseTest` — serial/parallel parity, bounce no-dedup, damage death)
- [x] `clang-format` clean
- [ ] Verify bounce behavior on a level with enemies and obstacles: enemy should bounce once on contact and not oscillate