### PR TITLE
Add local asset hot-reload for texture/audio/font source files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -511,6 +511,25 @@ if (OCTARINE_ENABLE_TESTS)
     endif ()
     add_test(NAME AssetRefcounterTest COMMAND OctarineAssetRefcounterTest)
 
+    # FileWatcher unit test: the generic mtime watcher shared by the script + asset hot-reload
+    # paths. Pure filesystem — links only the watcher source + Logger (for its stat-warning line).
+    add_executable(OctarineFileWatcherTest
+            src/General/FileWatcher.cpp
+            src/General/Logger.cpp
+            tests/FileWatcherTest.cpp)
+    set_target_properties(OctarineFileWatcherTest PROPERTIES
+            CXX_STANDARD 20
+            CXX_STANDARD_REQUIRED ON
+            CXX_EXTENSIONS OFF)
+    target_include_directories(OctarineFileWatcherTest PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/src
+            ${CMAKE_CURRENT_SOURCE_DIR}/tests)
+    target_link_libraries(OctarineFileWatcherTest PRIVATE spdlog::spdlog)
+    if (MSVC)
+        target_compile_options(OctarineFileWatcherTest PRIVATE /W4 /permissive- /MP /EHsc)
+    endif ()
+    add_test(NAME FileWatcherTest COMMAND OctarineFileWatcherTest)
+
     # DevListenServer smoke test (Stage 6 PR-A): standalone — only the server source + Logger.
     # Bound to the same OCTARINE_SHIPPED gate as the engine-side server.
     if (NOT OCTARINE_SHIPPED)

--- a/events.json
+++ b/events.json
@@ -75,13 +75,13 @@
       "emit_sites": [
         {
           "file": "src/Engine/FrameLoop.cpp",
-          "line": 103
+          "line": 105
         }
       ],
       "subscribe_sites": [
         {
           "file": "src/Engine/FrameLoop.cpp",
-          "line": 75,
+          "line": 77,
           "owner": "FrameLoop"
         },
         {
@@ -104,7 +104,7 @@
       "emit_sites": [
         {
           "file": "src/Engine/FrameLoop.cpp",
-          "line": 109
+          "line": 111
         }
       ],
       "subscribe_sites": [
@@ -137,7 +137,7 @@
       "emit_sites": [
         {
           "file": "src/Engine/FrameLoop.cpp",
-          "line": 113
+          "line": 115
         }
       ],
       "subscribe_sites": [

--- a/scripts/octarine-verify.sh
+++ b/scripts/octarine-verify.sh
@@ -146,10 +146,11 @@ fi
 # --- configure + build -------------------------------------------------------
 test_targets=(
   OctarineLuaApiTest OctarineAssetPipelineTest OctarineProcessTest OctarineProjectIniTest
+  OctarineAdbTest
   OctarineEcsTest OctarineEcsHierarchyTest OctarineSystemLogicTest OctarineEventBusTest
   OctarineCollisionSystemTest OctarineCollisionResponseTest OctarineProjectileEmitSystemTest
   OctarineAssetRefcounterTest OctarineDevListenServerTest OctarineLuaBehaviorTest
-  OctarineGameBakeTest
+  OctarineFileWatcherTest OctarineGameBakeTest
 )
 
 if [[ $do_build -eq 1 ]]; then

--- a/src/AssetManager/AssetHotReload.cpp
+++ b/src/AssetManager/AssetHotReload.cpp
@@ -1,0 +1,78 @@
+#include "AssetManager/AssetHotReload.h"
+
+#ifndef OCTARINE_SHIPPED
+
+#include <filesystem>
+#include <system_error>
+
+#include "AssetManager/AssetManager.h"
+#include "General/Logger.h"
+
+namespace {
+std::string Canonicalize(const std::string& path) {
+  std::error_code ec;
+  auto canon = std::filesystem::weakly_canonical(std::filesystem::path(path), ec);
+  if (ec) {
+    return path;
+  }
+  return canon.string();
+}
+}  // namespace
+
+void AssetHotReload::Tick(AssetManager& assets, SDL_Renderer* renderer, MIX_Mixer* mixer, float dt, float pollSeconds) {
+  accumulator_ += dt;
+  if (accumulator_ < pollSeconds) {
+    return;
+  }
+  accumulator_ = 0.0F;
+
+  RefreshTracking(assets);
+  if (watcher_.Empty()) {
+    return;
+  }
+  for (const auto& dirty : watcher_.Poll()) {
+    const int reloaded = assets.ReloadByPath(dirty, renderer, mixer);
+    if (reloaded > 0) {
+      last_.path = dirty;
+      ++last_.totalReloads;
+      last_.totalIdsReloaded += reloaded;
+      Logger::Info("Asset hot reload: " + dirty + " (" + std::to_string(reloaded) + " ids)");
+    }
+  }
+}
+
+void AssetHotReload::ForceReloadAll(AssetManager& assets, SDL_Renderer* renderer, MIX_Mixer* mixer) {
+  for (const auto& path : assets.ResidentSourcePaths()) {
+    const int reloaded = assets.ReloadByPath(path, renderer, mixer);
+    if (reloaded > 0) {
+      last_.path = path;
+      ++last_.totalReloads;
+      last_.totalIdsReloaded += reloaded;
+    }
+  }
+}
+
+void AssetHotReload::RefreshTracking(AssetManager& assets) {
+  // Canonicalize so the keys match what FileWatcher::Poll returns and what tracked_ stores.
+  std::unordered_set<std::string> seen;
+  for (const auto& path : assets.ResidentSourcePaths()) {
+    seen.insert(Canonicalize(path));
+  }
+
+  for (const auto& path : seen) {
+    if (tracked_.find(path) == tracked_.end()) {
+      watcher_.Track(path);
+      tracked_.insert(path);
+    }
+  }
+  for (auto it = tracked_.begin(); it != tracked_.end();) {
+    if (seen.find(*it) == seen.end()) {
+      watcher_.Untrack(*it);
+      it = tracked_.erase(it);
+    } else {
+      ++it;
+    }
+  }
+}
+
+#endif  // OCTARINE_SHIPPED

--- a/src/AssetManager/AssetHotReload.h
+++ b/src/AssetManager/AssetHotReload.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <SDL3/SDL.h>
+#include <SDL3_mixer/SDL_mixer.h>
+
+#include <string>
+#include <unordered_set>
+
+#include "General/FileWatcher.h"
+
+class AssetManager;
+
+#ifndef OCTARINE_SHIPPED
+
+// Local-disk asset hot reload: the editor/player counterpart to ScriptHotReload, but for content
+// instead of code. Owns a FileWatcher over the source files of every currently-resident asset
+// (textures / fonts / audio clips) and, when one changes on disk, calls AssetManager::ReloadByPath
+// to swap the underlying SDL_Texture* / TTF_Font* / MIX_Audio*. Consumers re-resolve for free:
+// sprite renderers poll AssetManager::TextureGeneration(), and audio is looked up by id on each
+// play, so no reload event is needed.
+//
+// One instance lives in the Registry singleton set; ticked from the main loop (FrameLoop::Update)
+// behind the same EngineOptions.hotReloadEnabled gate the script reloader uses. Compiled out under
+// OCTARINE_SHIPPED.
+//
+// Scope: this watches the loose source tree, so it is the dev/editor inner-loop path. The remote
+// hot-push path (DevListenDispatch) drives the same AssetManager::ReloadByPath directly.
+class AssetHotReload {
+ public:
+  struct ReloadInfo {
+    std::string path;  // last reloaded source file (empty until first reload)
+    int totalReloads = 0;
+    int totalIdsReloaded = 0;
+  };
+
+  AssetHotReload() = default;
+
+  // Called from the main loop. `dt` is real (non-time-scaled) time so paused editor sessions still
+  // iterate. Re-syncs the watch set against the resident assets, then reloads any file whose mtime
+  // advanced since the last poll.
+  void Tick(AssetManager& assets, SDL_Renderer* renderer, MIX_Mixer* mixer, float dt, float pollSeconds);
+
+  // Force a reload of every resident asset, ignoring mtime. Mirror of ScriptHotReload for the
+  // dev-listen force-reload op.
+  void ForceReloadAll(AssetManager& assets, SDL_Renderer* renderer, MIX_Mixer* mixer);
+
+  [[nodiscard]] const ReloadInfo& LastReload() const { return last_; }
+
+ private:
+  void RefreshTracking(AssetManager& assets);
+
+  FileWatcher watcher_;
+  std::unordered_set<std::string> tracked_;  // canonical paths the watcher currently watches
+  float accumulator_ = 0.0F;
+  ReloadInfo last_;
+};
+
+#else
+
+// Shipped stub.
+class AssetHotReload {
+ public:
+  struct ReloadInfo {};
+  void Tick(AssetManager&, SDL_Renderer*, MIX_Mixer*, float, float) {}
+  void ForceReloadAll(AssetManager&, SDL_Renderer*, MIX_Mixer*) {}
+  [[nodiscard]] ReloadInfo LastReload() const { return {}; }
+};
+
+#endif

--- a/src/AssetManager/AssetManager.cpp
+++ b/src/AssetManager/AssetManager.cpp
@@ -163,6 +163,24 @@ int AssetManager::ReloadByPath(const std::string &absPath, SDL_Renderer *rendere
   return reloaded;
 }
 
+std::vector<std::string> AssetManager::ResidentSourcePaths() const {
+  // Walk the three handle stores, map each resident id back to its catalog source file, and dedupe.
+  // One file can back several ids (atlas members share a backing texture), so a set collapses them;
+  // ReloadByPath re-expands a path to every id it backs on reload.
+  std::set<std::string> paths;
+  const auto collect = [&](const auto &store) {
+    for (const auto &[id, handle] : store) {
+      if (const CatalogEntry *entry = catalog_.Find(id); entry != nullptr && !entry->fullPath.empty()) {
+        paths.insert(entry->fullPath);
+      }
+    }
+  };
+  collect(texture_store_.All());
+  collect(font_store_.All());
+  collect(audio_store_.All());
+  return {paths.begin(), paths.end()};
+}
+
 int AssetManager::RefCount(const std::string &assetId) const { return refcounter_.Count(assetId); }
 
 // Mutually recursive with Release: an atlas member's unload path calls Release(atlasId).

--- a/src/AssetManager/AssetManager.h
+++ b/src/AssetManager/AssetManager.h
@@ -86,6 +86,12 @@ class AssetManager {
   // then calls this to refresh whatever ids that file backs. Returns the number of ids reloaded.
   int ReloadByPath(const std::string& absPath, SDL_Renderer* renderer, MIX_Mixer* mixer);
 
+  // Absolute source-file paths of every currently-resident asset (textures, fonts, audio clips),
+  // deduped. The local asset hot-reload watcher (AssetHotReload) watches exactly this set and
+  // calls ReloadByPath when one changes on disk. Paths come from the catalog entry behind each
+  // resident id; ids with no catalog entry (or no on-disk source) are skipped. Dev-only use.
+  [[nodiscard]] std::vector<std::string> ResidentSourcePaths() const;
+
   // Validate scene references against the catalog: an id missing from the catalog, or present but
   // whose backing file no longer exists on disk, is logged once with the referencing context.
   // Returns the number of failures (0 == clean). This is the authoritative miss check, replacing

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,6 +22,7 @@
 # -----------------------------------------------------------------------------
 set(OCTARINE_CORE_SOURCES
         General/Logger.cpp
+        General/FileWatcher.cpp
         ECS/Registry.cpp
         Game/GameConfig.cpp
         Deploy/Adb.cpp
@@ -66,6 +67,7 @@ endif ()
 # -----------------------------------------------------------------------------
 octarine_library(octarine_assets
         AssetManager/AssetCatalog.cpp
+        AssetManager/AssetHotReload.cpp
         AssetManager/AssetManager.cpp
         AssetManager/AssetPak.cpp
         AssetManager/AtlasBaker.cpp
@@ -112,7 +114,6 @@ octarine_library(octarine_lua
         Lua/Bindings/InputSystemLuaBinding.cpp
         Lua/Bindings/RegisterAllBindings.cpp
         Lua/HotReload/ScriptHotReload.cpp
-        Lua/HotReload/ScriptWatcher.cpp
         Lua/Modules/AssetsModuleLuaBinding.cpp
         Lua/Modules/AudioModuleLuaBinding.cpp
         Lua/Modules/EntityModuleLuaBinding.cpp

--- a/src/Engine/FrameLoop.cpp
+++ b/src/Engine/FrameLoop.cpp
@@ -6,6 +6,8 @@
 #include <algorithm>
 #include <cstdlib>
 
+#include "AssetManager/AssetHotReload.h"
+#include "AssetManager/AssetManager.h"
 #include "Components/ViewportInfo.h"
 #include "ECS/Registry.h"
 #include "Engine/EngineContext.h"
@@ -162,6 +164,11 @@ void FrameLoop::Update(const float deltaTime) {
   if (options.hotReloadEnabled) {
     if (auto* hotReload = registry_->TryGet<ScriptHotReload>()) {
       hotReload->Tick(*registry_, lua_, deltaTime, options.hotReloadPollSeconds);
+    }
+    if (auto* assetReload = registry_->TryGet<AssetHotReload>()) {
+      auto& ctx = registry_->Get<EngineContext>();
+      assetReload->Tick(registry_->Get<AssetManager>(), ctx.sdlRenderer, ctx.mixer, deltaTime,
+                        options.hotReloadPollSeconds);
     }
   }
 #endif

--- a/src/Game/Game.cpp
+++ b/src/Game/Game.cpp
@@ -12,6 +12,7 @@
 #include <unordered_set>
 
 #include "AssetManager/AssetCatalog.h"
+#include "AssetManager/AssetHotReload.h"
 #include "AssetManager/AssetPak.h"
 #include "AssetManager/AtlasBaker.h"
 #include "AssetManager/AudioNormalizer.h"
@@ -632,7 +633,10 @@ void Game::Setup() {
   damageSystem.Init(registry_.get(), event_bus_);
   obstacleBounceSystem.Init(registry_.get(), event_bus_);
 
-  // Hot reload owns its own ScriptWatcher + (path -> entities) discovery loop. Compiled out
+  // Hot reload owns its own FileWatcher + (path -> entities) discovery loop. Compiled out
   // under OCTARINE_SHIPPED; in dev/editor builds the runtime gate lives on EngineOptions.
   registry_->Set<ScriptHotReload>(ScriptHotReload());
+  // Asset hot reload: same FileWatcher infra, watching resident texture/font/audio source files
+  // and swapping the live SDL/MIX handles via AssetManager::ReloadByPath when they change on disk.
+  registry_->Set<AssetHotReload>(AssetHotReload());
 }

--- a/src/General/FileWatcher.cpp
+++ b/src/General/FileWatcher.cpp
@@ -1,4 +1,4 @@
-#include "ScriptWatcher.h"
+#include "General/FileWatcher.h"
 
 #ifndef OCTARINE_SHIPPED
 
@@ -8,7 +8,7 @@
 
 namespace fs = std::filesystem;
 
-std::string ScriptWatcher::Canonical(const std::string& absPath) {
+std::string FileWatcher::Canonical(const std::string& absPath) {
   std::error_code ec;
   // weakly_canonical so partial-existent paths still resolve (caller may register before the
   // file exists in some edge cases). On error, fall back to the input.
@@ -19,7 +19,7 @@ std::string ScriptWatcher::Canonical(const std::string& absPath) {
   return canon.string();
 }
 
-void ScriptWatcher::Track(const std::string& absPath) {
+void FileWatcher::Track(const std::string& absPath) {
   const std::string key = Canonical(absPath);
   if (mtimes_.find(key) != mtimes_.end()) {
     return;
@@ -28,18 +28,18 @@ void ScriptWatcher::Track(const std::string& absPath) {
   std::error_code ec;
   const auto mtime = fs::last_write_time(key, ec);
   if (ec) {
-    Logger::Warn("ScriptWatcher: cannot stat '" + key + "': " + ec.message());
+    Logger::Warn("FileWatcher: cannot stat '" + key + "': " + ec.message());
     return;
   }
   mtimes_.emplace(key, mtime);
 }
 
-void ScriptWatcher::Untrack(const std::string& absPath) {
+void FileWatcher::Untrack(const std::string& absPath) {
   const std::string key = Canonical(absPath);
   mtimes_.erase(key);
 }
 
-std::vector<std::string> ScriptWatcher::Poll() {
+std::vector<std::string> FileWatcher::Poll() {
   std::vector<std::string> dirty;
   for (auto& [path, lastMtime] : mtimes_) {
     std::error_code ec;

--- a/src/General/FileWatcher.h
+++ b/src/General/FileWatcher.h
@@ -11,9 +11,13 @@
 // about, ask Poll() periodically for the subset whose last_write_time advanced since the last
 // call. Atomic-save editors (temp + rename) are handled because we resolve the canonical path
 // at Track() time and re-stat it each Poll.
-class ScriptWatcher {
+//
+// Generic infrastructure shared by every hot-reload path: Lua script reload (ScriptHotReload)
+// and asset reload (AssetHotReload) both own one of these. It knows nothing about scripts,
+// assets, sol, or SDL — just paths and mtimes.
+class FileWatcher {
  public:
-  ScriptWatcher() = default;
+  FileWatcher() = default;
 
   // Add a file to the watch set. Path is canonicalized; duplicates and unknown files are
   // silently ignored (the second case logs and stays untracked — caller bug, not user error).
@@ -40,7 +44,7 @@ class ScriptWatcher {
 
 // Shipped builds: zero-cost stub so callers compile without #ifdef sprinkling. Track/Untrack
 // drop their args, Poll always returns empty.
-class ScriptWatcher {
+class FileWatcher {
  public:
   void Track(const std::string&) {}
   void Untrack(const std::string&) {}

--- a/src/Lua/HotReload/ScriptHotReload.h
+++ b/src/Lua/HotReload/ScriptHotReload.h
@@ -4,7 +4,7 @@
 #include <string>
 #include <unordered_set>
 
-#include "ScriptWatcher.h"
+#include "General/FileWatcher.h"
 
 class Registry;
 struct ScriptComponent;
@@ -41,7 +41,7 @@ class ScriptHotReload {
   void RecordSuccess(const std::string& path);
   void RecordFailure(const std::string& path, const std::string& error);
 
-  ScriptWatcher watcher_;
+  FileWatcher watcher_;
   std::unordered_set<std::string> tracked_;  // canonical paths the watcher currently watches
   float accumulator_ = 0.0F;
   ReloadInfo last_;

--- a/tests/FileWatcherTest.cpp
+++ b/tests/FileWatcherTest.cpp
@@ -5,13 +5,13 @@
 // mtime granularity varies by filesystem, so we drive change detection by explicitly advancing
 // last_write_time rather than relying on a real second-resolution clock between writes.
 
-#include "General/FileWatcher.h"
-#include "TestHarness.h"
-
 #include <chrono>
 #include <filesystem>
 #include <fstream>
 #include <string>
+
+#include "General/FileWatcher.h"
+#include "TestHarness.h"
 
 using octarine::test::Check;
 using octarine::test::CheckEq;

--- a/tests/FileWatcherTest.cpp
+++ b/tests/FileWatcherTest.cpp
@@ -1,0 +1,99 @@
+// Unit checks for FileWatcher — the generic mtime-polling watcher shared by ScriptHotReload and
+// AssetHotReload. Pure filesystem, no SDL / Lua / renderer, so it runs headless. gtest-free; exit
+// code = failed-check count. Registered with ctest as FileWatcherTest.
+//
+// mtime granularity varies by filesystem, so we drive change detection by explicitly advancing
+// last_write_time rather than relying on a real second-resolution clock between writes.
+
+#include "General/FileWatcher.h"
+#include "TestHarness.h"
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+using octarine::test::Check;
+using octarine::test::CheckEq;
+namespace fs = std::filesystem;
+
+namespace {
+std::string Canon(const fs::path& p) {
+  std::error_code ec;
+  auto c = fs::weakly_canonical(p, ec);
+  return ec ? p.string() : c.string();
+}
+
+void Write(const fs::path& p, const std::string& contents) {
+  std::ofstream out(p, std::ios::binary | std::ios::trunc);
+  out << contents;
+}
+
+// Force the file's mtime forward so Poll() sees a change deterministically.
+void BumpMtime(const fs::path& p) {
+  std::error_code ec;
+  auto t = fs::last_write_time(p, ec);
+  fs::last_write_time(p, t + std::chrono::seconds(2), ec);
+}
+}  // namespace
+
+int main() {
+  const fs::path dir = fs::temp_directory_path() / "octarine-filewatcher-test";
+  std::error_code ec;
+  fs::remove_all(dir, ec);
+  fs::create_directories(dir, ec);
+  const fs::path file = dir / "watched.txt";
+  Write(file, "v1");
+
+  {
+    FileWatcher fw;
+    Check(fw.Empty(), "fresh watcher is Empty()");
+
+    fw.Track(file.string());
+    CheckEq(fw.TrackedCount(), static_cast<std::size_t>(1), "Track adds one entry");
+    Check(!fw.Empty(), "watcher not Empty() after Track");
+
+    CheckEq(fw.Poll().size(), static_cast<std::size_t>(0), "Poll with no change returns nothing");
+
+    BumpMtime(file);
+    const auto dirty = fw.Poll();
+    CheckEq(dirty.size(), static_cast<std::size_t>(1), "Poll reports the changed file");
+    if (!dirty.empty()) {
+      CheckEq(dirty.front(), Canon(file), "dirty path is canonical");
+    }
+
+    CheckEq(fw.Poll().size(), static_cast<std::size_t>(0), "change is consumed — next Poll is clean");
+
+    // Idempotent Track: re-tracking the same path does not double-count.
+    fw.Track(file.string());
+    CheckEq(fw.TrackedCount(), static_cast<std::size_t>(1), "re-Track of same path is idempotent");
+
+    fw.Untrack(file.string());
+    Check(fw.Empty(), "Untrack removes the entry");
+    CheckEq(fw.Poll().size(), static_cast<std::size_t>(0), "Poll after Untrack returns nothing");
+  }
+
+  {
+    // Tracking a nonexistent file is a no-op (stat fails, logged, stays untracked).
+    FileWatcher fw;
+    fw.Track((dir / "does-not-exist.txt").string());
+    CheckEq(fw.TrackedCount(), static_cast<std::size_t>(0), "Track of missing file stays untracked");
+  }
+
+  {
+    // A file that disappears between Track and Poll is skipped without error and re-armed: once it
+    // reappears with a newer mtime, the next Poll reports it.
+    FileWatcher fw;
+    const fs::path transient = dir / "transient.txt";
+    Write(transient, "a");
+    fw.Track(transient.string());
+    fs::remove(transient, ec);
+    CheckEq(fw.Poll().size(), static_cast<std::size_t>(0), "vanished file is skipped, not errored");
+    Write(transient, "b");
+    BumpMtime(transient);
+    CheckEq(fw.Poll().size(), static_cast<std::size_t>(1), "reappeared file is reported on next Poll");
+  }
+
+  fs::remove_all(dir, ec);
+  return octarine::test::ReportSummary("FileWatcherTest");
+}


### PR DESCRIPTION
Closes #36.

## Summary

Adds a local-disk **asset hot-reload** path: the editor/player watches the loose source files behind every resident asset and swaps the live `SDL_Texture*` / `TTF_Font*` / `MIX_Audio*` in place when one changes on disk. Content now iterates without a restart — the content counterpart to the existing Lua script hot reload (#32).

Most of the rebind machinery already existed for the editor hot-**push** path (#78): `AssetManager::ReloadByPath` swaps handles and bumps the texture generation counter. The only missing piece was a watcher that detects *local* edits and drives it.

## What changed

- **Promote the generic watcher to core.** `Lua/HotReload/ScriptWatcher` had zero Lua dependency, so it moves to `src/General/FileWatcher.{h,cpp}` (octarine_core). `ScriptHotReload` now consumes it — both reload paths share one watcher, as the issue suggested.
- **`AssetHotReload`** (`octarine_assets`, dev-only with a shipped stub): re-syncs its watch set to `AssetManager::ResidentSourcePaths()` each tick and calls `ReloadByPath` on any changed file. Mirrors `ScriptHotReload`'s shape.
- **`AssetManager::ResidentSourcePaths()`** returns the deduped source paths of all resident textures/fonts/audio clips.
- **Wiring**: ticked from `FrameLoop::Update` behind the existing `EngineOptions.hotReloadEnabled` gate + poll cadence, right alongside the script reloader; constructed in `Game::Setup`.

## Why no reload event

Re-resolution reuses existing mechanisms, so the issue's "fire reload event" step isn't needed:
- **Textures** — sprite renderers already poll `TextureGeneration()`, which `ReloadByPath` bumps.
- **Audio** — resolved by id on every play (`GetAudioClip(id)`), so the next play picks up the new handle.

## Scope / deferred

- **Scene hot-reload is deferred.** It re-runs the scene file and reconciles runtime entities via the top-layer `SceneLoader::ReloadScene` — a heavier, more invasive mechanism than asset handle swapping, and worth its own change.

## Tests

- New headless **`FileWatcherTest`** (track/poll/untrack, idempotent track, vanish-then-reappear, missing-file no-op). Registered with ctest + the verify script.
- Also added the previously-unbuilt `OctarineAdbTest` to `octarine-verify.sh`'s build list (it was registered with ctest but never built locally → "Not Run").
- `scripts/octarine-verify.sh --full` is green: 17/17 ctest, clang-format clean, engine build + headless bake + Lua-API drift all pass. Modern clang-tidy (18.1.8) reports no findings on the changed lines.

## Manual verification (not yet done)

- [ ] Run the editor against `Octarine-Engine-Example`, edit a sprite PNG, and confirm the sprite updates live within the poll interval.
- [ ] Same for an audio clip (next play uses the new sound).