### PR TITLE
Add game developer guide to docs

### DIFF
--- a/docs/ecs-components.md
+++ b/docs/ecs-components.md
@@ -129,6 +129,23 @@ Tracks an entity's health.
 Forces the main camera to follow this entity. Has no fields.
 Example: `camera_follow = {}`
 
+### `audio_listener`
+
+Marks an entity as the spatial audio listener. Attenuation is computed relative
+to this entity's position. Has no fields — only one listener should exist per scene.
+Example: `audio_listener = {}`
+
+### `audio_source`
+
+Attaches a looping or triggered sound to an entity. The engine spatializes it
+relative to the `audio_listener`.
+
+| Field      | Type      | Default | Description                                        |
+|------------|-----------|---------|----------------------------------------------------|
+| `asset_id` | `string`  | `""`    | The ID of the loaded sound asset.                  |
+| `loop`     | `boolean` | `false` | If true, the sound loops continuously.             |
+| `volume`   | `number`  | `1.0`   | Playback volume (0.0–1.0).                         |
+
 ### `ui_button`
 
 Makes an entity clickable.
@@ -137,6 +154,105 @@ Makes an entity clickable.
 |-------------|------------|---------|-----------------------------------------------------|
 | `is_active` | `boolean`  | `true`  | Whether the button is interactive.                  |
 | `on_click`  | `function` | `nil`   | Function called on click: `function(self, entity)`. |
+
+---
+
+## Common Entity Patterns
+
+Components compose naturally. These combinations cover most game object archetypes.
+
+### Player
+
+```lua
+{
+    tag  = "player",
+    name = "Player",
+    components = {
+        transform      = { position = { x = 200, y = 300 } },
+        sprite         = { texture_asset_id = "player", width = 32, height = 32, layer = 2 },
+        rigidbody      = { velocity = { x = 0, y = 0 } },
+        box_collider   = { width = 32, height = 32 },
+        health         = { max_health = 100, current_health = 100 },
+        camera_follow  = {},
+        audio_listener = {},
+        script         = { speed = 100, on_update = player_update },
+    }
+}
+```
+
+### Enemy
+
+```lua
+{
+    tag  = "enemy",
+    name = "Enemy",
+    components = {
+        transform          = { position = { x = 600, y = 300 } },
+        sprite             = { texture_asset_id = "enemy", width = 32, height = 32, layer = 2 },
+        rigidbody          = { velocity = { x = 0, y = 0 } },
+        box_collider       = { width = 32, height = 32 },
+        health             = { max_health = 50, current_health = 50 },
+        projectile_emitter = {
+            projectile_velocity = { x = -150, y = 0 },
+            projectile_duration = 4.0,
+            repeat_frequency    = 2.0,
+            hit_damage          = 10,
+            friendly            = false,
+        },
+    }
+}
+```
+
+### Ambient sound source
+
+```lua
+{
+    components = {
+        transform    = { position = { x = 400, y = 400 } },
+        audio_source = { asset_id = "ambient-wind", loop = true, volume = 0.6 },
+    }
+}
+```
+
+### HUD overlay
+
+Text and shapes with `fixed = true` / `is_fixed = true` stay in screen space,
+unaffected by the camera. Layer them high so they always draw on top.
+
+```lua
+-- Score label
+{
+    components = {
+        transform  = { position = { x = 20, y = 20 } },
+        text_label = {
+            text     = "Score: 0",
+            font_id  = "hud-font",
+            color    = { r = 255, g = 255, b = 255, a = 255 },
+            layer    = 10,
+            is_fixed = true,
+        },
+        script = {
+            on_update = function(self, entity, dt)
+                -- update text via registry when score changes
+            end,
+        },
+    }
+}
+
+-- Semi-transparent health bar background
+{
+    components = {
+        transform = { position = { x = 20, y = 50 } },
+        square    = {
+            width  = 200,
+            height = 16,
+            color  = { r = 60, g = 0, b = 0, a = 180 },
+            layer  = 9,
+            fixed  = true,
+        },
+    }
+}
+```
 
 ---
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -3,6 +3,15 @@
 The engine has a small, type-erased publish/subscribe bus for decoupled communication — input,
 collisions, and audio triggers flow through it rather than through direct calls between systems.
 
+> **Lua game devs:** you do not call `SubscribeEvent` or `EmitEvent` from Lua. The event bus is an
+> internal C++ mechanism. Its results surface to scripts automatically:
+> - **Collision damage** — handled by `DamageSystem`; just add `box_collider` + `health` to your
+>   entities and damage applies without any script code.
+> - **Input** — folded into the `input.*` table each frame; use `input.is_action_pressed` etc.
+> - **Audio** — triggered by `play_sound()`, which emits an `AudioPlayEvent` internally.
+>
+> This document is for engine contributors adding new C++ systems.
+
 ## The bus
 
 `EventBus` (`src/EventBus/EventBus.h`) keys subscriptions by `std::type_index`, so any C++ type can be

--- a/docs/lua-scripting.md
+++ b/docs/lua-scripting.md
@@ -1,8 +1,11 @@
 # Lua Scripting Guide
 
-Octarine Engine is designed to be driven by Lua scripts. This guide explains how to structure your game project and use the engine's Lua API.
+Octarine Engine is designed to be driven by Lua scripts. This guide covers the
+`script` component, the update loop, reading and writing components at runtime,
+the full input API, and the ImGui debug UI surface.
 
-For a complete working example, refer to the sibling `Octarine-Engine-Example/` directory.
+For a complete working example, refer to the sibling `Octarine-Engine-Example/`
+directory.
 
 ---
 
@@ -39,151 +42,236 @@ DefaultScalingMode=nearest # 'nearest' or 'linear'
 
 ---
 
-## 3. Loading Assets
+## 3. The Script Component
 
-Assets must be loaded before they can be used by entities. The recommended
-flow is `acquire_scene_assets(scene)` — the scene table's references drive
-the load. The full asset model (catalog, `.meta` sidecars, bake, atlases,
-audio normalize) lives in [`docs/asset-pipeline.md`](asset-pipeline.md).
-The explicit `load_asset` form below is the legacy path.
+Attach a `script` table to any entity to give it per-frame Lua behaviour. The
+engine calls two callbacks on it each frame:
+
+| Callback | When called |
+|---|---|
+| `on_update(self, entity, dt)` | Every frame, in system order |
+| `on_debug_gui(self, entity)` | Every frame, but only when editor debug UI is visible |
+| `on_click(self, entity)` | When the entity has a `ui_button` component and is clicked |
+
+- **`self`** is the script table itself — store per-entity state here.
+- **`entity`** is the numeric entity ID — pass it to `registry.*` and helper globals.
+- **`dt`** is delta time in seconds since the last frame.
 
 ```lua
--- Load a texture
-load_asset({ 
-    type = "texture", 
-    id = "player-texture", 
-    file = "images/player.png" 
+load_entity({
+    components = {
+        transform = { position = { x = 100, y = 100 } },
+        sprite    = { texture_asset_id = "player", width = 32, height = 32, layer = 2 },
+        rigidbody = { velocity = { x = 0, y = 0 } },
+        script    = {
+            speed    = 80,
+            cooldown = 0,
+            on_update = function(self, entity, dt)
+                self.cooldown = self.cooldown - dt
+                -- movement and actions handled here each frame
+            end,
+        },
+    }
 })
+```
 
--- Load a font
-load_asset({ 
-    type = "font", 
-    id = "main-font", 
-    file = "fonts/arial.ttf", 
-    font_size = 12 
+Scripts are plain Lua tables — any key you add to the table persists across
+frames and is accessible through `self`.
+
+---
+
+## 4. Reading and Writing Components
+
+### `registry.get_*` / `registry.has_*`
+
+The `registry` table exposes a getter and a presence check for every component.
+The pattern is `registry.get_<key>` / `registry.has_<key>`, where the key for
+each component is listed in [`docs/ecs-components.md`](ecs-components.md).
+
+```lua
+-- Read and mutate a component (get returns a mutable proxy)
+local pos = registry.get_position(entity)
+pos.x = pos.x + 10
+
+-- Guard before accessing an optional component
+if registry.has_health(entity) then
+    local hp = registry.get_health(entity)
+    hp.current_health = hp.current_health - 1
+end
+
+-- Rigidbody velocity
+local rb = registry.get_rigidbody(entity)
+rb.velocity.x = 150
+rb.velocity.y = 0
+```
+
+### Convenience helpers
+
+These globals are shorthand for the most common reads and writes:
+
+| Function | Description |
+|---|---|
+| `get_position(entity)` | Returns `{x, y}` |
+| `set_position(entity, x, y)` | Teleports the entity |
+| `get_name(entity)` | Returns the entity's name string |
+| `set_name(entity, name)` | Sets the name |
+| `set_sprite_src_rect(entity, x, y)` | Sets the sprite source-rect origin |
+| `find_entity_by_name(name)` | Returns the entity ID, or `nil` |
+| `blam(entity)` | Destroys the entity |
+
+### Other Lua globals
+
+| Function | Description |
+|---|---|
+| `log(message)` | Print to the engine console |
+| `load_asset(table)` | Load a texture, font, or sound |
+| `load_entity(table)` | Spawn a new entity |
+| `get_asset_path(path)` | Resolve a project-relative path to an absolute path |
+| `fire_projectile(entity, dx, dy)` | Spawn a projectile from the entity's emitter |
+| `play_sound(asset_id)` | Play a sound or music track |
+| `get_camera_position()` | Returns `{x, y}` of the camera viewport origin |
+| `get_game_map_dimensions()` | Returns `{w, h}` of the playable area |
+| `set_game_map_dimensions(w, h)` | Set the world bounds for camera clamping |
+| `read_file_lines(path)` | Read a file and return its lines as a table |
+| `quit_game()` | Gracefully exit the engine |
+
+---
+
+## 5. Input
+
+The `input` table handles action binding, polling, and event callbacks.
+
+### Binding actions
+
+Bind named logical actions to physical keys once at startup (typically in
+`game.lua`). Bindings persist across the session unless explicitly removed.
+
+```lua
+input.bind("move_up",    "up")
+input.bind("move_up",    "w")       -- multiple keys per action
+input.bind("move_down",  "down")
+input.bind("move_down",  "s")
+input.bind("move_left",  "left")
+input.bind("move_left",  "a")
+input.bind("move_right", "right")
+input.bind("move_right", "d")
+input.bind("fire",       "space")
+
+input.unbind("fire", "space")       -- remove one key
+input.unbind("fire")                -- remove all keys for the action
+```
+
+> **Note:** action bindings and callbacks are cleared on `load_scene` /
+> `reload_scene`. Re-install them in the new scene's startup or use a guard for
+> idempotency. See [`docs/scenes.md`](scenes.md) for the full scene lifecycle.
+
+### Polling
+
+```lua
+-- Actions (fires for any key bound to the action)
+input.is_action_down("fire")        -- held this frame
+input.is_action_pressed("fire")     -- just went down this frame
+input.is_action_released("fire")    -- just came up this frame
+
+-- Raw keys
+input.is_key_down("escape")
+input.is_key_pressed("f5")
+input.is_key_released("space")
+
+-- Mouse
+local pos   = input.mouse_position()   -- returns {x, y}, viewport-aware
+local wheel = input.mouse_wheel()      -- returns {x, y} per-frame delta
+input.is_mouse_down(1)                 -- 1 = left, 2 = right, 3 = middle
+input.is_mouse_pressed(1)
+input.is_mouse_released(1)
+```
+
+### Callbacks
+
+```lua
+input.on_key_down(function(key_name) ... end)
+input.on_key_up(function(key_name) ... end)
+input.on_mouse_down(function(btn, x, y) ... end)
+input.on_mouse_up(function(btn, x, y) ... end)
+input.on_mouse_wheel(function(dx, dy) ... end)
+```
+
+### Example: 8-way movement
+
+```lua
+local function movement_update(self, entity, dt)
+    local dx, dy = 0, 0
+    if input.is_action_down("move_up")    then dy = dy - 1 end
+    if input.is_action_down("move_down")  then dy = dy + 1 end
+    if input.is_action_down("move_left")  then dx = dx - 1 end
+    if input.is_action_down("move_right") then dx = dx + 1 end
+
+    local rb = registry.get_rigidbody(entity)
+    if dx ~= 0 or dy ~= 0 then
+        local len = math.sqrt(dx * dx + dy * dy)
+        rb.velocity.x = (dx / len) * self.speed
+        rb.velocity.y = (dy / len) * self.speed
+    else
+        rb.velocity.x = 0
+        rb.velocity.y = 0
+    end
+end
+
+load_entity({
+    components = {
+        transform = { position = { x = 200, y = 200 } },
+        sprite    = { texture_asset_id = "player", width = 32, height = 32, layer = 2 },
+        rigidbody = { velocity = { x = 0, y = 0 } },
+        script    = { speed = 120, on_update = movement_update },
+    }
 })
 ```
 
 ---
 
-### 4. Creating Entities
+## 6. ImGui Debug UI
 
-Entities are created by passing a table to `load_entity`. They are composed of a `tag` (optional) and several `components`.
-
-For a full list of available components and their fields, see
-**[ECS Component Reference](ecs-components.md)**.
+The engine exposes full [Dear ImGui](https://github.com/ocornut/imgui) bindings
+to Lua. Wire debug windows through the `on_debug_gui` callback — it only fires
+when the editor's debug UI is visible, so release builds pay zero cost.
 
 ```lua
-local player = {
-
-    tag = "player",
+load_entity({
     components = {
-        transform = {
-            position = { x = 100, y = 100 },
-            scale = { x = 1.0, y = 1.0 },
-            rotation = 0.0,
-        },
-        sprite = {
-            texture_asset_id = "player-texture",
-            width = 32,
-            height = 32,
-            layer = 1
-        },
-        rigidbody = {
-            velocity = { x = 0, y = 0 }
-        },
         script = {
-            speed = 100,
-            on_update = function(self, entity, delta_time)
-                -- Movement via the global `input` table. See lib/player_controller.lua
-                -- in the example project for a clamped + normalized version.
-                local pos = get_position(entity)
-                local dx, dy = 0, 0
-                if input.is_key_down("left")  then dx = dx - 1 end
-                if input.is_key_down("right") then dx = dx + 1 end
-                if input.is_key_down("up")    then dy = dy - 1 end
-                if input.is_key_down("down")  then dy = dy + 1 end
-                set_position(entity, pos.x + dx * self.speed * delta_time,
-                                     pos.y + dy * self.speed * delta_time)
-                if input.is_key_pressed("space") then log("Jump!") end
-            end
+            spawn_x = 100,
+            spawn_y = 100,
+            on_debug_gui = function(self, entity)
+                if ImGui.Begin("Spawn Tool") then
+                    self.spawn_x = ImGui.InputInt("X", self.spawn_x)
+                    self.spawn_y = ImGui.InputInt("Y", self.spawn_y)
+
+                    if ImGui.Button("Spawn Enemy") then
+                        load_entity({
+                            components = {
+                                transform = { position = { x = self.spawn_x, y = self.spawn_y } },
+                                sprite    = { texture_asset_id = "enemy", width = 32, height = 32, layer = 2 },
+                                health    = { max_health = 50 },
+                            }
+                        })
+                    end
+                end
+                ImGui.End()
+            end,
         }
     }
-}
-
-load_entity(player)
+})
 ```
 
----
-
-## 5. Lua API Reference
-
-| Function | Description |
-| --- | --- |
-| `log(message)` | Logs a message to the console. |
-| `load_asset(table)` | Loads a texture or font. |
-| `load_entity(table)` | Spawns a new entity with components. |
-| `blam(entity)` | Destroys the specified entity. |
-| `get_asset_path(path)` | Returns the absolute path for a relative asset path. |
-| `set_position(entity, x, y)` | Manually updates an entity's position. |
-| `get_position(entity)` | Returns the entity's position as a `vec2`. |
-| `get_camera_position()` | Returns the current camera viewport origin as `vec2`. |
-| `get_game_map_dimensions()` | Returns playable area as `vec2(width, height)`. |
-| `set_game_map_dimensions(w, h)` | Sets the playable area used by off-screen despawn. |
-| `set_sprite_src_rect(entity, x, y)` | Sets the sprite's source-rect origin (animation row/col). |
-| `fire_projectile(entity, dx, dy)` | Spawns a projectile from `entity`'s `projectile_emitter`, aimed at `(dx, dy)` (zero = emitter default). |
-| `read_file_lines(path)` | Reads a file and returns its lines as a table. |
-| `quit_game()` | Gracefully exits the engine. |
-
-### `input` table
-
-Polling, action map, and callbacks. Action bindings + callbacks are cleared on `load_scene`/`reload_scene` — re-install in the new scene's `setup` (use a guard for idempotency). Full scene lifecycle in [`docs/scenes.md`](scenes.md).
-
-| Function | Description |
-| --- | --- |
-| `input.is_key_down(name)` / `is_key_pressed(name)` / `is_key_released(name)` | Held / went-down-this-frame / went-up-this-frame. |
-| `input.is_mouse_down(btn)` / `is_mouse_pressed(btn)` / `is_mouse_released(btn)` | `btn` is `"left"`, `"middle"`, `"right"`, `"x1"`, `"x2"`, or an SDL button id. |
-| `input.mouse_position()` | Cursor position as `vec2`. Mapped to game resolution, viewport-aware (works in Editor). |
-| `input.mouse_wheel()` | Per-frame wheel delta as `vec2`. |
-| `input.bind(action, key)` / `unbind(action, key?)` | Register / remove key for action; nil key removes all. |
-| `input.is_action_down(name)` / `is_action_pressed(name)` / `is_action_released(name)` | As above, OR over all keys bound to the action. |
-| `input.on_key_down(fn)` / `on_key_up(fn)` | `fn(key_name)`. |
-| `input.on_mouse_down(fn)` / `on_mouse_up(fn)` | `fn(btn, x, y)`. |
-| `input.on_mouse_wheel(fn)` | `fn(dx, dy)`. |
+The full ImGui API is documented in the
+[Dear ImGui wiki](https://github.com/ocornut/imgui/wiki) and the engine's
+generated Lua stub at
+[`lua_api.smoke.lua`](https://github.com/mblackman/Octarine-Engine/blob/main/lua_api.smoke.lua)
+(search for `ImGui.`).
 
 ---
 
-## 6. ImGui Integration
-
-The engine exposes ImGui to Lua, allowing you to create debug tools and UI directly in script.
-Wire it via the `script` component's `on_debug_gui` callback:
-
-```lua
-script = {
-    on_debug_gui = function(self, entity)
-        if ImGui.Begin("Tools") then
-            if ImGui.Button("Spawn Enemy") then
-                -- Logic to spawn an enemy
-            end
-        end
-        ImGui.End()
-    end
-}
-```
-
----
-
-## 7. Global Callbacks
-
-The engine looks for specific functions in your scripts:
-
-- `on_update(self, entity, delta_time)`: Called every frame.
-- `on_debug_gui(self, entity)`: Called during the ImGui rendering pass.
-- `on_click(self, entity)`: Called if the entity has a `ui_button` component and is clicked.
-
----
-
-## 8. Adding component methods
+## 7. Adding Component Methods (engine contributors)
 
 When you add a Lua binding for a component (`src/Lua/Bindings/<X>ComponentLuaBinding.h`),
 the `bindUsertype` call exposes both fields and **member functions** to scripts:
@@ -191,9 +279,9 @@ the `bindUsertype` call exposes both fields and **member functions** to scripts:
 ```cpp
 lua.new_usertype<HealthComponent>(kUsertypeName,
     "max_health", &HealthComponent::maxHealth,
-    "damage",     &HealthComponent::Damage,   // member function
+    "damage",     &HealthComponent::Damage,
     "heal",       &HealthComponent::Heal,
-    "is_dead",    sol::property(&HealthComponent::IsDead),   // derived read-only
+    "is_dead",    sol::property(&HealthComponent::IsDead),
     "fraction",   sol::property(&HealthComponent::Fraction));
 ```
 
@@ -225,10 +313,9 @@ them anywhere safely.
 
 ### Patterns
 
-- **Mutators with invariants** — bind the field with `sol::property` and a
-  clamping setter so Lua can't bypass the invariant by direct field assignment.
-  `HealthComponent::currentHealth` is the canonical example: writes clamp to
-  `[0, maxHealth]`.
+- **Mutators with invariants** — bind with `sol::property` and a clamping
+  setter so Lua can't bypass the invariant by direct field assignment.
+  `HealthComponent::currentHealth` is the canonical example.
 - **Derived read-only state** — bind with `sol::property(&T::accessor)` so
   scripts get field-style access (`health.is_dead`) without exposing a setter.
 - **Plain getters/setters** — bind the member function directly.

--- a/docs/making-games.md
+++ b/docs/making-games.md
@@ -34,13 +34,34 @@ it alongside this guide whenever an example would help.
 
 Before writing game code you need a built copy of the engine.
 
-**System requirements**
+### Option A — Download a pre-built binary (recommended)
 
-- CMake 3.15+
-- A C++20-capable compiler (MSVC 2022, GCC 12+, or Clang 14+)
-- vcpkg (the engine uses manifest mode; it manages its own dependencies)
+CI builds the engine for Windows, macOS, and Linux on every push to `main`.
+Download the artifact for your platform from the
+[Actions tab](https://github.com/mblackman/Octarine-Engine/actions) on GitHub:
 
-**Build the engine**
+1. Open the latest successful **Build** workflow run.
+2. Scroll to **Artifacts** at the bottom.
+3. Download `OctarineEngine-<platform>-editor-release` for day-to-day development
+   or `OctarineEngine-<platform>-player-release` for a runtime-only build with no
+   editor tools.
+4. Unzip and run the binary directly — no install step required.
+
+Available artifact names:
+
+| Artifact | Contents |
+|---|---|
+| `OctarineEngine-windows-editor-release` | Windows editor build |
+| `OctarineEngine-windows-player-release` | Windows player-only build |
+| `OctarineEngine-macos-editor-release` | macOS editor build |
+| `OctarineEngine-macos-player-release` | macOS player-only build |
+| `OctarineEngine-linux-editor-release` | Linux editor build |
+| `OctarineEngine-linux-player-release` | Linux player-only build |
+
+### Option B — Build from source
+
+Requires CMake 3.15+, a C++20-capable compiler (MSVC 2022, GCC 12+, or Clang 14+),
+and vcpkg (the engine uses manifest mode and manages its own dependencies).
 
 ```bash
 git clone https://github.com/mblackman/Octarine-Engine

--- a/docs/making-games.md
+++ b/docs/making-games.md
@@ -17,13 +17,14 @@ it alongside this guide whenever an example would help.
 3. [Configuration](#3-configuration)
 4. [Core Concepts](#4-core-concepts)
 5. [Your First Entity](#5-your-first-entity)
-6. [Scripting Entities](#6-scripting-entities)
-7. [Scenes](#7-scenes)
-8. [Assets](#8-assets)
-9. [Audio](#9-audio)
-10. [Camera](#10-camera)
-11. [Using the Editor](#11-using-the-editor)
-12. [Further Reading](#12-further-reading)
+6. [Collision and Damage](#6-collision-and-damage)
+7. [Scripting Entities](#7-scripting-entities)
+8. [Scenes](#8-scenes)
+9. [Assets](#9-assets)
+10. [Audio](#10-audio)
+11. [Camera](#11-camera)
+12. [Using the Editor](#12-using-the-editor)
+13. [Further Reading](#13-further-reading)
 
 ---
 
@@ -199,7 +200,83 @@ For the full list of available components and their fields see
 
 ---
 
-## 6. Scripting Entities
+## 6. Collision and Damage
+
+Add `box_collider` to any entity that should participate in collision detection.
+The engine resolves overlaps every frame and dispatches damage automatically —
+no script code required for the common case.
+
+### How damage works
+
+When a projectile hits an entity, the engine compares collision masks to decide
+whether the hit registers, then subtracts the projectile's `hit_damage` from the
+target's `health.current_health`. All three components must be present for the
+full chain:
+
+```lua
+-- Shooter — emits projectiles
+load_entity({
+    components = {
+        transform          = { position = { x = 50, y = 300 } },
+        sprite             = { texture_asset_id = "tank", width = 32, height = 32, layer = 2 },
+        box_collider       = { width = 32, height = 32 },
+        projectile_emitter = {
+            projectile_velocity = { x = 200, y = 0 },
+            projectile_duration = 4.0,
+            repeat_frequency    = 0,       -- 0 = manual; call fire_projectile() from a script
+            hit_damage          = 25,
+            friendly            = false,   -- can hurt the player
+        },
+    }
+})
+
+-- Target — takes damage automatically when hit
+load_entity({
+    components = {
+        transform    = { position = { x = 500, y = 300 } },
+        sprite       = { texture_asset_id = "enemy", width = 32, height = 32, layer = 2 },
+        box_collider = { width = 32, height = 32 },
+        health       = { max_health = 100, current_health = 100 },
+    }
+})
+```
+
+### Collision masks
+
+Masks let you control which entity groups can collide with each other. The engine
+performs a bitwise AND between the projectile's `collision_mask` and the target
+entity's `entity_mask`; a non-zero result means the hit registers.
+
+```lua
+-- entity_mask groups the entity into one or more collision layers
+entity_mask = { value = 2 }     -- layer 2 = "enemies"
+
+-- box_collider and projectile_emitter filter which layers they react to
+box_collider       = { width = 32, height = 32, collision_mask = 1 }  -- reacts to layer 1
+projectile_emitter = { ..., collision_mask = 2 }                       -- hits layer 2 only
+```
+
+### Checking health in a script
+
+If you need to react to damage (play a sound, spawn particles, change behaviour
+when low on health), poll the health component in `on_update`:
+
+```lua
+on_update = function(self, entity, dt)
+    if registry.has_health(entity) then
+        local hp = registry.get_health(entity)
+        if hp.current_health <= 0 then
+            blam(entity)    -- destroy when dead
+        elseif hp.current_health < hp.max_health * 0.25 then
+            play_sound("warning-beep")
+        end
+    end
+end
+```
+
+---
+
+## 7. Scripting Entities
 
 Attach a `script` component to give an entity per-frame Lua behaviour. The
 engine calls `on_update(self, entity, dt)` every frame and `on_debug_gui(self,
@@ -212,9 +289,7 @@ binding, and ImGui debug UI.
 
 ---
 
----
-
-## 7. Scenes
+## 8. Scenes
 
 `load_scene(path)` replaces the current scene. Scene transitions are
 synchronous — `load_scene` does not return to the caller.
@@ -242,7 +317,7 @@ preload flow.
 
 ---
 
-## 8. Assets
+## 9. Assets
 
 Assets must be loaded before any entity references them. The recommended
 approach is `acquire_scene_assets` — it accepts `preload` lists and scans
@@ -273,7 +348,7 @@ packing, audio normalisation, and the full bake/manifest workflow.
 
 ---
 
-## 9. Audio
+## 10. Audio
 
 ```lua
 play_sound("jump-sfx")          -- one-shot
@@ -296,7 +371,7 @@ audio_source = {
 
 ---
 
-## 10. Camera
+## 11. Camera
 
 The camera follows whichever entity carries a `camera_follow` component. Only
 one should be active at a time.
@@ -316,7 +391,7 @@ elements.
 
 ---
 
-## 11. Using the Editor
+## 12. Using the Editor
 
 Launch an editor build against your project:
 
@@ -330,7 +405,7 @@ reference and keyboard shortcuts.
 
 ---
 
-## 12. Further Reading
+## 13. Further Reading
 
 ### Engine documentation
 

--- a/docs/making-games.md
+++ b/docs/making-games.md
@@ -17,16 +17,15 @@ it alongside this guide whenever an example would help.
 3. [Configuration](#3-configuration)
 4. [Core Concepts](#4-core-concepts)
 5. [Your First Entity](#5-your-first-entity)
-6. [Components Reference](#6-components-reference)
-7. [Scripting Entities](#7-scripting-entities)
-8. [Input](#8-input)
-9. [Scenes](#9-scenes)
-10. [Assets](#10-assets)
-11. [Audio](#11-audio)
-12. [Camera](#12-camera)
-13. [Debug UI with ImGui](#13-debug-ui-with-imgui)
-14. [Using the Editor](#14-using-the-editor)
-15. [Further Reading](#15-further-reading)
+6. [Scripting Entities](#6-scripting-entities)
+7. [Input](#7-input)
+8. [Scenes](#8-scenes)
+9. [Assets](#9-assets)
+10. [Audio](#10-audio)
+11. [Camera](#11-camera)
+12. [Debug UI with ImGui](#12-debug-ui-with-imgui)
+13. [Using the Editor](#13-using-the-editor)
+14. [Further Reading](#14-further-reading)
 
 ---
 
@@ -162,7 +161,7 @@ You do not need to touch C++ to make a game.
 
 A scene is a Lua file. `load_scene("scenes/gameplay.lua")` replaces the current
 scene with a new one. Scenes can be declarative (return a table the engine
-processes) or procedural (build the scene themselves). See [Scenes](#9-scenes).
+processes) or procedural (build the scene themselves). See [Scenes](#8-scenes).
 
 ---
 
@@ -197,153 +196,12 @@ load_entity({
 })
 ```
 
-Every field shown is optional except where noted in
-[Components Reference](#6-components-reference). Omitted fields take their
-defaults.
-
----
-
-## 6. Components Reference
-
-Quick summary. Full field tables are in
+For the full list of available components and their fields see
 [`docs/ecs-components.md`](ecs-components.md).
 
-### Transform
-
-```lua
-transform = {
-    position = { x = 0, y = 0 },   -- world position in pixels
-    scale    = { x = 1, y = 1 },   -- multiplicative scale
-    rotation = 0.0,                 -- degrees
-}
-```
-
-### Sprite
-
-Renders a loaded texture.
-
-```lua
-sprite = {
-    texture_asset_id = "my-texture",    -- required; must be loaded first
-    width  = 32,
-    height = 32,
-    layer  = 1,         -- higher layers draw on top
-    fixed  = false,     -- true = screen-space (UI), false = world-space
-    src_rect_x = 0,     -- pixel offset into the source texture
-    src_rect_y = 0,
-}
-```
-
-### Animation
-
-Drives frame-strip animation on a `sprite`.
-
-```lua
-animation = {
-    num_frames = 4,     -- frames laid out horizontally in the sprite sheet
-    speed_rate = 10,    -- frames per second
-}
-```
-
-### Square
-
-Colored rectangle — no texture required.
-
-```lua
-square = {
-    width  = 200,
-    height = 50,
-    color  = { r = 255, g = 80, b = 80, a = 255 },
-    layer  = 0,
-    fixed  = false,
-}
-```
-
-### Text Label
-
-```lua
-text_label = {
-    text    = "Score: 0",
-    font_id = "main-font",
-    color   = { r = 255, g = 255, b = 255, a = 255 },
-    layer   = 5,
-    is_fixed = true,    -- true keeps it in screen-space
-}
-```
-
-### Rigidbody
-
-Gives an entity a velocity the physics system integrates each frame.
-
-```lua
-rigidbody = {
-    velocity = { x = 0, y = 0 },   -- pixels per second
-}
-```
-
-### Box Collider
-
-Axis-aligned bounding box for collision detection.
-
-```lua
-box_collider = {
-    width  = 32,
-    height = 32,
-    offset = { x = 0, y = 0 },  -- offset from the transform position
-}
-```
-
-### Health
-
-```lua
-health = {
-    max_health     = 100,
-    current_health = 100,
-}
-```
-
-### Projectile Emitter
-
-Spawns projectile entities automatically.
-
-```lua
-projectile_emitter = {
-    projectile_velocity = { x = 200, y = 0 },
-    projectile_duration = 3.0,   -- seconds before the projectile despawns
-    repeat_frequency    = 0,     -- 0 = fire only on explicit call; >0 = auto-fire interval in seconds
-    hit_damage          = 10,
-    friendly            = true,  -- true = won't damage entities tagged "player"
-}
-```
-
-To fire a projectile on demand from Lua (e.g. on a key press):
-
-```lua
-fire_projectile(entity, direction_x, direction_y)
-```
-
-### Camera Follow
-
-Attaches the camera to this entity.
-
-```lua
-camera_follow = {}
-```
-
-### Script
-
-Attach Lua callbacks. See [Scripting Entities](#7-scripting-entities).
-
-```lua
-script = {
-    on_update    = function(self, entity, dt) ... end,
-    on_debug_gui = function(self, entity)     ... end,
-}
-```
-
 ---
 
-## 7. Scripting Entities
+## 6. Scripting Entities
 
 The `script` component is how entities get custom behaviour. It supports two
 callbacks:
@@ -353,26 +211,23 @@ callbacks:
 | `on_update(self, entity, dt)` | Every frame, in update order |
 | `on_debug_gui(self, entity)` | Every frame, but only when editor debug UI is visible |
 
-`self` is the script table itself (useful for storing state). `entity` is the
-entity ID. `dt` is delta time in seconds.
+`self` is the script table itself — store per-entity state there. `entity` is
+the entity ID. `dt` is delta time in seconds.
 
 ```lua
-local function make_spinner(speed)
-    return {
-        angle = 0,
-        on_update = function(self, entity, dt)
-            self.angle = self.angle + speed * dt
-            -- set_rotation doesn't exist yet; rotate via rigidbody or
-            -- by updating the transform through registry accessors.
-        end,
-    }
-end
-
 load_entity({
     components = {
         transform = { position = { x = 400, y = 300 } },
         sprite    = { texture_asset_id = "gem", width = 16, height = 16, layer = 3 },
-        script    = make_spinner(90),
+        script    = {
+            speed = 80,
+            on_update = function(self, entity, dt)
+                if input.is_action_down("move_right") then
+                    local pos = registry.get_position(entity)
+                    pos.x = pos.x + self.speed * dt
+                end
+            end,
+        },
     }
 })
 ```
@@ -380,56 +235,38 @@ load_entity({
 **Reading and writing components from a script**
 
 ```lua
--- Get a component reference (returns a mutable proxy)
+-- Get a mutable component reference
 local pos = registry.get_position(entity)
 pos.x = pos.x + 10
 
--- Check whether a component exists
+-- Check whether a component exists before touching it
 if registry.has_health(entity) then
     local hp = registry.get_health(entity)
     hp.current_health = hp.current_health - 1
 end
 ```
 
-The pattern is `registry.get_<component_key>` / `registry.has_<component_key>`.
-The key for each component is listed in
-[`docs/ecs-components.md`](ecs-components.md).
+The pattern is `registry.get_<key>` / `registry.has_<key>`. Component keys are
+listed in [`docs/ecs-components.md`](ecs-components.md).
 
 **Convenience helpers**
 
-These globals are shorthand for common component reads/writes:
-
 ```lua
-local pos = get_position(entity)          -- returns {x, y}
+local pos = get_position(entity)      -- returns {x, y}
 set_position(entity, new_x, new_y)
 local name = get_name(entity)
 set_name(entity, "New Name")
-
--- Destroy an entity
-blam(entity)
+blam(entity)                          -- destroy an entity
 ```
 
-**Sharing state between scripts**
-
-Scripts are plain Lua tables. Store anything you need in `self`:
-
-```lua
-script = {
-    cooldown  = 0,
-    max_speed = 120,
-    on_update = function(self, entity, dt)
-        self.cooldown = self.cooldown - dt
-        ...
-    end,
-}
-```
+For the full Lua scripting guide see [`docs/lua-scripting.md`](lua-scripting.md).
 
 ---
 
-## 8. Input
+## 7. Input
 
-The `input` table is available globally. Bind named actions to keys or buttons
-once (typically in `game.lua`), then query them anywhere.
+The `input` table is available globally. Bind named actions to keys once
+(typically in `game.lua`), then query them anywhere.
 
 ### Binding actions
 
@@ -474,7 +311,6 @@ local function update(self, entity, dt)
     if input.is_action_down("move_right") then dx = dx + 1 end
 
     if dx ~= 0 or dy ~= 0 then
-        -- Normalise diagonal movement
         local len = math.sqrt(dx * dx + dy * dy)
         local rb  = registry.get_rigidbody(entity)
         rb.velocity.x = (dx / len) * self.speed
@@ -489,106 +325,35 @@ end
 
 ---
 
-## 9. Scenes
+## 8. Scenes
 
-### Loading a scene
+`load_scene(path)` replaces the current scene. Scene transitions are
+synchronous — `load_scene` does not return to the caller.
 
 ```lua
 load_scene("scenes/gameplay.lua")
+reload_scene()      -- hot-reload the current scene (useful during development)
 ```
 
-This unloads all current entities and assets, then runs the target script.
-Scene transitions are synchronous — `load_scene` does not return to the caller.
-
-To hot-reload the current scene without a full engine restart (useful in the
-editor):
-
-```lua
-reload_scene()
-```
-
-### Declarative scene (recommended)
-
-Return a table from your scene file. The engine processes `preload`, `tilemap`,
-and `entities` in order.
-
-```lua
--- scenes/gameplay.lua
-return {
-    preload = { "explosion-sfx", "music-gameplay" },
-
-    tilemap = {
-        texture_asset_id = "tileset-forest",
-        map = "tilemaps/forest.map",
-    },
-
-    entities = {
-        {
-            tag  = "player",
-            name = "Player",
-            components = {
-                transform = { position = { x = 100, y = 100 } },
-                sprite    = { texture_asset_id = "player", width = 32, height = 32, layer = 2 },
-                rigidbody = { velocity = { x = 0, y = 0 } },
-                health    = { max_health = 100, current_health = 100 },
-                camera_follow = {},
-                script = { on_update = player_update },
-            },
-        },
-    },
-
-    -- Optional hook called after entities are spawned
-    run = function()
-        play_sound("music-gameplay")
-    end,
-}
-```
-
-### Procedural scene
-
-Return a function (or nothing — run the setup at top level). Useful when entity
-definitions are data-driven or generated at runtime.
-
-```lua
--- scenes/procedural.lua
-return function()
-    acquire_scene_assets({ preload = { "rock", "enemy-sfx" } })
-    for i = 1, 20 do
-        load_entity({
-            components = {
-                transform = { position = { x = math.random(50, 900), y = math.random(50, 500) } },
-                sprite    = { texture_asset_id = "rock", width = 16, height = 16, layer = 1 },
-            }
-        })
-    end
-end
-```
-
-### Stopping / clearing the scene
-
-```lua
-clear_scene()   -- remove all entities; typically called before rebuilding
-stop_scene()    -- signals the engine to end the current scene lifecycle
-```
-
-### Switching scenes from a script
+Switching scenes from inside a script:
 
 ```lua
 script = {
     on_update = function(self, entity, dt)
-        if input.is_key_pressed("r") then
-            load_scene("scenes/gameplay.lua")
-        end
-        if input.is_key_pressed("escape") then
-            load_scene("scenes/title.lua")
-        end
+        if input.is_key_pressed("r")      then load_scene("scenes/gameplay.lua") end
+        if input.is_key_pressed("escape") then load_scene("scenes/title.lua")    end
     end,
 }
 ```
 
+Scene files can be declarative (return a table), procedural (return a function),
+or side-effect style (build the scene at top level as the file executes). See
+[`docs/scenes.md`](scenes.md) for the full lifecycle, file shape, and asset
+preload flow.
+
 ---
 
-## 10. Assets
+## 9. Assets
 
 Assets must be loaded before any entity references them. The recommended
 approach is `acquire_scene_assets` — it accepts `preload` lists and scans
@@ -596,20 +361,10 @@ entity definitions for asset references automatically. Explicit `load_asset`
 calls are also supported.
 
 ```lua
--- Texture
-load_asset({ type = "texture", id = "player", file = "images/player.png" })
-
--- Sprite sheet / atlas (individual frames are addressed by id in sprites)
-load_asset({ type = "texture", id = "explosion", file = "images/explosion.png" })
-
--- Font
-load_asset({ type = "font", id = "main-font", file = "fonts/arial.ttf", font_size = 16 })
-
--- Sound
-load_asset({ type = "sound", id = "jump-sfx", file = "sounds/jump.wav" })
+load_asset({ type = "texture", id = "player",    file = "images/player.png" })
+load_asset({ type = "font",    id = "main-font", file = "fonts/arial.ttf", font_size = 16 })
+load_asset({ type = "sound",   id = "jump-sfx",  file = "sounds/jump.wav" })
 ```
-
-**Resolving paths**
 
 All asset paths are relative to the project root. Use `get_asset_path` when
 building paths dynamically:
@@ -618,40 +373,31 @@ building paths dynamically:
 local path = get_asset_path("images/player.png")
 ```
 
-**Asset pipeline and baking**
-
-For shipping builds the engine can bake assets into a manifest. Run the bake
-step headlessly:
+For shipping builds, bake assets into a manifest with:
 
 ```bash
 ./OctarineEngine path/to/MyGame -m bake
 ```
 
-This writes `asset_manifest.lua` beside your project and packs assets for
-distribution. See [`docs/asset-pipeline.md`](asset-pipeline.md) for full detail
-on `.meta` sidecars, atlas packing, and audio normalisation.
+See [`docs/asset-pipeline.md`](asset-pipeline.md) for `.meta` sidecars, atlas
+packing, audio normalisation, and the full bake/manifest workflow.
 
 ---
 
-## 11. Audio
+## 10. Audio
 
 ```lua
--- Play a one-shot sound
-play_sound("jump-sfx")
-
--- Play music (typically looped; pass the asset id)
-play_sound("music-gameplay")
+play_sound("jump-sfx")          -- one-shot
+play_sound("music-gameplay")    -- looped music
 ```
 
-For spatial / 3D audio, add an `audio_listener` component to the camera or
-player entity and `audio_source` to the emitting entity. The engine computes
-attenuation based on the listener–source distance automatically.
+For spatial audio, add `audio_listener` to the player/camera entity and
+`audio_source` to emitting entities. The engine handles attenuation
+automatically.
 
 ```lua
--- Listener (usually on the player or camera)
 audio_listener = {}
 
--- Source (on enemies, pickups, etc.)
 audio_source = {
     asset_id = "enemy-growl",
     loop     = true,
@@ -661,27 +407,27 @@ audio_source = {
 
 ---
 
-## 12. Camera
+## 11. Camera
 
 The camera follows whichever entity carries a `camera_follow` component. Only
-one camera follower should be active at a time.
+one should be active at a time.
 
 ```lua
--- Query the camera's current world position
-local cam = get_camera_position()   -- returns {x, y}
+camera_follow = {}
+```
 
--- World bounds (the camera won't scroll past these)
-set_game_map_dimensions(width_px, height_px)
-local dims = get_game_map_dimensions()   -- returns {w, h}
+```lua
+local cam = get_camera_position()            -- returns {x, y}
+set_game_map_dimensions(width_px, height_px) -- clamp scrolling to world bounds
 ```
 
 Entities with `fixed = true` on their `sprite`, `square`, or `text_label`
-render in screen space and are unaffected by camera movement — use this for HUD
+render in screen space, unaffected by camera movement — use this for HUD
 elements.
 
 ---
 
-## 13. Debug UI with ImGui
+## 12. Debug UI with ImGui
 
 The engine ships full [Dear ImGui](https://github.com/ocornut/imgui) bindings.
 Use them inside `on_debug_gui` callbacks — they only fire when the editor's
@@ -716,7 +462,7 @@ load_entity({
 })
 ```
 
-The full ImGui API — over 200 functions — is documented in the
+The full ImGui API is documented in the
 [Dear ImGui wiki](https://github.com/ocornut/imgui/wiki) and the engine's
 generated Lua stub at
 [`lua_api.smoke.lua`](https://github.com/mblackman/Octarine-Engine/blob/main/lua_api.smoke.lua)
@@ -724,35 +470,29 @@ generated Lua stub at
 
 ---
 
-## 14. Using the Editor
+## 13. Using the Editor
 
 Launch an editor build against your project:
 
 ```bash
-./build/editor-debug/bin/debug/OctarineEngine path/to/MyGame
+./OctarineEngine path/to/MyGame
 ```
 
-The editor adds:
-- A toolbar with **Run** (launch a player window) and **Export** (package for distribution).
-- An entity inspector and scene hierarchy panel.
-- Your `on_debug_gui` windows, rendered into the editor layout.
-- Hot-reload: save a Lua file, press the reload button (or call `reload_scene()` from a script).
-
-See [`docs/editor.md`](editor.md) for the full panel reference and keyboard shortcuts.
+The editor adds a toolbar, entity inspector, scene hierarchy, and your
+`on_debug_gui` windows. See [`docs/editor.md`](editor.md) for the full panel
+reference and keyboard shortcuts.
 
 ---
 
-## 15. Further Reading
+## 14. Further Reading
 
 ### Engine documentation
-
-These live in `docs/` inside the engine repository:
 
 | Doc | What's in it |
 |---|---|
 | [`docs/ecs-components.md`](ecs-components.md) | Every component — all fields, types, and defaults |
-| [`docs/lua-scripting.md`](lua-scripting.md) | Detailed Lua scripting guide with more examples |
-| [`docs/scenes.md`](scenes.md) | Full scene lifecycle, declarative vs. procedural forms |
+| [`docs/lua-scripting.md`](lua-scripting.md) | Full Lua scripting guide |
+| [`docs/scenes.md`](scenes.md) | Scene lifecycle, declarative vs. procedural forms |
 | [`docs/asset-pipeline.md`](asset-pipeline.md) | `.meta` sidecars, baking, atlases, audio normalisation |
 | [`docs/systems.md`](systems.md) | Built-in systems and the order they run |
 | [`docs/events.md`](events.md) | The event bus — every event type and how to use them |
@@ -764,17 +504,13 @@ These live in `docs/` inside the engine repository:
 
 [`lua_api.smoke.lua`](https://github.com/mblackman/Octarine-Engine/blob/main/lua_api.smoke.lua)
 is the authoritative, auto-generated EmmyLua stub of the entire Lua surface.
-Every global, namespace table, and component accessor is listed there with type
-annotations. Load it into your editor (VS Code + the Lua Language Server
-extension is recommended) for autocomplete and inline docs.
+Load it into your editor (VS Code + the Lua Language Server extension is
+recommended) for autocomplete and inline docs.
 
 ### Example project
 
 [Octarine-Engine-Example](https://github.com/mblackman/Octarine-Engine-Example)
-is a complete, runnable game that shows every engine feature in practice:
-physics, animation, audio, projectile systems, scene transitions, debug UI, and
-more. It is the fastest way to see working patterns for anything not covered
-here.
+is a complete, runnable game showing every engine feature in practice.
 
 ### Engine repository
 
@@ -783,12 +519,11 @@ Source, issue tracker, and releases:
 
 ### Lua 5.4
 
-The engine embeds Lua 5.4. The official reference manual is the ground truth
-for the language itself: [lua.org/manual/5.4](https://www.lua.org/manual/5.4/)
+The engine embeds Lua 5.4. Reference manual: [lua.org/manual/5.4](https://www.lua.org/manual/5.4/)
 
 ### Dear ImGui
 
 The UI binding closely mirrors the C++ API. The
-[ImGui wiki](https://github.com/ocornut/imgui/wiki) and the header comments in
+[ImGui wiki](https://github.com/ocornut/imgui/wiki) and header comments in
 [`imgui.h`](https://github.com/ocornut/imgui/blob/master/imgui.h) are the best
-references for functions not yet documented in the engine's Lua stub.
+references for functions not yet in the engine's Lua stub.

--- a/docs/making-games.md
+++ b/docs/making-games.md
@@ -1,0 +1,773 @@
+# Making Games with Octarine Engine
+
+A practical guide for game developers. It covers how to set up a project, the
+core concepts you'll use every day, and where to go for deeper reference.
+
+The companion example project,
+[Octarine-Engine-Example](https://github.com/mblackman/Octarine-Engine-Example),
+is a small but complete game that exercises every feature described here — run
+it alongside this guide whenever an example would help.
+
+---
+
+## Table of Contents
+
+1. [Prerequisites](#1-prerequisites)
+2. [Project Structure](#2-project-structure)
+3. [Configuration](#3-configuration)
+4. [Core Concepts](#4-core-concepts)
+5. [Your First Entity](#5-your-first-entity)
+6. [Components Reference](#6-components-reference)
+7. [Scripting Entities](#7-scripting-entities)
+8. [Input](#8-input)
+9. [Scenes](#9-scenes)
+10. [Assets](#10-assets)
+11. [Audio](#11-audio)
+12. [Camera](#12-camera)
+13. [Debug UI with ImGui](#13-debug-ui-with-imgui)
+14. [Using the Editor](#14-using-the-editor)
+15. [Further Reading](#15-further-reading)
+
+---
+
+## 1. Prerequisites
+
+Before writing game code you need a built copy of the engine.
+
+**System requirements**
+
+- CMake 3.15+
+- A C++20-capable compiler (MSVC 2022, GCC 12+, or Clang 14+)
+- vcpkg (the engine uses manifest mode; it manages its own dependencies)
+
+**Build the engine**
+
+```bash
+git clone https://github.com/mblackman/Octarine-Engine
+cd Octarine-Engine
+cmake --preset editor-debug
+cmake --build build/editor-debug
+```
+
+The resulting binary is `build/editor-debug/bin/debug/OctarineEngine` (Linux/macOS)
+or `build\editor-debug\bin\debug\OctarineEngine.exe` (Windows).
+
+**Run against your project**
+
+```bash
+./build/editor-debug/bin/debug/OctarineEngine path/to/MyGame
+```
+
+The engine takes your game's root directory as its only positional argument. The
+`config.ini` there tells it what startup script to run.
+
+---
+
+## 2. Project Structure
+
+A minimal project needs only `config.ini` and `game.lua`. A more typical layout:
+
+```
+MyGame/
+├── config.ini              # window settings, startup script
+├── game.lua                # entry point — runs first
+├── scenes/
+│   ├── title.lua
+│   ├── gameplay.lua
+│   └── game_over.lua
+├── scripts/
+│   └── lib/                # reusable Lua helpers
+│       ├── input_map.lua
+│       └── player_controller.lua
+├── images/                 # .png / .jpg textures
+├── fonts/                  # .ttf fonts
+├── sounds/                 # .wav / .ogg audio
+└── tilemaps/               # .map files + tileset PNGs
+```
+
+There are no enforced path conventions beyond `config.ini` and the startup
+script — organise the rest however suits your project.
+
+---
+
+## 3. Configuration
+
+`config.ini` lives at the project root and controls window setup:
+
+```ini
+Title=My Awesome Game
+Version=1.0.0
+Author=Your Name
+StartupScript=game.lua
+DefaultWindowWidth=1280
+DefaultWindowHeight=720
+DefaultScalingMode=nearest      # 'nearest' for pixel art, 'linear' for smooth
+```
+
+`StartupScript` is the first Lua file that runs. Everything else — scenes,
+assets, entities — is loaded from there.
+
+---
+
+## 4. Core Concepts
+
+### Entities and Components
+
+Octarine uses an **Entity-Component System (ECS)**. The key ideas:
+
+- An **entity** is just an ID — a number with no data of its own.
+- **Components** are plain data structs attached to entities (`position`,
+  `sprite`, `rigidbody`, etc.).
+- **Systems** are the engine's update loops — they query for entities with a
+  given set of components and act on them each frame.
+
+You never subclass anything or register callbacks on a base class. Instead you
+compose entities from components and attach a `script` component when an entity
+needs custom per-frame behaviour.
+
+### Lua is the game layer
+
+All game logic lives in Lua. The engine exposes its entire surface through:
+
+- **Free globals** — `load_entity`, `load_scene`, `play_sound`, `get_position`,
+  `set_position`, `fire_projectile`, `log`, etc.
+- **Namespace tables** — `input.*`, `ImGui.*`, `registry.*`
+- **The `script` component** — attach `on_update` and `on_debug_gui` callbacks
+  to any entity.
+
+You do not need to touch C++ to make a game.
+
+### Scenes
+
+A scene is a Lua file. `load_scene("scenes/gameplay.lua")` replaces the current
+scene with a new one. Scenes can be declarative (return a table the engine
+processes) or procedural (build the scene themselves). See [Scenes](#9-scenes).
+
+---
+
+## 5. Your First Entity
+
+Pass a table to `load_entity` from anywhere in your Lua code:
+
+```lua
+load_entity({
+    tag = "player",         -- optional group label
+    name = "Player",        -- optional display name
+    components = {
+        transform = {
+            position = { x = 100, y = 100 },
+            scale    = { x = 1.0, y = 1.0 },
+            rotation = 0.0,
+        },
+        sprite = {
+            texture_asset_id = "player-texture",
+            width  = 32,
+            height = 32,
+            layer  = 2,
+        },
+        rigidbody = {
+            velocity = { x = 0, y = 0 },
+        },
+        health = {
+            max_health     = 100,
+            current_health = 100,
+        },
+    }
+})
+```
+
+Every field shown is optional except where noted in
+[Components Reference](#6-components-reference). Omitted fields take their
+defaults.
+
+---
+
+## 6. Components Reference
+
+Quick summary. Full field tables are in
+[`docs/ecs-components.md`](ecs-components.md).
+
+### Transform
+
+```lua
+transform = {
+    position = { x = 0, y = 0 },   -- world position in pixels
+    scale    = { x = 1, y = 1 },   -- multiplicative scale
+    rotation = 0.0,                 -- degrees
+}
+```
+
+### Sprite
+
+Renders a loaded texture.
+
+```lua
+sprite = {
+    texture_asset_id = "my-texture",    -- required; must be loaded first
+    width  = 32,
+    height = 32,
+    layer  = 1,         -- higher layers draw on top
+    fixed  = false,     -- true = screen-space (UI), false = world-space
+    src_rect_x = 0,     -- pixel offset into the source texture
+    src_rect_y = 0,
+}
+```
+
+### Animation
+
+Drives frame-strip animation on a `sprite`.
+
+```lua
+animation = {
+    num_frames = 4,     -- frames laid out horizontally in the sprite sheet
+    speed_rate = 10,    -- frames per second
+}
+```
+
+### Square
+
+Colored rectangle — no texture required.
+
+```lua
+square = {
+    width  = 200,
+    height = 50,
+    color  = { r = 255, g = 80, b = 80, a = 255 },
+    layer  = 0,
+    fixed  = false,
+}
+```
+
+### Text Label
+
+```lua
+text_label = {
+    text    = "Score: 0",
+    font_id = "main-font",
+    color   = { r = 255, g = 255, b = 255, a = 255 },
+    layer   = 5,
+    is_fixed = true,    -- true keeps it in screen-space
+}
+```
+
+### Rigidbody
+
+Gives an entity a velocity the physics system integrates each frame.
+
+```lua
+rigidbody = {
+    velocity = { x = 0, y = 0 },   -- pixels per second
+}
+```
+
+### Box Collider
+
+Axis-aligned bounding box for collision detection.
+
+```lua
+box_collider = {
+    width  = 32,
+    height = 32,
+    offset = { x = 0, y = 0 },  -- offset from the transform position
+}
+```
+
+### Health
+
+```lua
+health = {
+    max_health     = 100,
+    current_health = 100,
+}
+```
+
+### Projectile Emitter
+
+Spawns projectile entities automatically.
+
+```lua
+projectile_emitter = {
+    projectile_velocity = { x = 200, y = 0 },
+    projectile_duration = 3.0,   -- seconds before the projectile despawns
+    repeat_frequency    = 0,     -- 0 = fire only on explicit call; >0 = auto-fire interval in seconds
+    hit_damage          = 10,
+    friendly            = true,  -- true = won't damage entities tagged "player"
+}
+```
+
+To fire a projectile on demand from Lua (e.g. on a key press):
+
+```lua
+fire_projectile(entity, direction_x, direction_y)
+```
+
+### Camera Follow
+
+Attaches the camera to this entity.
+
+```lua
+camera_follow = {}
+```
+
+### Script
+
+Attach Lua callbacks. See [Scripting Entities](#7-scripting-entities).
+
+```lua
+script = {
+    on_update    = function(self, entity, dt) ... end,
+    on_debug_gui = function(self, entity)     ... end,
+}
+```
+
+---
+
+## 7. Scripting Entities
+
+The `script` component is how entities get custom behaviour. It supports two
+callbacks:
+
+| Callback | When called |
+|---|---|
+| `on_update(self, entity, dt)` | Every frame, in update order |
+| `on_debug_gui(self, entity)` | Every frame, but only when editor debug UI is visible |
+
+`self` is the script table itself (useful for storing state). `entity` is the
+entity ID. `dt` is delta time in seconds.
+
+```lua
+local function make_spinner(speed)
+    return {
+        angle = 0,
+        on_update = function(self, entity, dt)
+            self.angle = self.angle + speed * dt
+            -- set_rotation doesn't exist yet; rotate via rigidbody or
+            -- by updating the transform through registry accessors.
+        end,
+    }
+end
+
+load_entity({
+    components = {
+        transform = { position = { x = 400, y = 300 } },
+        sprite    = { texture_asset_id = "gem", width = 16, height = 16, layer = 3 },
+        script    = make_spinner(90),
+    }
+})
+```
+
+**Reading and writing components from a script**
+
+```lua
+-- Get a component reference (returns a mutable proxy)
+local pos = registry.get_position(entity)
+pos.x = pos.x + 10
+
+-- Check whether a component exists
+if registry.has_health(entity) then
+    local hp = registry.get_health(entity)
+    hp.current_health = hp.current_health - 1
+end
+```
+
+The pattern is `registry.get_<component_key>` / `registry.has_<component_key>`.
+The key for each component is listed in
+[`docs/ecs-components.md`](ecs-components.md).
+
+**Convenience helpers**
+
+These globals are shorthand for common component reads/writes:
+
+```lua
+local pos = get_position(entity)          -- returns {x, y}
+set_position(entity, new_x, new_y)
+local name = get_name(entity)
+set_name(entity, "New Name")
+
+-- Destroy an entity
+blam(entity)
+```
+
+**Sharing state between scripts**
+
+Scripts are plain Lua tables. Store anything you need in `self`:
+
+```lua
+script = {
+    cooldown  = 0,
+    max_speed = 120,
+    on_update = function(self, entity, dt)
+        self.cooldown = self.cooldown - dt
+        ...
+    end,
+}
+```
+
+---
+
+## 8. Input
+
+The `input` table is available globally. Bind named actions to keys or buttons
+once (typically in `game.lua`), then query them anywhere.
+
+### Binding actions
+
+```lua
+input.bind("move_up",    "up")
+input.bind("move_up",    "w")       -- multiple keys per action
+input.bind("move_down",  "down")
+input.bind("move_down",  "s")
+input.bind("move_left",  "left")
+input.bind("move_left",  "a")
+input.bind("move_right", "right")
+input.bind("move_right", "d")
+input.bind("fire",       "space")
+```
+
+### Querying actions and keys
+
+```lua
+-- Action queries (works with any key bound to the action)
+input.is_action_down("fire")        -- held this frame
+input.is_action_pressed("fire")     -- just went down this frame
+input.is_action_released("fire")    -- just came up this frame
+
+-- Raw key queries
+input.is_key_down("escape")
+input.is_key_pressed("f5")
+
+-- Mouse
+local pos = input.mouse_position()     -- returns {x, y}
+input.is_mouse_down(1)                 -- 1 = left, 2 = right, 3 = middle
+input.is_mouse_pressed(1)
+```
+
+### Example: 8-way movement
+
+```lua
+local function update(self, entity, dt)
+    local dx, dy = 0, 0
+    if input.is_action_down("move_up")    then dy = dy - 1 end
+    if input.is_action_down("move_down")  then dy = dy + 1 end
+    if input.is_action_down("move_left")  then dx = dx - 1 end
+    if input.is_action_down("move_right") then dx = dx + 1 end
+
+    if dx ~= 0 or dy ~= 0 then
+        -- Normalise diagonal movement
+        local len = math.sqrt(dx * dx + dy * dy)
+        local rb  = registry.get_rigidbody(entity)
+        rb.velocity.x = (dx / len) * self.speed
+        rb.velocity.y = (dy / len) * self.speed
+    else
+        local rb = registry.get_rigidbody(entity)
+        rb.velocity.x = 0
+        rb.velocity.y = 0
+    end
+end
+```
+
+---
+
+## 9. Scenes
+
+### Loading a scene
+
+```lua
+load_scene("scenes/gameplay.lua")
+```
+
+This unloads all current entities and assets, then runs the target script.
+Scene transitions are synchronous — `load_scene` does not return to the caller.
+
+To hot-reload the current scene without a full engine restart (useful in the
+editor):
+
+```lua
+reload_scene()
+```
+
+### Declarative scene (recommended)
+
+Return a table from your scene file. The engine processes `preload`, `tilemap`,
+and `entities` in order.
+
+```lua
+-- scenes/gameplay.lua
+return {
+    preload = { "explosion-sfx", "music-gameplay" },
+
+    tilemap = {
+        texture_asset_id = "tileset-forest",
+        map = "tilemaps/forest.map",
+    },
+
+    entities = {
+        {
+            tag  = "player",
+            name = "Player",
+            components = {
+                transform = { position = { x = 100, y = 100 } },
+                sprite    = { texture_asset_id = "player", width = 32, height = 32, layer = 2 },
+                rigidbody = { velocity = { x = 0, y = 0 } },
+                health    = { max_health = 100, current_health = 100 },
+                camera_follow = {},
+                script = { on_update = player_update },
+            },
+        },
+    },
+
+    -- Optional hook called after entities are spawned
+    run = function()
+        play_sound("music-gameplay")
+    end,
+}
+```
+
+### Procedural scene
+
+Return a function (or nothing — run the setup at top level). Useful when entity
+definitions are data-driven or generated at runtime.
+
+```lua
+-- scenes/procedural.lua
+return function()
+    acquire_scene_assets({ preload = { "rock", "enemy-sfx" } })
+    for i = 1, 20 do
+        load_entity({
+            components = {
+                transform = { position = { x = math.random(50, 900), y = math.random(50, 500) } },
+                sprite    = { texture_asset_id = "rock", width = 16, height = 16, layer = 1 },
+            }
+        })
+    end
+end
+```
+
+### Stopping / clearing the scene
+
+```lua
+clear_scene()   -- remove all entities; typically called before rebuilding
+stop_scene()    -- signals the engine to end the current scene lifecycle
+```
+
+### Switching scenes from a script
+
+```lua
+script = {
+    on_update = function(self, entity, dt)
+        if input.is_key_pressed("r") then
+            load_scene("scenes/gameplay.lua")
+        end
+        if input.is_key_pressed("escape") then
+            load_scene("scenes/title.lua")
+        end
+    end,
+}
+```
+
+---
+
+## 10. Assets
+
+Assets must be loaded before any entity references them. The recommended
+approach is `acquire_scene_assets` — it accepts `preload` lists and scans
+entity definitions for asset references automatically. Explicit `load_asset`
+calls are also supported.
+
+```lua
+-- Texture
+load_asset({ type = "texture", id = "player", file = "images/player.png" })
+
+-- Sprite sheet / atlas (individual frames are addressed by id in sprites)
+load_asset({ type = "texture", id = "explosion", file = "images/explosion.png" })
+
+-- Font
+load_asset({ type = "font", id = "main-font", file = "fonts/arial.ttf", font_size = 16 })
+
+-- Sound
+load_asset({ type = "sound", id = "jump-sfx", file = "sounds/jump.wav" })
+```
+
+**Resolving paths**
+
+All asset paths are relative to the project root. Use `get_asset_path` when
+building paths dynamically:
+
+```lua
+local path = get_asset_path("images/player.png")
+```
+
+**Asset pipeline and baking**
+
+For shipping builds the engine can bake assets into a manifest. Run the bake
+step headlessly:
+
+```bash
+./OctarineEngine path/to/MyGame -m bake
+```
+
+This writes `asset_manifest.lua` beside your project and packs assets for
+distribution. See [`docs/asset-pipeline.md`](asset-pipeline.md) for full detail
+on `.meta` sidecars, atlas packing, and audio normalisation.
+
+---
+
+## 11. Audio
+
+```lua
+-- Play a one-shot sound
+play_sound("jump-sfx")
+
+-- Play music (typically looped; pass the asset id)
+play_sound("music-gameplay")
+```
+
+For spatial / 3D audio, add an `audio_listener` component to the camera or
+player entity and `audio_source` to the emitting entity. The engine computes
+attenuation based on the listener–source distance automatically.
+
+```lua
+-- Listener (usually on the player or camera)
+audio_listener = {}
+
+-- Source (on enemies, pickups, etc.)
+audio_source = {
+    asset_id = "enemy-growl",
+    loop     = true,
+    volume   = 0.8,
+}
+```
+
+---
+
+## 12. Camera
+
+The camera follows whichever entity carries a `camera_follow` component. Only
+one camera follower should be active at a time.
+
+```lua
+-- Query the camera's current world position
+local cam = get_camera_position()   -- returns {x, y}
+
+-- World bounds (the camera won't scroll past these)
+set_game_map_dimensions(width_px, height_px)
+local dims = get_game_map_dimensions()   -- returns {w, h}
+```
+
+Entities with `fixed = true` on their `sprite`, `square`, or `text_label`
+render in screen space and are unaffected by camera movement — use this for HUD
+elements.
+
+---
+
+## 13. Debug UI with ImGui
+
+The engine ships full [Dear ImGui](https://github.com/ocornut/imgui) bindings.
+Use them inside `on_debug_gui` callbacks — they only fire when the editor's
+debug UI is visible, so release builds pay nothing.
+
+```lua
+local spawn_x = 100
+local spawn_y = 100
+
+load_entity({
+    components = {
+        script = {
+            on_debug_gui = function(self, entity)
+                if ImGui.Begin("Spawn Tool") then
+                    spawn_x = ImGui.InputInt("X", spawn_x)
+                    spawn_y = ImGui.InputInt("Y", spawn_y)
+
+                    if ImGui.Button("Spawn Enemy") then
+                        load_entity({
+                            components = {
+                                transform = { position = { x = spawn_x, y = spawn_y } },
+                                sprite    = { texture_asset_id = "enemy", width = 32, height = 32, layer = 2 },
+                                health    = { max_health = 50 },
+                            }
+                        })
+                    end
+                end
+                ImGui.End()
+            end,
+        }
+    }
+})
+```
+
+The full ImGui API — over 200 functions — is documented in the
+[Dear ImGui wiki](https://github.com/ocornut/imgui/wiki) and the engine's
+generated Lua stub at
+[`lua_api.smoke.lua`](https://github.com/mblackman/Octarine-Engine/blob/main/lua_api.smoke.lua)
+(search for `ImGui.`).
+
+---
+
+## 14. Using the Editor
+
+Launch an editor build against your project:
+
+```bash
+./build/editor-debug/bin/debug/OctarineEngine path/to/MyGame
+```
+
+The editor adds:
+- A toolbar with **Run** (launch a player window) and **Export** (package for distribution).
+- An entity inspector and scene hierarchy panel.
+- Your `on_debug_gui` windows, rendered into the editor layout.
+- Hot-reload: save a Lua file, press the reload button (or call `reload_scene()` from a script).
+
+See [`docs/editor.md`](editor.md) for the full panel reference and keyboard shortcuts.
+
+---
+
+## 15. Further Reading
+
+### Engine documentation
+
+These live in `docs/` inside the engine repository:
+
+| Doc | What's in it |
+|---|---|
+| [`docs/ecs-components.md`](ecs-components.md) | Every component — all fields, types, and defaults |
+| [`docs/lua-scripting.md`](lua-scripting.md) | Detailed Lua scripting guide with more examples |
+| [`docs/scenes.md`](scenes.md) | Full scene lifecycle, declarative vs. procedural forms |
+| [`docs/asset-pipeline.md`](asset-pipeline.md) | `.meta` sidecars, baking, atlases, audio normalisation |
+| [`docs/systems.md`](systems.md) | Built-in systems and the order they run |
+| [`docs/events.md`](events.md) | The event bus — every event type and how to use them |
+| [`docs/editor.md`](editor.md) | Editor panels, hotkeys, export workflow |
+| [`docs/tilemaps.md`](tilemaps.md) | Tilemap scene field |
+| [`docs/device-builds.md`](device-builds.md) | Shipping for desktop and Android |
+
+### Lua API reference
+
+[`lua_api.smoke.lua`](https://github.com/mblackman/Octarine-Engine/blob/main/lua_api.smoke.lua)
+is the authoritative, auto-generated EmmyLua stub of the entire Lua surface.
+Every global, namespace table, and component accessor is listed there with type
+annotations. Load it into your editor (VS Code + the Lua Language Server
+extension is recommended) for autocomplete and inline docs.
+
+### Example project
+
+[Octarine-Engine-Example](https://github.com/mblackman/Octarine-Engine-Example)
+is a complete, runnable game that shows every engine feature in practice:
+physics, animation, audio, projectile systems, scene transitions, debug UI, and
+more. It is the fastest way to see working patterns for anything not covered
+here.
+
+### Engine repository
+
+Source, issue tracker, and releases:
+[github.com/mblackman/Octarine-Engine](https://github.com/mblackman/Octarine-Engine)
+
+### Lua 5.4
+
+The engine embeds Lua 5.4. The official reference manual is the ground truth
+for the language itself: [lua.org/manual/5.4](https://www.lua.org/manual/5.4/)
+
+### Dear ImGui
+
+The UI binding closely mirrors the C++ API. The
+[ImGui wiki](https://github.com/ocornut/imgui/wiki) and the header comments in
+[`imgui.h`](https://github.com/ocornut/imgui/blob/master/imgui.h) are the best
+references for functions not yet documented in the engine's Lua stub.

--- a/docs/making-games.md
+++ b/docs/making-games.md
@@ -18,14 +18,12 @@ it alongside this guide whenever an example would help.
 4. [Core Concepts](#4-core-concepts)
 5. [Your First Entity](#5-your-first-entity)
 6. [Scripting Entities](#6-scripting-entities)
-7. [Input](#7-input)
-8. [Scenes](#8-scenes)
-9. [Assets](#9-assets)
-10. [Audio](#10-audio)
-11. [Camera](#11-camera)
-12. [Debug UI with ImGui](#12-debug-ui-with-imgui)
-13. [Using the Editor](#13-using-the-editor)
-14. [Further Reading](#14-further-reading)
+7. [Scenes](#7-scenes)
+8. [Assets](#8-assets)
+9. [Audio](#9-audio)
+10. [Camera](#10-camera)
+11. [Using the Editor](#11-using-the-editor)
+12. [Further Reading](#12-further-reading)
 
 ---
 
@@ -161,7 +159,7 @@ You do not need to touch C++ to make a game.
 
 A scene is a Lua file. `load_scene("scenes/gameplay.lua")` replaces the current
 scene with a new one. Scenes can be declarative (return a table the engine
-processes) or procedural (build the scene themselves). See [Scenes](#8-scenes).
+processes) or procedural (build the scene themselves). See [Scenes](#7-scenes).
 
 ---
 
@@ -203,129 +201,20 @@ For the full list of available components and their fields see
 
 ## 6. Scripting Entities
 
-The `script` component is how entities get custom behaviour. It supports two
-callbacks:
+Attach a `script` component to give an entity per-frame Lua behaviour. The
+engine calls `on_update(self, entity, dt)` every frame and `on_debug_gui(self,
+entity)` when editor debug UI is visible. `self` is the script table — store
+per-entity state there.
 
-| Callback | When called |
-|---|---|
-| `on_update(self, entity, dt)` | Every frame, in update order |
-| `on_debug_gui(self, entity)` | Every frame, but only when editor debug UI is visible |
-
-`self` is the script table itself — store per-entity state there. `entity` is
-the entity ID. `dt` is delta time in seconds.
-
-```lua
-load_entity({
-    components = {
-        transform = { position = { x = 400, y = 300 } },
-        sprite    = { texture_asset_id = "gem", width = 16, height = 16, layer = 3 },
-        script    = {
-            speed = 80,
-            on_update = function(self, entity, dt)
-                if input.is_action_down("move_right") then
-                    local pos = registry.get_position(entity)
-                    pos.x = pos.x + self.speed * dt
-                end
-            end,
-        },
-    }
-})
-```
-
-**Reading and writing components from a script**
-
-```lua
--- Get a mutable component reference
-local pos = registry.get_position(entity)
-pos.x = pos.x + 10
-
--- Check whether a component exists before touching it
-if registry.has_health(entity) then
-    local hp = registry.get_health(entity)
-    hp.current_health = hp.current_health - 1
-end
-```
-
-The pattern is `registry.get_<key>` / `registry.has_<key>`. Component keys are
-listed in [`docs/ecs-components.md`](ecs-components.md).
-
-**Convenience helpers**
-
-```lua
-local pos = get_position(entity)      -- returns {x, y}
-set_position(entity, new_x, new_y)
-local name = get_name(entity)
-set_name(entity, "New Name")
-blam(entity)                          -- destroy an entity
-```
-
-For the full Lua scripting guide see [`docs/lua-scripting.md`](lua-scripting.md).
+See [`docs/lua-scripting.md`](lua-scripting.md) for the full scripting guide:
+update loop, `registry.get_*` / `registry.has_*`, all global helpers, input
+binding, and ImGui debug UI.
 
 ---
 
-## 7. Input
-
-The `input` table is available globally. Bind named actions to keys once
-(typically in `game.lua`), then query them anywhere.
-
-### Binding actions
-
-```lua
-input.bind("move_up",    "up")
-input.bind("move_up",    "w")       -- multiple keys per action
-input.bind("move_down",  "down")
-input.bind("move_down",  "s")
-input.bind("move_left",  "left")
-input.bind("move_left",  "a")
-input.bind("move_right", "right")
-input.bind("move_right", "d")
-input.bind("fire",       "space")
-```
-
-### Querying actions and keys
-
-```lua
--- Action queries (works with any key bound to the action)
-input.is_action_down("fire")        -- held this frame
-input.is_action_pressed("fire")     -- just went down this frame
-input.is_action_released("fire")    -- just came up this frame
-
--- Raw key queries
-input.is_key_down("escape")
-input.is_key_pressed("f5")
-
--- Mouse
-local pos = input.mouse_position()     -- returns {x, y}
-input.is_mouse_down(1)                 -- 1 = left, 2 = right, 3 = middle
-input.is_mouse_pressed(1)
-```
-
-### Example: 8-way movement
-
-```lua
-local function update(self, entity, dt)
-    local dx, dy = 0, 0
-    if input.is_action_down("move_up")    then dy = dy - 1 end
-    if input.is_action_down("move_down")  then dy = dy + 1 end
-    if input.is_action_down("move_left")  then dx = dx - 1 end
-    if input.is_action_down("move_right") then dx = dx + 1 end
-
-    if dx ~= 0 or dy ~= 0 then
-        local len = math.sqrt(dx * dx + dy * dy)
-        local rb  = registry.get_rigidbody(entity)
-        rb.velocity.x = (dx / len) * self.speed
-        rb.velocity.y = (dy / len) * self.speed
-    else
-        local rb = registry.get_rigidbody(entity)
-        rb.velocity.x = 0
-        rb.velocity.y = 0
-    end
-end
-```
-
 ---
 
-## 8. Scenes
+## 7. Scenes
 
 `load_scene(path)` replaces the current scene. Scene transitions are
 synchronous — `load_scene` does not return to the caller.
@@ -353,7 +242,7 @@ preload flow.
 
 ---
 
-## 9. Assets
+## 8. Assets
 
 Assets must be loaded before any entity references them. The recommended
 approach is `acquire_scene_assets` — it accepts `preload` lists and scans
@@ -384,7 +273,7 @@ packing, audio normalisation, and the full bake/manifest workflow.
 
 ---
 
-## 10. Audio
+## 9. Audio
 
 ```lua
 play_sound("jump-sfx")          -- one-shot
@@ -407,7 +296,7 @@ audio_source = {
 
 ---
 
-## 11. Camera
+## 10. Camera
 
 The camera follows whichever entity carries a `camera_follow` component. Only
 one should be active at a time.
@@ -427,50 +316,7 @@ elements.
 
 ---
 
-## 12. Debug UI with ImGui
-
-The engine ships full [Dear ImGui](https://github.com/ocornut/imgui) bindings.
-Use them inside `on_debug_gui` callbacks — they only fire when the editor's
-debug UI is visible, so release builds pay nothing.
-
-```lua
-local spawn_x = 100
-local spawn_y = 100
-
-load_entity({
-    components = {
-        script = {
-            on_debug_gui = function(self, entity)
-                if ImGui.Begin("Spawn Tool") then
-                    spawn_x = ImGui.InputInt("X", spawn_x)
-                    spawn_y = ImGui.InputInt("Y", spawn_y)
-
-                    if ImGui.Button("Spawn Enemy") then
-                        load_entity({
-                            components = {
-                                transform = { position = { x = spawn_x, y = spawn_y } },
-                                sprite    = { texture_asset_id = "enemy", width = 32, height = 32, layer = 2 },
-                                health    = { max_health = 50 },
-                            }
-                        })
-                    end
-                end
-                ImGui.End()
-            end,
-        }
-    }
-})
-```
-
-The full ImGui API is documented in the
-[Dear ImGui wiki](https://github.com/ocornut/imgui/wiki) and the engine's
-generated Lua stub at
-[`lua_api.smoke.lua`](https://github.com/mblackman/Octarine-Engine/blob/main/lua_api.smoke.lua)
-(search for `ImGui.`).
-
----
-
-## 13. Using the Editor
+## 11. Using the Editor
 
 Launch an editor build against your project:
 
@@ -484,7 +330,7 @@ reference and keyboard shortcuts.
 
 ---
 
-## 14. Further Reading
+## 12. Further Reading
 
 ### Engine documentation
 


### PR DESCRIPTION
## Summary

- Adds `docs/making-games.md` — a practical guide aimed at game developers using Octarine Engine to build games (distinct from the existing `QUICKSTART.md` which targets engine contributors)
- Covers project structure, `config.ini`, all components, Lua scripting patterns, input, scenes (declarative + procedural), asset loading, audio, camera, ImGui debug UI, and the editor
- Cross-links to every existing topic doc, the generated `lua_api.smoke.lua` stub, the example project, the Lua 5.4 manual, and the Dear ImGui wiki for deeper reference

## Test plan

- [ ] Read through for accuracy against the current Lua API surface (`lua_api.smoke.lua`) and component list (`components.json`)
- [ ] Verify all internal doc links (`ecs-components.md`, `lua-scripting.md`, `scenes.md`, etc.) resolve correctly
- [ ] Confirm the GitHub URL for `lua_api.smoke.lua` is accessible on main