### PR TITLE
Editor P1: dev-listen protocol ops + adb deploy wrapper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -429,6 +429,28 @@ if (OCTARINE_ENABLE_TESTS)
     endif ()
     add_test(NAME ProjectIniTest COMMAND OctarineProjectIniTest)
 
+    # adb wrapper parser test: standalone — Adb + its Process/Logger deps. Exercises the pure
+    # `adb devices -l` parser; no device or adb binary required.
+    add_executable(OctarineAdbTest
+            src/Deploy/Adb.cpp
+            src/Process/Process.cpp
+            src/General/Logger.cpp
+            tests/AdbTest.cpp
+    )
+    set_target_properties(OctarineAdbTest PROPERTIES
+            CXX_STANDARD 20
+            CXX_STANDARD_REQUIRED ON
+            CXX_EXTENSIONS OFF
+    )
+    target_include_directories(OctarineAdbTest PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/src
+    )
+    target_link_libraries(OctarineAdbTest PRIVATE spdlog::spdlog Threads::Threads)
+    if (MSVC)
+        target_compile_options(OctarineAdbTest PRIVATE /W4 /permissive- /MP /EHsc)
+    endif ()
+    add_test(NAME AdbTest COMMAND OctarineAdbTest)
+
     # Headless ECS / system tests. These link only the ECS core (Registry + Logger) — no SDL,
     # window, or Lua — exactly like the benchmark target, so they build and run fast. One helper
     # per target keeps the registrations DRY.

--- a/src/AssetManager/AssetManager.cpp
+++ b/src/AssetManager/AssetManager.cpp
@@ -123,6 +123,46 @@ void AssetManager::ReleaseAll(const std::vector<std::string> &assetIds) {
   for (const auto &id : assetIds) Release(id);
 }
 
+bool AssetManager::Reload(const std::string &assetId, SDL_Renderer *renderer, MIX_Mixer *mixer) {
+  const CatalogEntry *entry = catalog_.Find(assetId);
+  if (entry == nullptr) {
+    Logger::Warn("AssetManager::Reload: id not in catalog: " + assetId);
+    return false;
+  }
+  // Only refresh assets that are actually resident — nothing to reload otherwise, and we must
+  // not pull in something no scene currently references.
+  const bool resident =
+      texture_store_.Contains(assetId) || font_store_.Contains(assetId) || audio_store_.Contains(assetId);
+  if (!resident) return false;
+
+  // Drop the live handle (refcount untouched), then re-run the catalog load so the new bytes on
+  // disk take effect. The texture store bumps its generation on Remove so cached pointers re-resolve.
+  UnloadAsset(assetId);
+  const bool loaded = LoadFromCatalog(*entry, assetId, renderer, mixer);
+  if (!loaded) {
+    Logger::Error("AssetManager::Reload: reload failed for " + assetId);
+  }
+  return loaded;
+}
+
+int AssetManager::ReloadByPath(const std::string &absPath, SDL_Renderer *renderer, MIX_Mixer *mixer) {
+  std::error_code ec;
+  const std::filesystem::path target = std::filesystem::weakly_canonical(std::filesystem::path(absPath), ec);
+  int reloaded = 0;
+  // Collect ids first: Reload mutates the stores, and the texture path can recurse into atlases,
+  // so don't reload while iterating the catalog map.
+  std::vector<std::string> ids;
+  for (const auto &[id, entry] : catalog_.Entries()) {
+    const std::filesystem::path entryPath =
+        std::filesystem::weakly_canonical(std::filesystem::path(entry.fullPath), ec);
+    if (entryPath == target) ids.push_back(id);
+  }
+  for (const auto &id : ids) {
+    if (Reload(id, renderer, mixer)) ++reloaded;
+  }
+  return reloaded;
+}
+
 int AssetManager::RefCount(const std::string &assetId) const { return refcounter_.Count(assetId); }
 
 // Mutually recursive with Release: an atlas member's unload path calls Release(atlasId).

--- a/src/AssetManager/AssetManager.h
+++ b/src/AssetManager/AssetManager.h
@@ -74,6 +74,18 @@ class AssetManager {
   void Release(const std::string& assetId);
   void ReleaseAll(const std::vector<std::string>& assetIds);
 
+  // Force a resident asset to reload from disk (dev hot-push). When `assetId` is currently
+  // resident its handle is destroyed and re-loaded from the catalog, preserving the acquire
+  // count so existing references keep working (the texture store bumps its generation so cached
+  // SDL_Texture* re-resolve). No-op (returns false) for unknown or non-resident ids. Dev-only:
+  // editor-driven content push, never on shipped builds.
+  bool Reload(const std::string& assetId, SDL_Renderer* renderer, MIX_Mixer* mixer);
+
+  // Reload every resident asset whose catalog source file is `absPath` (an absolute path). The
+  // hot-push path resolves a pushed project-relative file to its absolute form, writes the bytes,
+  // then calls this to refresh whatever ids that file backs. Returns the number of ids reloaded.
+  int ReloadByPath(const std::string& absPath, SDL_Renderer* renderer, MIX_Mixer* mixer);
+
   // Validate scene references against the catalog: an id missing from the catalog, or present but
   // whose backing file no longer exists on disk, is logged once with the referencing context.
   // Returns the number of failures (0 == clean). This is the authoritative miss check, replacing

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,6 +24,7 @@ set(OCTARINE_CORE_SOURCES
         General/Logger.cpp
         ECS/Registry.cpp
         Game/GameConfig.cpp
+        Deploy/Adb.cpp
         Process/Process.cpp
         Project/ProjectIni.cpp
 )
@@ -232,7 +233,7 @@ set(OCTARINE_ENGINE_SOURCES
 # DevListenServer (Stage 6): TCP listener for the dev iterate loop. Available in editor + player
 # presets; compile-stripped from ship-release (OCTARINE_SHIPPED).
 if (NOT OCTARINE_SHIPPED)
-    list(APPEND OCTARINE_ENGINE_SOURCES Dev/DevListenServer.cpp)
+    list(APPEND OCTARINE_ENGINE_SOURCES Dev/DevListenServer.cpp Dev/DevListenDispatch.cpp)
 endif ()
 octarine_library(octarine_engine ${OCTARINE_ENGINE_SOURCES})
 target_link_libraries(octarine_engine PUBLIC

--- a/src/Deploy/Adb.cpp
+++ b/src/Deploy/Adb.cpp
@@ -1,0 +1,132 @@
+#include "Deploy/Adb.h"
+
+#include <sstream>
+#include <utility>
+
+#include "General/Logger.h"
+
+namespace octarine::deploy {
+namespace {
+using octarine::process::Process;
+using octarine::process::SpawnOptions;
+
+// Builds an adb argv, prefixing `-s <serial>` when a serial is given (empty = the single attached
+// device). `tail` is the subcommand + its args.
+std::vector<std::string> AdbArgv(const std::string& serial, std::vector<std::string> tail) {
+  std::vector<std::string> argv;
+  argv.reserve(tail.size() + 3);
+  argv.emplace_back("adb");
+  if (!serial.empty()) {
+    argv.emplace_back("-s");
+    argv.push_back(serial);
+  }
+  for (auto& a : tail) argv.push_back(std::move(a));
+  return argv;
+}
+
+// Spawns `adb <args>` to completion, capturing stdout (and stderr) into `*out` when non-null.
+// Returns the exit code, or -1 when adb could not be spawned (not on PATH).
+int RunAdb(std::vector<std::string> argv, std::string* out) {
+  SpawnOptions opts;
+  opts.argv = std::move(argv);
+  auto proc = Process::Spawn(opts);
+  if (!proc) {
+    Logger::Warn("Adb: failed to spawn 'adb' (is Android Platform Tools on PATH?)");
+    return -1;
+  }
+  if (out != nullptr) {
+    proc->OnStdout([out](std::string_view chunk) { out->append(chunk); });
+    proc->OnStderr([out](std::string_view chunk) { out->append(chunk); });
+  }
+  return proc->Wait();
+}
+
+// Pulls the value of a `key:value` token (e.g. "model:Pixel_5") out of a -l detail line. Empty if
+// the key isn't present.
+std::string DetailField(const std::string& line, const std::string& key) {
+  const std::string needle = key + ":";
+  std::size_t pos = line.find(needle);
+  if (pos == std::string::npos) return {};
+  pos += needle.size();
+  const std::size_t end = line.find_first_of(" \t", pos);
+  return line.substr(pos, end == std::string::npos ? std::string::npos : end - pos);
+}
+}  // namespace
+
+std::vector<AdbDevice> Adb::ParseDevices(std::string_view devicesOutput) {
+  std::vector<AdbDevice> devices;
+  std::istringstream stream{std::string(devicesOutput)};
+  std::string line;
+  while (std::getline(stream, line)) {
+    // Trim a trailing CR so CRLF capture (Windows adb) parses identically.
+    if (!line.empty() && line.back() == '\r') line.pop_back();
+    if (line.empty()) continue;
+    // Skip the header and the daemon chatter adb sometimes prepends.
+    if (line.rfind("List of devices", 0) == 0) continue;
+    if (line.rfind("* daemon", 0) == 0) continue;
+
+    std::istringstream cols{line};
+    AdbDevice dev;
+    cols >> dev.serial >> dev.state;
+    if (dev.serial.empty() || dev.state.empty()) continue;
+    dev.model = DetailField(line, "model");
+    dev.product = DetailField(line, "product");
+    devices.push_back(std::move(dev));
+  }
+  return devices;
+}
+
+std::optional<std::string> Adb::Detect() {
+  std::string out;
+  if (RunAdb({"adb", "version"}, &out) != 0) return std::nullopt;
+  // First non-empty line, e.g. "Android Debug Bridge version 1.0.41".
+  std::istringstream stream{out};
+  std::string line;
+  while (std::getline(stream, line)) {
+    if (!line.empty() && line.back() == '\r') line.pop_back();
+    if (!line.empty()) return line;
+  }
+  return out.empty() ? std::nullopt : std::optional<std::string>{out};
+}
+
+std::vector<AdbDevice> Adb::ListDevices() {
+  std::string out;
+  if (RunAdb({"adb", "devices", "-l"}, &out) != 0) return {};
+  return ParseDevices(out);
+}
+
+bool Adb::Connect(const std::string& hostPort) {
+  std::string out;
+  // adb connect exits 0 even for some failures on older clients; gate on the success phrasing too.
+  return RunAdb({"adb", "connect", hostPort}, &out) == 0 && out.find("connected") != std::string::npos;
+}
+
+bool Adb::Disconnect(const std::string& hostPort) { return RunAdb({"adb", "disconnect", hostPort}, nullptr) == 0; }
+
+bool Adb::Install(const std::string& serial, const std::string& apkPath, bool replace) {
+  std::vector<std::string> tail{"install"};
+  if (replace) tail.emplace_back("-r");
+  tail.push_back(apkPath);
+  std::string out;
+  return RunAdb(AdbArgv(serial, std::move(tail)), &out) == 0 && out.find("Success") != std::string::npos;
+}
+
+bool Adb::Push(const std::string& serial, const std::string& local, const std::string& remote) {
+  return RunAdb(AdbArgv(serial, {"push", local, remote}), nullptr) == 0;
+}
+
+bool Adb::Reverse(const std::string& serial, int devicePort, int hostPort) {
+  const std::string deviceSpec = "tcp:" + std::to_string(devicePort);
+  const std::string hostSpec = "tcp:" + std::to_string(hostPort);
+  return RunAdb(AdbArgv(serial, {"reverse", deviceSpec, hostSpec}), nullptr) == 0;
+}
+
+std::optional<Process> Adb::Logcat(const std::string& serial, const std::vector<std::string>& tags) {
+  std::vector<std::string> tail{"logcat"};
+  for (const auto& t : tags) tail.push_back(t);
+  SpawnOptions opts;
+  opts.argv = AdbArgv(serial, std::move(tail));
+  return Process::Spawn(opts);
+}
+
+}  // namespace octarine::deploy

--- a/src/Deploy/Adb.h
+++ b/src/Deploy/Adb.h
@@ -1,0 +1,66 @@
+#pragma once
+
+// Adb — thin wrapper around the Android Platform Tools `adb` CLI, used by the editor's Devices
+// panel + hot-push deploy path. Every call shells out through octarine::process::Process; nothing
+// here links the Android SDK. Blocking calls (ListDevices/Connect/Install/Push/Reverse/Detect)
+// spawn-and-Wait; Logcat hands back a live Process the caller owns and pumps for streaming output.
+//
+// Lives in octarine_core (alongside Process/) so both the editor and a headless CLI can reach it.
+
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "Process/Process.h"
+
+namespace octarine::deploy {
+
+// One row of `adb devices -l`. `state` is adb's own word ("device", "offline", "unauthorized",
+// "no permissions", ...); only "device" means usable, which IsReady() reflects.
+struct AdbDevice {
+  std::string serial;   // "emulator-5554" or "192.168.1.5:5555"
+  std::string state;    // adb connection state
+  std::string model;    // model:<...> from -l (underscores kept), empty when absent
+  std::string product;  // product:<...> from -l, empty when absent
+
+  [[nodiscard]] bool IsReady() const { return state == "device"; }
+};
+
+// Shown by the UI when Detect() reports adb is missing.
+inline constexpr const char* kInstallPlatformToolsUrl = "https://developer.android.com/tools/releases/platform-tools";
+
+class Adb {
+ public:
+  // PATH-probe via `adb version`. Returns adb's first version line on success, nullopt when adb is
+  // absent / not runnable (UI then points the user at kInstallPlatformToolsUrl).
+  static std::optional<std::string> Detect();
+
+  // `adb devices -l` parsed into rows. Empty on adb-missing / command failure / no devices.
+  static std::vector<AdbDevice> ListDevices();
+
+  // Pure parser for `adb devices -l` stdout — exposed so it can be unit-tested without a device.
+  static std::vector<AdbDevice> ParseDevices(std::string_view devicesOutput);
+
+  // `adb connect <hostPort>` / `adb disconnect <hostPort>`. True when adb reports success.
+  static bool Connect(const std::string& hostPort);
+  static bool Disconnect(const std::string& hostPort);
+
+  // `adb -s <serial> install [-r] <apkPath>`. Empty serial targets the single attached device.
+  static bool Install(const std::string& serial, const std::string& apkPath, bool replace = true);
+
+  // `adb -s <serial> push <local> <remote>`.
+  static bool Push(const std::string& serial, const std::string& local, const std::string& remote);
+
+  // `adb -s <serial> reverse tcp:<devicePort> tcp:<hostPort>` — forwards a device-side port back to
+  // the host so an on-device build can reach the host's --dev-listen server over localhost.
+  static bool Reverse(const std::string& serial, int devicePort, int hostPort);
+
+  // `adb -s <serial> logcat <tags...>` — returns a LIVE process for the caller to Pump() for
+  // streaming logs (and Kill() when done). nullopt if adb could not be spawned. `tags` are passed
+  // verbatim (e.g. {"Octarine:I", "*:S"} to isolate the engine tag).
+  static std::optional<octarine::process::Process> Logcat(const std::string& serial,
+                                                          const std::vector<std::string>& tags = {});
+};
+
+}  // namespace octarine::deploy

--- a/src/Dev/DevListenDispatch.cpp
+++ b/src/Dev/DevListenDispatch.cpp
@@ -1,0 +1,169 @@
+#include "Dev/DevListenDispatch.h"
+
+#ifndef OCTARINE_SHIPPED
+
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <sol/sol.hpp>
+#include <string>
+#include <vector>
+
+#include "AssetManager/AssetManager.h"
+#include "ECS/Registry.h"
+#include "Engine/EngineContext.h"
+#include "Engine/SceneLoader.h"
+#include "General/Logger.h"
+#include "Lua/HotReload/ScriptHotReload.h"
+
+namespace octarine::dev {
+namespace {
+
+// reply convention for the mutating ops: byte[0] = 1 ok / 0 error, remainder = utf8 message.
+std::string OkReply(const std::string& message = {}) { return std::string(1, '\1') + message; }
+std::string ErrReply(const std::string& message) { return std::string(1, '\0') + message; }
+
+// Parses a push body: u32 LE path_len | path[path_len] | bytes[rest]. Returns false on truncation.
+bool ParsePushBody(const std::vector<char>& body, std::string& path, const char*& bytes, std::size_t& bytes_len) {
+  if (body.size() < sizeof(std::uint32_t)) return false;
+  std::uint32_t path_len = 0;
+  std::memcpy(&path_len, body.data(), sizeof(path_len));
+  const std::size_t header = sizeof(path_len) + static_cast<std::size_t>(path_len);
+  if (header > body.size()) return false;
+  path.assign(body.data() + sizeof(path_len), path_len);
+  bytes = body.data() + header;
+  bytes_len = body.size() - header;
+  return true;
+}
+
+// Writes `bytes` to <project-root>/<relPath>, creating parent dirs. Resolves the root off the
+// AssetManager base path (the project dir passed on the command line). Returns the absolute path
+// written, or empty on failure.
+std::string WriteProjectFile(Registry& registry, const std::string& relPath, const char* bytes, std::size_t len) {
+  std::string abs = registry.Get<AssetManager>().GetFullPath(relPath);
+  std::error_code ec;
+  std::filesystem::create_directories(std::filesystem::path(abs).parent_path(), ec);
+  std::ofstream out(abs, std::ios::binary | std::ios::trunc);
+  if (!out) {
+    Logger::Error("DevListenServer: failed to open for write: " + abs);
+    return {};
+  }
+  if (len > 0) out.write(bytes, static_cast<std::streamsize>(len));
+  if (!out) {
+    Logger::Error("DevListenServer: write failed: " + abs);
+    return {};
+  }
+  return abs;
+}
+
+// Renders the first return value of an eval as text for the reply. Primitive types only; tables /
+// userdata / functions report their type name (callers that need richer output can `return tostring(x)`
+// in the snippet itself). The ok byte already signals success, so an empty string is fine here.
+std::string StringifyLuaResult(const sol::protected_function_result& r) {
+  if (r.return_count() < 1) return {};
+  const sol::object first = r.get<sol::object>(0);
+  switch (first.get_type()) {
+    case sol::type::string:
+      return first.as<std::string>();
+    case sol::type::number:
+      return std::to_string(first.as<double>());
+    case sol::type::boolean:
+      return first.as<bool>() ? "true" : "false";
+    case sol::type::nil:
+    case sol::type::none:
+      return {};
+    default:
+      return "<" + std::string(sol::type_name(first.lua_state(), first.get_type())) + ">";
+  }
+}
+
+void HandleEvalLua(sol::state& lua, const std::vector<char>& body, std::string& reply_body) {
+  const std::string src(body.data(), body.size());
+  const sol::protected_function_result r = lua.safe_script(src, sol::script_pass_on_error);
+  if (r.valid()) {
+    reply_body = OkReply(StringifyLuaResult(r));
+  } else {
+    const sol::error err = r;
+    reply_body = ErrReply(err.what());
+  }
+}
+
+void HandleReloadScene(Registry& registry, std::string& reply_body) {
+  auto* loader = registry.TryGet<SceneLoader*>();
+  if (loader == nullptr || *loader == nullptr) {
+    reply_body = ErrReply("no scene loader");
+    return;
+  }
+  (*loader)->ReloadScene();
+  reply_body = OkReply();
+}
+
+void HandlePushScript(Registry& registry, sol::state& lua, const std::vector<char>& body, std::string& reply_body) {
+  std::string path;
+  const char* bytes = nullptr;
+  std::size_t len = 0;
+  if (!ParsePushBody(body, path, bytes, len)) {
+    reply_body = ErrReply("malformed push body");
+    return;
+  }
+  if (WriteProjectFile(registry, path, bytes, len).empty()) {
+    reply_body = ErrReply("write failed: " + path);
+    return;
+  }
+  // Force a reload so the new source is live this frame rather than waiting on the mtime poll.
+  if (auto* hot = registry.TryGet<ScriptHotReload>()) {
+    hot->ForceReloadAll(registry, lua);
+  }
+  reply_body = OkReply(path);
+}
+
+void HandlePushAsset(Registry& registry, const std::vector<char>& body, std::string& reply_body) {
+  std::string path;
+  const char* bytes = nullptr;
+  std::size_t len = 0;
+  if (!ParsePushBody(body, path, bytes, len)) {
+    reply_body = ErrReply("malformed push body");
+    return;
+  }
+  const std::string abs = WriteProjectFile(registry, path, bytes, len);
+  if (abs.empty()) {
+    reply_body = ErrReply("write failed: " + path);
+    return;
+  }
+  auto& engine = registry.Get<EngineContext>();
+  registry.Get<AssetManager>().ReloadByPath(abs, engine.sdlRenderer, engine.mixer);
+  reply_body = OkReply(path);
+}
+
+}  // namespace
+
+CommandHandler MakeEngineCommandHandler(Registry& registry, sol::state& lua) {
+  Registry* reg = &registry;
+  sol::state* lua_ptr = &lua;
+  return [reg, lua_ptr](OpCode op, const std::vector<char>& body, std::uint32_t& reply_op, std::string& reply_body) {
+    reply_op = static_cast<std::uint32_t>(op);
+    switch (op) {
+      case OpCode::EvalLua:
+        HandleEvalLua(*lua_ptr, body, reply_body);
+        return;
+      case OpCode::ReloadScene:
+        HandleReloadScene(*reg, reply_body);
+        return;
+      case OpCode::PushScript:
+        HandlePushScript(*reg, *lua_ptr, body, reply_body);
+        return;
+      case OpCode::PushAsset:
+        HandlePushAsset(*reg, body, reply_body);
+        return;
+      default:
+        reply_op = kErrorReplyOp;
+        reply_body.clear();
+        return;
+    }
+  };
+}
+
+}  // namespace octarine::dev
+
+#endif  // !OCTARINE_SHIPPED

--- a/src/Dev/DevListenDispatch.cpp
+++ b/src/Dev/DevListenDispatch.cpp
@@ -57,25 +57,18 @@ std::string WriteProjectFile(Registry& registry, const std::string& relPath, con
   return abs;
 }
 
-// Renders the first return value of an eval as text for the reply. Primitive types only; tables /
-// userdata / functions report their type name (callers that need richer output can `return tostring(x)`
-// in the snippet itself). The ok byte already signals success, so an empty string is fine here.
+// Renders the first return value of an eval as text for the reply. Primitive types only; nil /
+// tables / userdata / functions render empty (callers that need richer output can
+// `return tostring(x)` in the snippet itself). The ok byte already signals success, so empty is
+// fine. Uses is<T>() rather than the sol::type enum on purpose: `nil` is a macro on some platforms
+// (Objective-C on macOS), so `sol::type::nil` fails to compile there.
 std::string StringifyLuaResult(const sol::protected_function_result& r) {
   if (r.return_count() < 1) return {};
   const sol::object first = r.get<sol::object>(0);
-  switch (first.get_type()) {
-    case sol::type::string:
-      return first.as<std::string>();
-    case sol::type::number:
-      return std::to_string(first.as<double>());
-    case sol::type::boolean:
-      return first.as<bool>() ? "true" : "false";
-    case sol::type::nil:
-    case sol::type::none:
-      return {};
-    default:
-      return "<" + std::string(sol::type_name(first.lua_state(), first.get_type())) + ">";
-  }
+  if (first.is<std::string>()) return first.as<std::string>();
+  if (first.is<bool>()) return first.as<bool>() ? "true" : "false";
+  if (first.is<double>()) return std::to_string(first.as<double>());
+  return {};
 }
 
 void HandleEvalLua(sol::state& lua, const std::vector<char>& body, std::string& reply_body) {

--- a/src/Dev/DevListenDispatch.h
+++ b/src/Dev/DevListenDispatch.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#ifndef OCTARINE_SHIPPED
+
+#include "Dev/DevListenServer.h"
+
+class Registry;
+namespace sol {
+class state;
+}
+
+namespace octarine::dev {
+
+// Builds the main-thread CommandHandler that applies the dev-listen engine-mutating ops (eval_lua,
+// reload_scene, push_script, push_asset) against the live engine. Captures non-owning references to
+// the Registry + sol::state, both stable for the engine's lifetime. Install the result via
+// DevListenServer::SetCommandHandler. Lives in the engine layer so the transport (DevListenServer)
+// stays free of Registry / sol / AssetManager dependencies and its smoke test can build standalone.
+CommandHandler MakeEngineCommandHandler(Registry& registry, sol::state& lua);
+
+}  // namespace octarine::dev
+
+#endif  // !OCTARINE_SHIPPED

--- a/src/Dev/DevListenServer.cpp
+++ b/src/Dev/DevListenServer.cpp
@@ -31,8 +31,13 @@ constexpr int kSocketError = -1;
 #endif
 
 #include <atomic>
+#include <chrono>
+#include <condition_variable>
 #include <cstdint>
 #include <cstring>
+#include <deque>
+#include <memory>
+#include <mutex>
 #include <string>
 #include <thread>
 #include <utility>
@@ -40,6 +45,14 @@ constexpr int kSocketError = -1;
 
 namespace octarine::dev {
 namespace {
+// Listener select() wait before re-checking stop_requested, and the same cadence for a parked
+// command re-checking stop while it waits on Pump(). Keeps Stop() prompt without a blocking accept.
+constexpr int kSelectTimeoutMs = 100;
+constexpr int kPumpWaitMs = 100;
+constexpr int kMicrosPerMilli = 1000;
+// Hard cap on an inbound frame body so a malformed/hostile length can't drive an enormous alloc.
+constexpr std::uint32_t kMaxFrameBytes = 1024U * 1024U;
+
 void CloseSocket(socket_t s) {
   if (s == kInvalidSocket) return;
 #ifdef _WIN32
@@ -129,6 +142,43 @@ void WsaRelease() {
 void WsaAcquire() {}
 void WsaRelease() {}
 #endif
+
+// Hand-off slot between the listener thread (which parks an engine-mutating op and waits) and
+// the main thread (which runs it in Pump and fills the reply). shared_ptr-owned so neither side
+// outlives the other if Stop() abandons a wait mid-flight.
+struct ReplySlot {
+  std::mutex m;
+  std::condition_variable cv;
+  bool done = false;
+  std::uint32_t reply_op = 0;
+  std::string reply_body;
+};
+
+struct PendingCommand {
+  OpCode op{};
+  std::vector<char> body;
+  std::shared_ptr<ReplySlot> slot;
+};
+
+// The subset of Impl the connection helpers touch, passed by reference so the free helpers need
+// not name the private DevListenServer::Impl type.
+struct ListenerContext {
+  std::mutex& queue_mutex;
+  std::deque<PendingCommand>& queue;
+  std::atomic<bool>& stop_requested;
+};
+
+bool IsMainThreadOp(OpCode op) {
+  switch (op) {
+    case OpCode::EvalLua:
+    case OpCode::ReloadScene:
+    case OpCode::PushScript:
+    case OpCode::PushAsset:
+      return true;
+    default:
+      return false;
+  }
+}
 }  // namespace
 
 struct DevListenServer::Impl {
@@ -137,7 +187,89 @@ struct DevListenServer::Impl {
   std::uint16_t bound_port{0};
   socket_t listen_sock{kInvalidSocket};
   std::thread listener;
+
+  // Engine-mutating ops parked by the listener thread, drained by Pump() on the main thread.
+  std::mutex queue_mutex;
+  std::deque<PendingCommand> queue;
+  CommandHandler handler;  // set once on the main thread before Start; read only in Pump
 };
+
+// Connection-serving helpers — kept small + free so the listener loop stays a thin
+// accept-and-dispatch (and under the complexity threshold).
+namespace {
+// Parks an engine-mutating op on the queue and blocks until Pump() services it, re-checking
+// stop_requested so Stop() can't deadlock a listener waiting on a Pump that will never come.
+void ParkAndReply(socket_t cs, ListenerContext& ctx, OpCode op, std::vector<char> body) {
+  auto slot = std::make_shared<ReplySlot>();
+  {
+    std::lock_guard<std::mutex> lk(ctx.queue_mutex);
+    ctx.queue.push_back(PendingCommand{op, std::move(body), slot});
+  }
+  std::unique_lock<std::mutex> lk(slot->m);
+  while (!slot->done && !ctx.stop_requested.load(std::memory_order_acquire)) {
+    slot->cv.wait_for(lk, std::chrono::milliseconds(kPumpWaitMs));
+  }
+  if (slot->done) {
+    WriteFrame(cs, slot->reply_op, slot->reply_body.data(), static_cast<std::uint32_t>(slot->reply_body.size()));
+  }
+}
+
+// Pure-I/O ops answered entirely on the listener thread (no engine state touched).
+void ReplyDirect(socket_t cs, OpCode op, const std::vector<char>& body) {
+  switch (op) {
+    case OpCode::Hello:
+      WriteFrame(cs, static_cast<std::uint32_t>(OpCode::Hello), kHelloBanner,
+                 static_cast<std::uint32_t>(std::strlen(kHelloBanner)));
+      break;
+    case OpCode::Ping:
+      // Echo the client nonce back (any body size; some clients ping empty).
+      WriteFrame(cs, static_cast<std::uint32_t>(OpCode::Ping), body.data(), static_cast<std::uint32_t>(body.size()));
+      break;
+    default:
+      Logger::Warn("DevListenServer: unknown op=" + std::to_string(static_cast<std::uint32_t>(op)));
+      WriteFrame(cs, kErrorReplyOp, nullptr, 0);
+      break;
+  }
+}
+
+// Reads one `length | op | body` frame off an accepted socket and dispatches it (engine-mutating
+// ops park for the main thread; pure-I/O ops reply inline). One frame per connection (v1); always
+// closes the socket.
+void ServeConnection(socket_t cs, ListenerContext& ctx) {
+  // Accepted sockets inherit the listener's non-blocking flag on Windows; force blocking so the
+  // ReadAll/WriteAll loops keep their simple >0 / <=0 semantics.
+  SetSocketBlocking(cs, true);
+  std::uint32_t length = 0;
+  if (!ReadAll(cs, &length, sizeof(length))) {
+    CloseSocket(cs);
+    return;
+  }
+  if (length < sizeof(std::uint32_t) || length > kMaxFrameBytes) {
+    Logger::Warn("DevListenServer: rejecting frame length=" + std::to_string(length));
+    CloseSocket(cs);
+    return;
+  }
+  std::uint32_t op = 0;
+  if (!ReadAll(cs, &op, sizeof(op))) {
+    CloseSocket(cs);
+    return;
+  }
+  const std::uint32_t body_len = length - static_cast<std::uint32_t>(sizeof(std::uint32_t));
+  std::vector<char> body(body_len);
+  if (body_len > 0 && !ReadAll(cs, body.data(), body_len)) {
+    CloseSocket(cs);
+    return;
+  }
+
+  const auto opcode = static_cast<OpCode>(op);
+  if (IsMainThreadOp(opcode)) {
+    ParkAndReply(cs, ctx, opcode, std::move(body));
+  } else {
+    ReplyDirect(cs, opcode, body);
+  }
+  CloseSocket(cs);
+}
+}  // namespace
 
 DevListenServer::DevListenServer() : impl_(std::make_unique<Impl>()) {}
 
@@ -150,10 +282,37 @@ bool DevListenServer::IsRunning() const { return impl_ && impl_->running.load(st
 
 std::uint16_t DevListenServer::BoundPort() const { return impl_ ? impl_->bound_port : 0; }
 
+void DevListenServer::SetCommandHandler(CommandHandler handler) {
+  if (impl_) impl_->handler = std::move(handler);
+}
+
 void DevListenServer::Pump() {
-  // PR-A reserved hook: no off-thread commands queued yet. PR-B will drain a SPSC ring of
-  // EvalLua / ReloadScene / PushScript / PushAsset requests here so they execute on the main
-  // thread (Registry / sol::state / AssetManager are not thread-safe).
+  if (!impl_) return;
+
+  std::deque<PendingCommand> batch;
+  {
+    std::lock_guard<std::mutex> lk(impl_->queue_mutex);
+    batch.swap(impl_->queue);
+  }
+
+  for (auto& cmd : batch) {
+    auto reply_op = static_cast<std::uint32_t>(cmd.op);
+    std::string reply_body;
+    if (impl_->handler) {
+      impl_->handler(cmd.op, cmd.body, reply_op, reply_body);
+    } else {
+      // No engine handler installed — refuse rather than hang the client.
+      reply_op = kErrorReplyOp;
+    }
+
+    {
+      std::lock_guard<std::mutex> lk(cmd.slot->m);
+      cmd.slot->reply_op = reply_op;
+      cmd.slot->reply_body = std::move(reply_body);
+      cmd.slot->done = true;
+    }
+    cmd.slot->cv.notify_one();
+  }
 }
 
 bool DevListenServer::Start(const ServerOptions& opts) {
@@ -217,15 +376,16 @@ bool DevListenServer::Start(const ServerOptions& opts) {
 
   impl_->listener = std::thread([this]() {
     socket_t ls = impl_->listen_sock;
+    ListenerContext ctx{impl_->queue_mutex, impl_->queue, impl_->stop_requested};
     while (!impl_->stop_requested.load(std::memory_order_acquire)) {
-      // Wait up to 100ms for a pending connection, then re-check stop_requested. This is
-      // what makes Stop() prompt and deadlock-free: no blocking accept() to interrupt.
+      // Wait up to kSelectTimeoutMs for a pending connection, then re-check stop_requested. This
+      // is what makes Stop() prompt and deadlock-free: no blocking accept() to interrupt.
       fd_set readable;
       FD_ZERO(&readable);
       FD_SET(ls, &readable);
       timeval timeout{};
       timeout.tv_sec = 0;
-      timeout.tv_usec = 100 * 1000;  // 100ms
+      timeout.tv_usec = kSelectTimeoutMs * kMicrosPerMilli;
       const int ready = ::select(static_cast<int>(ls + 1), &readable, nullptr, nullptr, &timeout);
       if (ready <= 0) {
         // 0 = timeout, <0 = interrupted/error; loop and re-test stop_requested.
@@ -236,59 +396,10 @@ bool DevListenServer::Start(const ServerOptions& opts) {
       socklen_t clen = sizeof(client);
       socket_t cs = ::accept(ls, reinterpret_cast<sockaddr*>(&client), &clen);
       if (cs == kInvalidSocket) {
-        // Connection withdrawn between select() and accept(), or a transient error;
-        // not fatal — go back to waiting.
+        // Connection withdrawn between select() and accept(), or a transient error; not fatal.
         continue;
       }
-      // The accepted socket inherits the listener's non-blocking flag on Windows; force it
-      // blocking so the ReadAll/WriteAll loops below keep their simple semantics.
-      SetSocketBlocking(cs, true);
-      // Handle one frame per connection for v1 simplicity; the matrix of
-      // op x persistent-connection-state is small enough that closing+reopening is fine.
-      std::uint32_t length = 0;
-      if (!ReadAll(cs, &length, sizeof(length))) {
-        CloseSocket(cs);
-        continue;
-      }
-      if (length < 4 || length > 1024 * 1024) {
-        Logger::Warn("DevListenServer: rejecting frame length=" + std::to_string(length));
-        CloseSocket(cs);
-        continue;
-      }
-      std::uint32_t op = 0;
-      if (!ReadAll(cs, &op, sizeof(op))) {
-        CloseSocket(cs);
-        continue;
-      }
-
-      const std::uint32_t body_len = length - 4;
-      std::vector<char> body(body_len);
-      if (body_len > 0 && !ReadAll(cs, body.data(), body_len)) {
-        CloseSocket(cs);
-        continue;
-      }
-
-      switch (static_cast<OpCode>(op)) {
-        case OpCode::Hello: {
-          WriteFrame(cs, static_cast<std::uint32_t>(OpCode::Hello), kHelloBanner,
-                     static_cast<std::uint32_t>(std::strlen(kHelloBanner)));
-          break;
-        }
-        case OpCode::Ping: {
-          // Echo the 8-byte client nonce back. Tolerate other body sizes (some clients
-          // may ping with an empty body); just echo whatever they sent.
-          WriteFrame(cs, static_cast<std::uint32_t>(OpCode::Ping), body.data(), body_len);
-          break;
-        }
-        default: {
-          Logger::Warn("DevListenServer: unknown op=" + std::to_string(op));
-          const std::uint32_t err_op = 0xFFFFFFFFu;
-          WriteFrame(cs, err_op, nullptr, 0);
-          break;
-        }
-      }
-
-      CloseSocket(cs);
+      ServeConnection(cs, ctx);
     }
   });
 

--- a/src/Dev/DevListenServer.h
+++ b/src/Dev/DevListenServer.h
@@ -2,31 +2,45 @@
 
 #ifndef OCTARINE_SHIPPED
 
-// DevListenServer — Stage 6 of ai/EditorBuildAndDeployPlan.md (PR-A foundation: TCP listener +
-// hello/ping handshake; PR-B will add eval_lua / reload_scene / push_script / push_asset).
-//
-// Compile-time stripped from shipped builds (#ifndef OCTARINE_SHIPPED). When enabled, owns a
-// background listener thread bound to 127.0.0.1:<port> (or 0.0.0.0:<port> with --dev-listen-all)
-// and serves a tiny length-prefixed binary protocol:
+// DevListenServer — editor dev-iteration TCP listener (compile-time stripped from shipped builds
+// via #ifndef OCTARINE_SHIPPED). When enabled, owns a background listener thread bound to
+// 127.0.0.1:<port> (or 0.0.0.0:<port> with --dev-listen-all) and serves a tiny length-prefixed
+// binary protocol:
 //
 //     each message:  uint32 LE length | uint32 LE op | body[length-4]
 //     hello reply:   op=Hello, body = "OCTARINE_DEV_LISTEN/v1\n"
-//     ping reply:    op=Pong,  body = client nonce (8 bytes echoed back)
+//     ping reply:    op=Pong,  body = client nonce echoed back
 //
-// I/O lives on the listener thread; PR-A ops are pure I/O so they reply directly. Pump() exists
-// on the main thread as the seam PR-B will route commands-that-touch-engine-state through (Lua
-// eval, scene reload, asset/script writes) once those land. No engine state is touched off the
-// main thread today.
+// Pure-I/O ops (Hello/Ping) reply directly on the listener thread. The engine-mutating ops
+// (EvalLua / ReloadScene / PushScript / PushAsset) cannot touch the Registry / sol::state /
+// AssetManager off the main thread, so the listener parks each one on a queue and blocks until
+// the main thread drains it in Pump(); Pump runs the command and hands the reply back so the
+// listener can write it and close. See `kPush*` body layout on each opcode below.
 
 #include <cstdint>
+#include <functional>
 #include <memory>
+#include <string>
+#include <vector>
 
 namespace octarine::dev {
 enum class OpCode : std::uint32_t {
-  Hello = 1,  // body: empty       -> reply Hello with banner
+  Hello = 1,  // body: empty        -> reply Hello with banner
   Ping = 2,   // body: u64 LE nonce -> reply Pong with same nonce
-              // Reserved by PR-B (do not reuse): 10 EvalLua, 11 ReloadScene, 12 PushScript, 13 PushAsset.
+  // Engine-mutating ops, parked by the listener and dispatched to the main thread via Pump():
+  EvalLua = 10,      // body: lua source        -> reply { u8 ok, utf8 result/error }
+  ReloadScene = 11,  // body: empty             -> re-runs the active scene; reply { u8 ok }
+  PushScript = 12,   // body: u32 path_len | path | bytes -> writes script + forces reload; reply { u8 ok }
+  PushAsset = 13,    // body: u32 path_len | path | bytes -> writes asset + reloads it; reply { u8 ok }
 };
+
+// Handler the engine installs to apply an engine-mutating op on the main thread. Invoked from
+// Pump() for each parked command; receives the op + raw body and fills reply_op/reply_body (the
+// frame written back to the client). Keeping this a std::function is what lets the transport layer
+// carry zero engine dependencies — the Registry/sol/AssetManager-touching logic lives in
+// DevListenDispatch (engine layer), installed via SetCommandHandler.
+using CommandHandler =
+    std::function<void(OpCode op, const std::vector<char>& body, std::uint32_t& reply_op, std::string& reply_body)>;
 
 struct ServerOptions {
   std::uint16_t port = 0;   // 0 = pick ephemeral (BoundPort() reads back after Start)
@@ -55,9 +69,13 @@ class DevListenServer {
   bool IsRunning() const;
   std::uint16_t BoundPort() const;
 
-  // Per-frame drain for commands that must run on the main thread. PR-A queues nothing
-  // (hello/ping reply on the listener thread); PR-B wires eval_lua / reload_scene through
-  // a SPSC ring drained here.
+  // Install the main-thread handler for engine-mutating ops. Call before Start() (or any time;
+  // commands park until a handler exists). Without one, parked ops reply with an error frame.
+  void SetCommandHandler(CommandHandler handler);
+
+  // Per-frame drain for engine-mutating commands the listener parked. Runs each queued op through
+  // the installed handler on the calling (main) thread, then unblocks the listener with its reply.
+  // Cheap when the queue is empty; call every frame. Hello/Ping never reach here.
   void Pump();
 
  private:
@@ -65,8 +83,12 @@ class DevListenServer {
   std::unique_ptr<Impl> impl_;
 };
 
-// Engine banner returned by the Hello op. Versioned so PR-B can bump and clients can gate.
+// Engine banner returned by the Hello op. Versioned so clients can gate on protocol capabilities.
 inline constexpr const char* kHelloBanner = "OCTARINE_DEV_LISTEN/v1\n";
+
+// Reply op written back for an unknown opcode or a command with no handler installed. Distinct
+// from every real OpCode so clients can detect "server refused" without parsing the body.
+inline constexpr std::uint32_t kErrorReplyOp = 0xFFFFFFFFu;
 }  // namespace octarine::dev
 
 #endif  // !OCTARINE_SHIPPED

--- a/src/Game/Game.cpp
+++ b/src/Game/Game.cpp
@@ -89,6 +89,7 @@
 #endif
 
 #ifndef OCTARINE_SHIPPED
+#include "Dev/DevListenDispatch.h"
 #include "Dev/DevListenServer.h"
 #endif
 
@@ -124,6 +125,12 @@ Game::Game() {
   event_bus_ = std::make_unique<EventBus>();
   renderer_ = std::make_unique<Renderer>();
   scene_loader_ = std::make_unique<SceneLoader>(registry_.get(), lua);
+#ifndef OCTARINE_SHIPPED
+  // Expose the scene loader as a Registry singleton so the dev-iteration listener's reload_scene
+  // op can reach it from its main-thread dispatch context. Game still owns the instance; this is a
+  // non-owning pointer handle.
+  registry_->Set<SceneLoader*>(scene_loader_.get());
+#endif
   frame_loop_ = std::make_unique<FrameLoop>(this, registry_.get(), event_bus_.get(), renderer_.get(), &runtime_, lua);
   // Generational GC collects the short-lived objects that dominate game-loop Lua allocations
   // (per-frame script tables, vectors, closures) cheaply in minor cycles, reserving full sweeps
@@ -223,12 +230,14 @@ void Game::InitImGuiBackend() {
 #endif
 }
 
-void Game::StartDevListenServer() const {
+void Game::StartDevListenServer() {
 #ifndef OCTARINE_SHIPPED
-  // DevListenServer (Stage 6): TCP listener on 127.0.0.1:<port> when --dev-listen given.
-  // Compile-stripped from shipped builds. Available in editor + player presets alike so the
-  // standalone player can host the dev-iterate loop too.
+  // DevListenServer: TCP listener on 127.0.0.1:<port> when --dev-listen given. Compile-stripped
+  // from shipped builds. Available in editor + player presets alike so the standalone player can
+  // host the dev-iterate loop too.
   auto& devListen = registry_->Set<octarine::dev::DevListenServer>(octarine::dev::DevListenServer());
+  // Install the engine handler so parked eval/reload/push ops apply on the main thread in Pump().
+  devListen.SetCommandHandler(octarine::dev::MakeEngineCommandHandler(*registry_, lua));
   if (dev_listen_port_ > 0) {
     octarine::dev::ServerOptions opts;
     opts.port = static_cast<std::uint16_t>(dev_listen_port_);

--- a/src/Game/Game.h
+++ b/src/Game/Game.h
@@ -112,9 +112,8 @@ class Game : public LuaBindingContext {
   // Initialize so the feature gate stays out of that function.
   void InitImGuiBackend();
   // Start the dev-iterate TCP listener when --dev-listen was passed. Empty in shipped builds.
-  // const: it mutates only Registry-owned state through the registry_ pointer, like the other
-  // const accessors here.
-  void StartDevListenServer() const;
+  // Non-const: installs the engine command handler capturing the non-const sol::state.
+  void StartDevListenServer();
   // Size + create the window and the off-screen scene target. Returns false (→ Initialize aborts)
   // on window or render-target creation failure.
   [[nodiscard]] bool CreateWindowAndScene(bool projectLoaded);

--- a/tests/AdbTest.cpp
+++ b/tests/AdbTest.cpp
@@ -1,0 +1,73 @@
+// Unit checks for the adb wrapper's pure parser (Adb::ParseDevices). gtest-free; failed-check
+// count is the exit code. Mirrors the style of ProcessTest / DevListenServerTest. Registered as
+// AdbTest in ctest. No device or adb binary is required — only the stdout-parsing logic is tested.
+
+#include <iostream>
+#include <string>
+
+#include "Deploy/Adb.h"
+
+namespace {
+int g_failures = 0;
+
+void Check(const bool cond, const std::string& what) {
+  if (cond) {
+    std::cout << "  ok   " << what << "\n";
+  } else {
+    std::cerr << "  FAIL " << what << "\n";
+    ++g_failures;
+  }
+}
+}  // namespace
+
+int main() {
+  using octarine::deploy::Adb;
+  using octarine::deploy::AdbDevice;
+
+  {
+    // Typical `adb devices -l`: header, a USB device, a wifi/tcp device, and an offline one.
+    const std::string out =
+        "List of devices attached\n"
+        "emulator-5554          device product:sdk_gphone_x86 model:Android_SDK_built_for_x86 "
+        "device:generic_x86 transport_id:1\n"
+        "192.168.1.5:5555       device product:redfin model:Pixel_5 device:redfin transport_id:2\n"
+        "0123456789ABCDEF       offline\n";
+    const std::vector<AdbDevice> devices = Adb::ParseDevices(out);
+
+    Check(devices.size() == 3, "parses one row per device, skipping the header");
+    if (devices.size() == 3) {
+      Check(devices[0].serial == "emulator-5554", "row 0 serial");
+      Check(devices[0].state == "device", "row 0 state");
+      Check(devices[0].model == "Android_SDK_built_for_x86", "row 0 model field extracted");
+      Check(devices[0].IsReady(), "row 0 IsReady() for state=device");
+
+      Check(devices[1].serial == "192.168.1.5:5555", "row 1 tcp serial kept intact");
+      Check(devices[1].model == "Pixel_5", "row 1 model field extracted");
+      Check(devices[1].product == "redfin", "row 1 product field extracted");
+
+      Check(devices[2].serial == "0123456789ABCDEF", "row 2 serial");
+      Check(devices[2].state == "offline", "row 2 state=offline");
+      Check(!devices[2].IsReady(), "row 2 not IsReady() when offline");
+      Check(devices[2].model.empty(), "row 2 model empty when -l detail absent");
+    }
+  }
+
+  {
+    // Empty / no-devices output yields no rows (header only, plus daemon chatter).
+    const std::string out =
+        "* daemon not running; starting now at tcp:5037\n"
+        "* daemon started successfully\n"
+        "List of devices attached\n";
+    Check(Adb::ParseDevices(out).empty(), "no devices -> empty, daemon lines skipped");
+  }
+
+  {
+    // CRLF-terminated capture (Windows adb) parses identically.
+    const std::string out = "List of devices attached\r\nemulator-5554\tdevice\r\n";
+    const std::vector<AdbDevice> devices = Adb::ParseDevices(out);
+    Check(devices.size() == 1 && devices[0].serial == "emulator-5554" && devices[0].state == "device",
+          "CRLF + tab-separated row parses, trailing CR trimmed");
+  }
+
+  return g_failures;
+}

--- a/tests/DevListenServerTest.cpp
+++ b/tests/DevListenServerTest.cpp
@@ -29,11 +29,15 @@ using io_ssize_t = ssize_t;
 constexpr socket_t kInvalidSocket = -1;
 #endif
 
+#include <atomic>
+#include <cctype>
+#include <chrono>
 #include <cstdint>
 #include <cstring>
 #include <iostream>
 #include <string>
 #include <thread>
+#include <vector>
 
 namespace {
 int g_failures = 0;
@@ -160,6 +164,43 @@ int main() {
     const std::string nonce = "OCTARINE";
     const std::string echo = RoundTrip(port, static_cast<std::uint32_t>(OpCode::Ping), nonce);
     Check(echo == nonce, "Ping echoes the client nonce");
+  }
+
+  {
+    // Engine-mutating op path: the listener parks the command and blocks; the main thread runs it
+    // via Pump() and the reply flows back. The real engine handler touches Registry/sol; here a
+    // stand-in upper-cases the body so the cross-thread park -> Pump -> reply handoff is provable
+    // without linking the engine. Mirrors how DevListenServer is driven each frame.
+    const std::thread::id pumpThreadId = std::this_thread::get_id();
+    std::atomic<bool> handlerRan{false};
+    server.SetCommandHandler(
+        [&](OpCode op, const std::vector<char>& body, std::uint32_t& replyOp, std::string& replyBody) {
+          handlerRan.store(true);
+          Check(op == OpCode::EvalLua, "handler receives the EvalLua op");
+          Check(std::this_thread::get_id() == pumpThreadId, "handler runs on the Pump (main) thread");
+          replyOp = static_cast<std::uint32_t>(op);
+          std::string out(1, '\1');  // ok = 1
+          for (const char c : body) out.push_back(static_cast<char>(std::toupper(static_cast<unsigned char>(c))));
+          replyBody = out;
+        });
+
+    std::string reply;
+    std::atomic<bool> done{false};
+    std::thread client([&]() {
+      reply = RoundTrip(port, static_cast<std::uint32_t>(OpCode::EvalLua), "ping-cmd");
+      done.store(true);
+    });
+    // Drive Pump() on this (main) thread until the parked command is serviced and the client's
+    // round-trip completes. Bounded so a regression can't hang the suite.
+    for (int i = 0; i < 400 && !done.load(); ++i) {
+      server.Pump();
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    client.join();
+
+    Check(handlerRan.load(), "command handler executed via Pump()");
+    Check(!reply.empty() && reply[0] == '\1', "EvalLua reply signals ok");
+    Check(reply.substr(1) == "PING-CMD", "EvalLua reply carries the handler-transformed body");
   }
 
   server.Stop();


### PR DESCRIPTION
First two slices of the editor **Play / Deploy** epic (#45), building on the P0 foundation. Closes **#75** and **#76**.

## #75 — dev-listen protocol ops
Extends `DevListenServer` past the PR-A hello/ping handshake to the four engine-mutating ops over the existing `length | op | body` framing (no msgpack):

- `EvalLua` → `{ok, result}`, `ReloadScene`, `PushScript` (write + force reload), `PushAsset` (write + invalidate/reload).
- The listener **parks** mutating ops on a queue and blocks; the **main thread** drains them in `Pump()` via an injected `CommandHandler`, then the reply flows back. No engine state is touched off the main thread.
- **Layering:** the transport (`DevListenServer`) stays free of `Registry`/`sol`/`AssetManager` deps — that's what keeps its smoke-test target standalone. The engine-touching dispatch lives in the new `src/Dev/DevListenDispatch` TU and is installed via `SetCommandHandler`.
- `AssetManager::Reload` / `ReloadByPath` added (resident-only, refcount-preserving) for asset hot-push; `SceneLoader` exposed as a Registry singleton for `reload_scene`.
- Dropped the stale `ai/` doc reference from the header per the tracked-file rule.

## #76 — adb deploy wrapper
New `src/Deploy/Adb` — a thin wrapper over the `Process` spawn helper (no Android SDK linkage):

- `Detect`, `ListDevices`/`ParseDevices`, `Connect`/`Disconnect`, `Install`, `Push`, `Reverse` (dev-listen tunnel), `Logcat` (live streaming process).
- Lives in `octarine_core` alongside `Process/` so the editor and a future CLI both reach it.

## Tests
- `DevListenServerTest` extended with a cross-thread park → `Pump()` → reply round-trip.
- New `AdbTest` covers the `adb devices -l` parser (USB/tcp/offline rows, model/product extraction, CRLF).
- Full suite green (16/16); clang-format + clang-tidy (18.1.8) clean on changed lines.

## Notes
- Everything dev-only stays behind `OCTARINE_SHIPPED` / `OCTARINE_WITH_EDITOR` gates.
- Next in the epic: #77 (Devices panel) and #78 (hot-push) build on this; #74 (Export Build polish) is independent.