### PR TITLE
Add sanitizer builds: per-PR ASan+UBSan job and nightly TSan workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -190,6 +190,47 @@ jobs:
           path: build/${{ matrix.preset }}/bin/release
           if-no-files-found: error
 
+  # ASan+UBSan over the full unit-test suite. Catches the memory-bug class (chunk over-alignment,
+  # archetype-move use-after-free) that plain builds only surface as crashes, plus UB like
+  # misaligned loads and signed overflow. Debug preset so asserts stay live. The TSan counterpart
+  # (ThreadPool/parallel-system races ASan cannot see) is nightly-only in sanitize-tsan.yml —
+  # the two sanitizers cannot be combined in one binary.
+  sanitize:
+    name: linux (asan+ubsan, editor-debug)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Export GitHub Actions cache env (vcpkg binary cache)
+        uses: ./.github/actions/vcpkg-cache-env
+
+      - name: Install Linux build deps (SDL3 / X11 / Wayland)
+        uses: ./.github/actions/linux-build-deps
+
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: linux-editor-debug-asan
+          max-size: 500M
+
+      - name: Configure CMake
+        run: cmake --preset editor-debug -DOCTARINE_SANITIZE=asan -DOCTARINE_ENABLE_TESTS=ON
+
+      - name: Build
+        run: cmake --build build/editor-debug --parallel
+
+      - name: Run engine tests (ctest under ASan+UBSan)
+        env:
+          # halt_on_error makes the first finding fail the test instead of logging past it.
+          # Leak checking stays off for now: exit-time leaks in non-instrumented third-party
+          # libs (SDL/Lua via vcpkg) would drown real findings — revisit once a baseline exists.
+          ASAN_OPTIONS: halt_on_error=1:detect_leaks=0
+          UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
+        run: ctest --test-dir build/editor-debug --output-on-failure
+
   # Style gate. Lightweight (no vcpkg/SDL): formats only the files a PR actually changed, so the
   # large pre-existing tree never blocks on legacy style. Auto-fixable via the CMake `format` target.
   # clang-tidy runs as a blocking changed-lines gate in the editor-release build leg above, which

--- a/.github/workflows/sanitize-tsan.yml
+++ b/.github/workflows/sanitize-tsan.yml
@@ -1,0 +1,48 @@
+name: Sanitize (TSan)
+
+# ThreadSanitizer leg of the sanitizer coverage. Targets the ThreadPool parallel paths
+# (parallel collision response, RegisterParallelSystem chunk fan-out) whose data races ASan
+# cannot see. TSan and ASan cannot be combined in one binary, and TSan's slowdown is too large
+# for every PR, so this runs nightly + on dispatch — same gating rationale as android-emulator.yml.
+# The per-PR ASan+UBSan job lives in build.yml.
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 5 * * *'   # 05:00 UTC nightly
+
+env:
+  VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+
+jobs:
+  tsan:
+    name: linux (tsan, editor-debug)
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Export GitHub Actions cache env (vcpkg binary cache)
+        uses: ./.github/actions/vcpkg-cache-env
+
+      - name: Install Linux build deps (SDL3 / X11 / Wayland)
+        uses: ./.github/actions/linux-build-deps
+
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: linux-editor-debug-tsan
+          max-size: 500M
+
+      - name: Configure CMake
+        run: cmake --preset editor-debug -DOCTARINE_SANITIZE=tsan -DOCTARINE_ENABLE_TESTS=ON
+
+      - name: Build
+        run: cmake --build build/editor-debug --parallel
+
+      - name: Run engine tests (ctest under TSan)
+        env:
+          TSAN_OPTIONS: halt_on_error=1:second_deadlock_stack=1
+        run: ctest --test-dir build/editor-debug --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,29 @@ if (OCTARINE_IPO_SUPPORTED)
     set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_MINSIZEREL ON)
 endif ()
 
+# Sanitizer instrumentation (GCC/Clang only — MSVC's ASan needs different flags and has no UBSan).
+# `asan` layers AddressSanitizer + UBSan (they combine cleanly and share one CI job); `tsan` is a
+# separate value because ThreadSanitizer cannot be combined with ASan. Flags must reach both
+# compile and link lines, and apply to every target (engine, tests) so the interceptors see all
+# allocations.
+set(OCTARINE_SANITIZE "OFF" CACHE STRING "Sanitizer instrumentation: OFF, asan (ASan+UBSan), or tsan")
+set_property(CACHE OCTARINE_SANITIZE PROPERTY STRINGS OFF asan tsan)
+if (NOT OCTARINE_SANITIZE STREQUAL "OFF")
+    if (NOT (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang"))
+        message(FATAL_ERROR "OCTARINE_SANITIZE requires GCC or Clang (got ${CMAKE_CXX_COMPILER_ID})")
+    endif ()
+    if (OCTARINE_SANITIZE STREQUAL "asan")
+        set(OCTARINE_SANITIZE_FLAGS -fsanitize=address,undefined -fno-omit-frame-pointer)
+    elseif (OCTARINE_SANITIZE STREQUAL "tsan")
+        set(OCTARINE_SANITIZE_FLAGS -fsanitize=thread -fno-omit-frame-pointer)
+    else ()
+        message(FATAL_ERROR "OCTARINE_SANITIZE must be OFF, asan, or tsan (got ${OCTARINE_SANITIZE})")
+    endif ()
+    add_compile_options(${OCTARINE_SANITIZE_FLAGS})
+    add_link_options(${OCTARINE_SANITIZE_FLAGS})
+    message(STATUS "Octarine: sanitizers ENABLED (${OCTARINE_SANITIZE})")
+endif ()
+
 # Profiling option — when ON, enables TIMER/ACCUM logging in PerfUtils.h.
 # OFF by default so Debug and Release builds have zero profiling overhead.
 option(OCTARINE_ENABLE_PROFILING "Enable per-system performance instrumentation" OFF)


### PR DESCRIPTION
## Summary
- New `OCTARINE_SANITIZE` CMake cache option (`OFF`/`asan`/`tsan`), GCC/Clang only with a clear FATAL_ERROR on MSVC. `asan` = `-fsanitize=address,undefined -fno-omit-frame-pointer`; `tsan` = `-fsanitize=thread` (the two cannot be combined in one binary). Flags applied globally to compile + link.
- `build.yml`: new ubuntu `sanitize` job — editor-debug preset + `OCTARINE_SANITIZE=asan` + `OCTARINE_ENABLE_TESTS=ON`, full ctest with `halt_on_error`. Leak detection off initially (exit-time leaks in non-instrumented vcpkg libs would drown findings); flip on once a baseline exists.
- `sanitize-tsan.yml`: TSan leg nightly (05:00 UTC) + workflow_dispatch only — the payoff is the ThreadPool parallel paths ASan can't see, and TSan is too slow for every PR. Same gating rationale as android-emulator.yml; kept as its own workflow so the cron doesn't fire the whole build matrix.
- If ASan wall-time proves too high per-PR, the plan's fallback is gating it like android-emulator (push-to-main + nightly + dispatch).

## Verification
- Local configure with the option unset (OFF path) parses clean; the asan/tsan branches are exercised by the new CI jobs themselves on this PR / nightly.