### PR TITLE
Add explicit system execution ordering via After/Before edges

### DIFF
--- a/src/ECS/Registry.cpp
+++ b/src/ECS/Registry.cpp
@@ -1,6 +1,8 @@
 #include "Registry.h"
 
 #include <algorithm>
+#include <set>
+#include <stdexcept>
 
 #include "CommandBuffer.h"
 #include "General/Logger.h"
@@ -8,15 +10,69 @@
 #include "Query.h"
 #include "Systems/EntityPoolSystem.h"
 
+void Registry::AddOrderEdge(const SystemId before, const SystemId after) {
+  if (before >= systems_.size() || after >= systems_.size() || before == after) {
+    Logger::Error("Registry::Order: invalid system ordering edge (" + std::to_string(before) + " -> " +
+                  std::to_string(after) + ")");
+    return;
+  }
+  system_order_edges_.emplace_back(before, after);
+  system_order_dirty_ = true;
+}
+
+void Registry::RebuildExecutionOrder() {
+  const size_t count = systems_.size();
+  std::vector<std::vector<SystemId>> adjacency(count);
+  std::vector<size_t> indegree(count, 0);
+  for (const auto& [before, after] : system_order_edges_) {
+    adjacency[before].push_back(after);
+    ++indegree[after];
+  }
+
+  // Kahn's algorithm. The ready set is ordered ascending by SystemId, so the lowest-registered
+  // ready system always runs next — unconstrained systems keep exact registration order.
+  std::set<SystemId> ready;
+  for (SystemId i = 0; i < count; ++i) {
+    if (indegree[i] == 0) ready.insert(i);
+  }
+
+  system_execution_order_.clear();
+  system_execution_order_.reserve(count);
+  while (!ready.empty()) {
+    const SystemId id = *ready.begin();
+    ready.erase(ready.begin());
+    system_execution_order_.push_back(id);
+    for (const SystemId next : adjacency[id]) {
+      if (--indegree[next] == 0) ready.insert(next);
+    }
+  }
+
+  if (system_execution_order_.size() != count) {
+    std::string names;
+    for (SystemId i = 0; i < count; ++i) {
+      if (indegree[i] > 0) {
+        if (!names.empty()) names += ", ";
+        names += systems_[i]->GetName();
+      }
+    }
+    Logger::Error("Registry: system ordering constraints form a cycle between: " + names);
+    throw std::runtime_error("Registry: system ordering cycle between: " + names);
+  }
+  system_order_dirty_ = false;
+}
+
 void Registry::Update(const float deltaTime) {
   PROFILE_NAMED_SCOPE("Registry::Update (total)");
   delta_time_ = deltaTime;
-  for (size_t i = 0; i < systems_.size(); ++i) {
+  if (system_order_dirty_ || system_execution_order_.size() != systems_.size()) {
+    RebuildExecutionOrder();
+  }
+  for (const SystemId id : system_execution_order_) {
 #ifdef OCTARINE_PROFILING
-    ACCUMULATE_PROFILE_SCOPE(systems_[i]->GetName());
-    PROFILE_NAMED_SCOPE(systems_[i]->GetName());
+    ACCUMULATE_PROFILE_SCOPE(systems_[id]->GetName());
+    PROFILE_NAMED_SCOPE(systems_[id]->GetName());
 #endif
-    systems_[i]->Update(*this);
+    systems_[id]->Update(*this);
   }
   if (!pending_blams_.empty() || !pending_despawns_.empty()) {
     PROFILE_NAMED_SCOPE("Registry::Update (pending blam/despawn)");

--- a/src/ECS/Registry.cpp
+++ b/src/ECS/Registry.cpp
@@ -10,6 +10,22 @@
 #include "Query.h"
 #include "Systems/EntityPoolSystem.h"
 
+namespace {
+// Names of the systems still blocked (indegree > 0) when Kahn's algorithm stalls — i.e. the
+// members of the constraint cycle, for the error message.
+std::string CollectBlockedSystemNames(const std::vector<std::unique_ptr<ISystem>>& systems,
+                                      const std::vector<size_t>& indegree) {
+  std::string names;
+  for (size_t i = 0; i < systems.size(); ++i) {
+    if (indegree[i] > 0) {
+      if (!names.empty()) names += ", ";
+      names += systems[i]->GetName();
+    }
+  }
+  return names;
+}
+}  // namespace
+
 void Registry::AddOrderEdge(const SystemId before, const SystemId after) {
   if (before >= systems_.size() || after >= systems_.size() || before == after) {
     Logger::Error("Registry::Order: invalid system ordering edge (" + std::to_string(before) + " -> " +
@@ -48,13 +64,7 @@ void Registry::RebuildExecutionOrder() {
   }
 
   if (system_execution_order_.size() != count) {
-    std::string names;
-    for (SystemId i = 0; i < count; ++i) {
-      if (indegree[i] > 0) {
-        if (!names.empty()) names += ", ";
-        names += systems_[i]->GetName();
-      }
-    }
+    const std::string names = CollectBlockedSystemNames(systems_, indegree);
     Logger::Error("Registry: system ordering constraints form a cycle between: " + names);
     throw std::runtime_error("Registry: system ordering cycle between: " + names);
   }
@@ -74,31 +84,36 @@ void Registry::Update(const float deltaTime) {
 #endif
     systems_[id]->Update(*this);
   }
-  if (!pending_blams_.empty() || !pending_despawns_.empty()) {
-    PROFILE_NAMED_SCOPE("Registry::Update (pending blam/despawn)");
-    auto pending = std::move(pending_blams_);
-    auto despawns = std::move(pending_despawns_);
-    pending_blams_.clear();
-    pending_blam_ids_.clear();
-    pending_despawns_.clear();
-    pending_despawn_ids_.clear();
+  FlushPendingDestruction();
+}
 
-    for (const Entity entity : pending) {
-      BlamEntity(entity);
-    }
+void Registry::FlushPendingDestruction() {
+  if (pending_blams_.empty() && pending_despawns_.empty()) {
+    return;
+  }
+  PROFILE_NAMED_SCOPE("Registry::Update (pending blam/despawn)");
+  auto pending = std::move(pending_blams_);
+  auto despawns = std::move(pending_despawns_);
+  pending_blams_.clear();
+  pending_blam_ids_.clear();
+  pending_despawns_.clear();
+  pending_despawn_ids_.clear();
 
-    // PoolableTag-bearing entities are routed straight into the pool's free list — Deactivate
-    // collapses them into the chunk's inactive tail without crossing archetypes. Non-pooled
-    // entities are blammed outright.
-    if (!despawns.empty()) {
-      auto* pool = TryGet<EntityPoolManager>();
-      for (const Entity entity : despawns) {
-        if (!IsAlive(entity)) continue;
-        if (pool && HasTag<PoolableTag>(entity)) {
-          pool->Park(*this, entity);
-        } else {
-          BlamEntity(entity);
-        }
+  for (const Entity entity : pending) {
+    BlamEntity(entity);
+  }
+
+  // PoolableTag-bearing entities are routed straight into the pool's free list — Deactivate
+  // collapses them into the chunk's inactive tail without crossing archetypes. Non-pooled
+  // entities are blammed outright.
+  if (!despawns.empty()) {
+    auto* pool = TryGet<EntityPoolManager>();
+    for (const Entity entity : despawns) {
+      if (!IsAlive(entity)) continue;
+      if (pool && HasTag<PoolableTag>(entity)) {
+        pool->Park(*this, entity);
+      } else {
+        BlamEntity(entity);
       }
     }
   }

--- a/src/ECS/Registry.h
+++ b/src/ECS/Registry.h
@@ -331,6 +331,9 @@ class Registry {
   // responsible for thread-safety: expose an EntityCommandBuffer on your system to handle requests for registry state
   // changes so they resolve on the calling thread all at once.
   template <typename... TArgs, typename Func>
+  // Complexity is pre-existing: the wrapper's if-constexpr dispatch over the four supported
+  // callback shapes reads linearly; splitting it would obscure the signature table.
+  // NOLINTNEXTLINE(readability-function-cognitive-complexity)
   SystemHandle<std::decay_t<Func>> RegisterParallelSystem(Func&& func) {
     using StoredFunc = std::decay_t<Func>;
     static_assert(std::is_invocable_v<StoredFunc, Entity, float, TArgs&...> ||
@@ -650,6 +653,9 @@ class Registry {
   // execute in registration order.
   void AddOrderEdge(SystemId before, SystemId after);
   void RebuildExecutionOrder();
+
+  // Deferred blam/despawn processing at the end of Update, once all systems have run.
+  void FlushPendingDestruction();
 
   // Helper for CreateEntityWithBundle: index-pack expansion to dispatch each component to
   // Archetype::AddComponent at its corresponding location slot.

--- a/src/ECS/Registry.h
+++ b/src/ECS/Registry.h
@@ -289,7 +289,7 @@ class Registry {
 
   // System Management
   template <typename... TArgs, typename Func>
-  std::decay_t<Func>& RegisterSystem(Func&& func) {
+  SystemHandle<std::decay_t<Func>> RegisterSystem(Func&& func) {
     using StoredFunc = std::decay_t<Func>;
     class SystemWrapper final : public ISystem {
      public:
@@ -319,8 +319,9 @@ class Registry {
 
     auto wrapper = std::make_unique<SystemWrapper>(this, std::forward<Func>(func));
     StoredFunc& ref = wrapper->GetFunc();
+    const SystemId id = systems_.size();
     systems_.push_back(std::move(wrapper));
-    return ref;
+    return SystemHandle<StoredFunc>(id, &ref);
   }
 
   // Parallel per-entity system. Same shape as RegisterSystem but the per-entity callback runs
@@ -330,7 +331,7 @@ class Registry {
   // responsible for thread-safety: expose an EntityCommandBuffer on your system to handle requests for registry state
   // changes so they resolve on the calling thread all at once.
   template <typename... TArgs, typename Func>
-  std::decay_t<Func>& RegisterParallelSystem(Func&& func) {
+  SystemHandle<std::decay_t<Func>> RegisterParallelSystem(Func&& func) {
     using StoredFunc = std::decay_t<Func>;
     static_assert(std::is_invocable_v<StoredFunc, Entity, float, TArgs&...> ||
                       std::is_invocable_v<StoredFunc, Entity, TArgs&...> ||
@@ -404,8 +405,9 @@ class Registry {
 
     auto wrapper = std::make_unique<ParallelSystemWrapper>(this, std::forward<Func>(func));
     StoredFunc& ref = wrapper->GetFunc();
+    const SystemId id = systems_.size();
     systems_.push_back(std::move(wrapper));
-    return ref;
+    return SystemHandle<StoredFunc>(id, &ref);
   }
 
   // Bulk system: wrapper invokes Func once per Update with the matching Iterable.
@@ -413,7 +415,7 @@ class Registry {
   // exposes Registry/DeltaTime and a sentinel Entity (Entity{}); per-entity component
   // access goes through iterating the Iterable.
   template <typename... TArgs, typename Func>
-  std::decay_t<Func>& RegisterBulkSystem(Func&& func) {
+  SystemHandle<std::decay_t<Func>> RegisterBulkSystem(Func&& func) {
     using StoredFunc = std::decay_t<Func>;
     class BulkSystemWrapper final : public ISystem {
      public:
@@ -442,8 +444,41 @@ class Registry {
 
     auto wrapper = std::make_unique<BulkSystemWrapper>(this, std::forward<Func>(func));
     StoredFunc& ref = wrapper->GetFunc();
+    const SystemId id = systems_.size();
     systems_.push_back(std::move(wrapper));
-    return ref;
+    return SystemHandle<StoredFunc>(id, &ref);
+  }
+
+  // Execution-order constraints between registered systems, declared after registration:
+  //   registry.Order(collision).After(transform);
+  //   registry.Order(producer).Before(consumer);
+  // Update topo-sorts (Kahn's algorithm) with registration order breaking ties, so systems
+  // without constraints keep exact registration order. A constraint cycle throws
+  // std::runtime_error naming the systems involved.
+  class OrderBuilder {
+   public:
+    OrderBuilder(Registry* registry, const SystemId id) : registry_(registry), id_(id) {}
+
+    template <typename T>
+    OrderBuilder& After(const SystemHandle<T>& other) {
+      registry_->AddOrderEdge(other.Id(), id_);
+      return *this;
+    }
+
+    template <typename T>
+    OrderBuilder& Before(const SystemHandle<T>& other) {
+      registry_->AddOrderEdge(id_, other.Id());
+      return *this;
+    }
+
+   private:
+    Registry* registry_;
+    SystemId id_;
+  };
+
+  template <typename T>
+  OrderBuilder Order(const SystemHandle<T>& handle) {
+    return OrderBuilder(this, handle.Id());
   }
 
   // Singleton components. Stored as std::shared_ptr<T> inside std::any so that
@@ -610,6 +645,12 @@ class Registry {
   Archetype* GetOrCreateArchetypeRemove(std::vector<ComponentID> componentIDs, ComponentID removeComponentId);
   Archetype* GetOrCreateArchetypeFromSet(std::vector<ComponentID> componentIDs);
 
+  // System-ordering graph (fed by Order().After()/.Before()). RebuildExecutionOrder runs Kahn's
+  // algorithm over the edges; the ready set is kept ordered by SystemId so unconstrained systems
+  // execute in registration order.
+  void AddOrderEdge(SystemId before, SystemId after);
+  void RebuildExecutionOrder();
+
   // Helper for CreateEntityWithBundle: index-pack expansion to dispatch each component to
   // Archetype::AddComponent at its corresponding location slot.
   template <typename Tuple, size_t N, size_t... Is>
@@ -624,6 +665,10 @@ class Registry {
   std::unordered_map<ArchetypeID, std::unique_ptr<Archetype>> archetypes_;
   std::unique_ptr<Archetype> root_archetype_;  // The root of the archetype graph. Empty signature.
   std::vector<std::unique_ptr<ISystem>> systems_;
+  // Ordering edges (before, after) between systems_ indices; consumed by RebuildExecutionOrder.
+  std::vector<std::pair<SystemId, SystemId>> system_order_edges_;
+  std::vector<SystemId> system_execution_order_;
+  bool system_order_dirty_ = false;
   // Singleton storage keyed by typeid(T).name() (string_view into static storage). Was
   // ComponentID-keyed via Component<T>(), but on Android NDK with -fvisibility=hidden, opaque-type
   // pointers like MIX_Mixer* get TU-local typeinfo; std::type_index in type_to_entity_ produces

--- a/src/ECS/System.h
+++ b/src/ECS/System.h
@@ -1,10 +1,31 @@
 #pragma once
 
+#include <cstddef>
 #include <string>
 #include <string_view>
 #include <utility>
 
 class Registry;
+
+// Stable identity of a registered system — its index into Registry::systems_. Systems are never
+// removed, so the id stays valid for the registry's lifetime.
+using SystemId = std::size_t;
+
+// Returned by Registry::Register*System. Carries the SystemId that Registry::Order uses to
+// declare execution-order constraints, plus access to the stored functor for the existing
+// wire-up pattern (handle.Func().SubscribeToEvents(bus)).
+template <typename StoredFunc>
+class SystemHandle {
+ public:
+  SystemHandle(const SystemId id, StoredFunc* func) : id_(id), func_(func) {}
+
+  [[nodiscard]] SystemId Id() const { return id_; }
+  [[nodiscard]] StoredFunc& Func() const { return *func_; }
+
+ private:
+  SystemId id_;
+  StoredFunc* func_;
+};
 
 class ISystem {
  public:

--- a/src/Game/Game.cpp
+++ b/src/Game/Game.cpp
@@ -478,7 +478,7 @@ void Game::Setup() {
 
   // ScriptSystem is registered as a per-frame system (vs. Bake's stack instance) so its
   // operator() runs each tick. CreateLuaBindings still happens below in the bootstrap spine.
-  auto& scriptSystem = registry_->RegisterSystem<ScriptComponent>(ScriptSystem());
+  auto scriptSystem = registry_->RegisterSystem<ScriptComponent>(ScriptSystem());
 
   auto& inputSystem = engine_bootstrap::InstallInputSystem(*registry_, event_bus_);
   engine_bootstrap::RegisterAllComponentBindings();
@@ -489,7 +489,7 @@ void Game::Setup() {
   // engine adds. Cheap; the actual dump only fires when OCTARINE_DUMP_LUA_API is set.
   const auto preBindingGlobals = LuaApiManifest::SnapshotGlobals(lua);
   engine_bootstrap::InstallPoolAndProjectile(*registry_);
-  scriptSystem.CreateLuaBindings(lua);
+  scriptSystem.Func().CreateLuaBindings(lua);
   engine_bootstrap::InstallLuaModules(lua, *this);
   LuaSystemRegistry::bindAll(lua);
   engine_bootstrap::SetCommonLuaGlobals(lua, gameConfig, startup_mode_);
@@ -554,13 +554,13 @@ void Game::Setup() {
   // entries, which need the mixer. RegisterSystem owns the single AudioSystem instance — Init
   // runs against that instance so the EventBus subscription, cmd buffer, and per-frame Update
   // all share state.
-  auto& audioSystem = registry_->RegisterSystem<AudioSourceComponent>(AudioSystem());
-  if (!audioSystem.Init(registry_.get(), event_bus_)) {
+  auto audioSystem = registry_->RegisterSystem<AudioSourceComponent>(AudioSystem());
+  if (!audioSystem.Func().Init(registry_.get(), event_bus_)) {
     Logger::Error("AudioSystem failed to initialize; audio disabled this session.");
   }
   // Mixer is owned by AudioSystem; publish it on the context so asset loads + the master-
   // volume sync (in Game::Update) can reach it without going through the Registry's typed slot.
-  registry_->Get<EngineContext>().mixer = audioSystem.Mixer();
+  registry_->Get<EngineContext>().mixer = audioSystem.Func().Mixer();
 
   if (gameConfig.HasLoadedConfig()) {
     LoadGame(lua, assetManager, gameConfig);
@@ -577,50 +577,68 @@ void Game::Setup() {
   //
   // Serial (RegisterSystem, not parallel): the tick spawns into the registry. It is registered
   // here, after InstallPoolAndProjectile Set + Init'd the canonical ProjectileEmitSystem, so the
-  // copy stored by the system list carries the initialized pool id. Placed before
-  // VelocityIntegrationSystem so freshly-spawned projectiles integrate/transform/collide this same
-  // frame — matching the spawn-timing the old ScriptSystem-driven Lua path had.
-  registry_->RegisterSystem<ProjectileEmitterComponent, PositionComponent>(registry_->Get<ProjectileEmitSystem>());
+  // copy stored by the system list carries the initialized pool id.
+  auto projectileEmit =
+      registry_->RegisterSystem<ProjectileEmitterComponent, PositionComponent>(registry_->Get<ProjectileEmitSystem>());
 
-  // Integrate velocity into local position. Must run before TransformSystem so the hierarchy
-  // resolves with the latest positions, and before CollisionSystem reads the global transforms.
-  registry_->RegisterParallelSystem<PositionComponent, RigidBodyComponent>(VelocityIntegrationSystem());
+  // Integrate velocity into local position.
+  auto velocityIntegration =
+      registry_->RegisterParallelSystem<PositionComponent, RigidBodyComponent>(VelocityIntegrationSystem());
 
   // Despawn entities (except the player) once they leave the playable area.
   registry_->RegisterParallelSystem<PositionComponent, SpriteComponent>(OffScreenDespawnSystem());
 
-  // Resolve hierarchy after Movement mutates local positions, before Collision reads globals.
-  registry_->RegisterBulkSystem<GlobalTransformComponent>(TransformSystem());
+  // Resolve the transform hierarchy into global positions/scales.
+  auto transform = registry_->RegisterBulkSystem<GlobalTransformComponent>(TransformSystem());
 
-  // Collision reads transform.globalPosition / globalScale — must run after TransformSystem.
-  registry_->RegisterBulkSystem(CollisionSystem());
+  auto collision = registry_->RegisterBulkSystem(CollisionSystem());
 
   // Spatial audio: snapshot the listener entity (UpdateListenerTransformSystem) then mutate
-  // gain + stereo pan on live spatial tracks (SpatialAudioSystem). Both must run AFTER
-  // TransformSystem so emitter + listener globals are this-frame values; AudioSystem (above)
-  // is the one that adds the AudioSinkComponent and caches its MIX_Track in AudioTrackCache,
-  // which these resolve per entity.
+  // gain + stereo pan on live spatial tracks (SpatialAudioSystem). AudioSystem (above) is the
+  // one that adds the AudioSinkComponent and caches its MIX_Track in AudioTrackCache, which
+  // these resolve per entity.
   registry_->Set<AudioListenerCache>(AudioListenerCache{});
-  registry_->RegisterBulkSystem<GlobalTransformComponent>(UpdateListenerTransformSystem());
+  auto listenerTransform = registry_->RegisterBulkSystem<GlobalTransformComponent>(UpdateListenerTransformSystem());
   // Phase 5 culling: pre-register the AudioActiveTag so its component entity exists
   // before any HasTag query fires (Tag<T>() is lazy otherwise). CullingSystem then gates
   // SpatialAudioSystem / DopplerSystem implicitly — culled emitters lose their sink, and
   // both downstream systems short-circuit on the missing sink.
   registry_->Tag<AudioActiveTag>();
-  registry_->RegisterSystem<GlobalTransformComponent, AudioSourceComponent>(AudioCullingSystem());
-  registry_->RegisterSystem<GlobalTransformComponent, AudioSourceComponent, AudioSinkComponent>(SpatialAudioSystem());
+  auto audioCulling = registry_->RegisterSystem<GlobalTransformComponent, AudioSourceComponent>(AudioCullingSystem());
+  auto spatialAudio = registry_->RegisterSystem<GlobalTransformComponent, AudioSourceComponent, AudioSinkComponent>(
+      SpatialAudioSystem());
   // Doppler is independent of spatial: governs frequency ratio via MIX_SetTrackFrequencyRatio.
   // Requires RigidBodyComponent on the emitter (no body → no velocity → no shift).
-  registry_->RegisterSystem<GlobalTransformComponent, RigidBodyComponent, AudioSourceComponent, AudioSinkComponent>(
-      DopplerSystem());
+  auto doppler =
+      registry_->RegisterSystem<GlobalTransformComponent, RigidBodyComponent, AudioSourceComponent, AudioSinkComponent>(
+          DopplerSystem());
 
-  // Camera follows after gameplay-driven transform updates
-  registry_->RegisterSystem<PositionComponent, CameraFollowComponent>(CameraFollowSystem());
+  auto cameraFollow = registry_->RegisterSystem<PositionComponent, CameraFollowComponent>(CameraFollowSystem());
 
   // Render queue producers
   registry_->RegisterParallelSystem<GlobalTransformComponent, SpriteComponent>(RenderSpriteSystem());
   registry_->RegisterSystem<TextLabelComponent>(RenderTextSystem());
   registry_->RegisterParallelSystem<SquarePrimitiveComponent, GlobalTransformComponent>(RenderPrimitiveSystem());
+
+  // Execution-order edges (topo-sorted in Registry::Update; registration order breaks ties).
+  // Emit before integration so freshly-spawned projectiles integrate/transform/collide the same
+  // frame — matching the spawn-timing the old ScriptSystem-driven Lua path had.
+  registry_->Order(velocityIntegration).After(projectileEmit);
+  // Transforms resolve after velocity integration mutates local positions; collision reads
+  // transform.globalPosition / globalScale, so it runs after both.
+  registry_->Order(transform).After(velocityIntegration);
+  registry_->Order(collision).After(transform).After(velocityIntegration);
+  // Listener snapshot + spatial gain/pan need this-frame globals; spatial reads the listener
+  // snapshot and is gated by culling (culled emitters lose their sink); both resolve tracks the
+  // AudioSystem update cached.
+  registry_->Order(listenerTransform).After(transform);
+  registry_->Order(audioCulling).After(audioSystem);
+  registry_->Order(spatialAudio).After(transform).After(listenerTransform).After(audioCulling).After(audioSystem);
+  // Doppler needs this-frame emitter globals + listener snapshot, and sits behind the same
+  // culling gate and AudioSystem-cached tracks as spatial.
+  registry_->Order(doppler).After(transform).After(listenerTransform).After(audioCulling).After(audioSystem);
+  // Camera follows after gameplay-driven transform updates.
+  registry_->Order(cameraFollow).After(transform);
 
   // Event subscriptions (one-time). FrameLoop holds its own RAII subscription handle.
   frame_loop_->SubscribeToEvents();

--- a/tests/EcsRegistryTest.cpp
+++ b/tests/EcsRegistryTest.cpp
@@ -6,6 +6,10 @@
 // benchmark target. Uses local POD component structs (same approach as EntityPoolBenchmark.cpp)
 // so the test is independent of the real Components/ headers.
 
+#include <stdexcept>
+#include <string>
+#include <vector>
+
 #include "ECS/Query.h"  // full ComponentQuery definition for CreateQuery / ForEach
 #include "ECS/Registry.h"
 #include "TestHarness.h"
@@ -174,6 +178,62 @@ int main() {
     const Entity b = registry.CreateEntity();
     registry.AddComponent(b, Position{0.0f, 0.0f});  // same shape — no new archetype
     Check(registry.ArchetypeGeneration() == gen1, "ArchetypeGeneration stable for a repeated shape");
+  }
+
+  // System ordering: unconstrained registration order, After edges, lazy re-sort.
+  {
+    Registry registry;
+    const Entity e = registry.CreateEntity();
+    registry.AddComponent(e, Position{0.0f, 0.0f});
+
+    std::string order;
+    auto a = registry.RegisterSystem<Position>([&order](Position&) { order += 'a'; });
+    auto b = registry.RegisterSystem<Position>([&order](Position&) { order += 'b'; });
+    auto c = registry.RegisterSystem<Position>([&order](Position&) { order += 'c'; });
+
+    registry.Update(1.0f / 60.0f);
+    octarine::test::CheckEq(order, "abc", "unconstrained systems run in registration order");
+
+    // Edge added after the first Update must trigger a re-sort: a now runs after c, while the
+    // unconstrained b keeps its registration position via the SystemId tiebreak.
+    order.clear();
+    registry.Order(a).After(c);
+    registry.Update(1.0f / 60.0f);
+    octarine::test::CheckEq(order, "bca", "After edge respected; tiebreak keeps registration order");
+    (void)b;
+  }
+
+  // System ordering: Before edge flips an order that registration alone would produce.
+  {
+    Registry registry;
+    const Entity e = registry.CreateEntity();
+    registry.AddComponent(e, Position{0.0f, 0.0f});
+
+    std::string order;
+    auto first = registry.RegisterSystem<Position>([&order](Position&) { order += '1'; });
+    auto second = registry.RegisterSystem<Position>([&order](Position&) { order += '2'; });
+    registry.Order(second).Before(first);
+    registry.Update(1.0f / 60.0f);
+    octarine::test::CheckEq(order, "21", "Before edge respected regardless of registration order");
+  }
+
+  // System ordering: a constraint cycle throws on Update instead of running a bogus order.
+  {
+    Registry registry;
+    const Entity e = registry.CreateEntity();
+    registry.AddComponent(e, Position{0.0f, 0.0f});
+
+    auto a = registry.RegisterSystem<Position>([](Position&) {});
+    auto b = registry.RegisterSystem<Position>([](Position&) {});
+    registry.Order(a).After(b);
+    registry.Order(b).After(a);
+    bool threw = false;
+    try {
+      registry.Update(1.0f / 60.0f);
+    } catch (const std::runtime_error&) {
+      threw = true;
+    }
+    Check(threw, "ordering cycle detected and thrown on Update");
   }
 
   return octarine::test::Result();


### PR DESCRIPTION
## Summary
- `Registry::Register*System` (serial / parallel / bulk) now returns a `SystemHandle<StoredFunc>` carrying a stable `SystemId` plus `Func()` access for the existing wire-up pattern.
- New `registry.Order(handle).After(other)` / `.Before(other)` constraint builder; `Registry::Update` topo-sorts with Kahn's algorithm, registration order breaking ties — unconstrained systems keep exactly the previous execution order.
- Constraint cycles throw `std::runtime_error` naming the systems in the cycle.
- `Game::Setup` ordering comments converted into explicit edges (emit→integrate→transform→collision, audio listener/culling/spatial/doppler, camera follow).
- `EcsRegistryTest`: edge respected regardless of registration order, tiebreak preserves registration order, lazy re-sort when edges are added after the first Update, cycle detection.

## Verification
- editor-debug build + full ctest (17/17) green on Windows.
- Engine ran headless against Octarine-Engine-Example for 120 frames: exit 0, no Lua errors, no ordering cycle.