### PR TITLE
Run ctest on Windows and macOS editor-release legs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,13 +80,15 @@ jobs:
 
       - name: Configure CMake
         shell: bash
-        run: cmake --preset ${{ matrix.preset }} ${{ (matrix.platform == 'linux' && matrix.preset == 'editor-release') && '-DOCTARINE_ENABLE_TESTS=ON' || '' }}
+        run: cmake --preset ${{ matrix.preset }} ${{ matrix.preset == 'editor-release' && '-DOCTARINE_ENABLE_TESTS=ON' || '' }}
 
       - name: Build
         run: cmake --build build/${{ matrix.preset }} --config Release --parallel
 
+      # All three OSes, not just linux: MSVC-specific breakage (AVX2 chunk alignment) and
+      # macOS-specific behavior otherwise ship untested.
       - name: Run engine tests (ctest)
-        if: matrix.platform == 'linux' && matrix.preset == 'editor-release'
+        if: matrix.preset == 'editor-release'
         run: ctest --test-dir build/${{ matrix.preset }} --output-on-failure
 
       # Headless bake against the example project. Catches unresolved-asset regressions and


### PR DESCRIPTION
## Summary
- `OCTARINE_ENABLE_TESTS=ON` now set for the editor-release preset on every OS in the build matrix (was linux-only).
- ctest step condition relaxed from `linux && editor-release` to `editor-release` — Windows (vcvars already wired via msvc-dev-cmd) and macOS now run the 17-test suite, catching MSVC-specific breakage like the AVX2 chunk-alignment class before it ships.

## Verification
- CI on this PR runs the new Windows/macOS ctest legs directly.
- Same suite passes locally on Windows (MSVC editor-debug, 17/17) as part of the Stage 1 branch work.