### PR TITLE
Add runtime boot smoke against the example project in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,6 +100,30 @@ jobs:
           ./build/${{ matrix.preset }}/bin/release/OctarineEngine "$GITHUB_WORKSPACE/example_repo" -m bake
           test -s "$GITHUB_WORKSPACE/example_repo/asset_manifest.lua"
 
+      # Runtime boot smoke: actually run the engine against the example project, headless. The
+      # bake smoke above never enters the frame loop, so setup-order bugs, Lua binding
+      # regressions, and asset-load failures ship invisibly past unit tests without this. The
+      # frame-capture env vars bound the run — FrameLoop quits right after writing frame 120
+      # (~2s of simulation). Gates: engine exit code, the capture file existing (proves the
+      # render path produced frames), and zero error/critical log lines (runtime Lua errors
+      # log-and-continue, so the exit code alone can't catch them).
+      - name: Runtime boot smoke (example project)
+        if: matrix.platform == 'linux' && matrix.preset == 'editor-release'
+        shell: bash
+        env:
+          SDL_VIDEODRIVER: dummy
+          SDL_AUDIODRIVER: dummy
+          OCTARINE_CAPTURE_FRAME: "120"
+        run: |
+          export OCTARINE_CAPTURE_PATH="$RUNNER_TEMP/boot-smoke.bmp"
+          log="$RUNNER_TEMP/boot-smoke.log"
+          ./build/${{ matrix.preset }}/bin/release/OctarineEngine "$GITHUB_WORKSPACE/example_repo" | tee "$log"
+          test -s "$OCTARINE_CAPTURE_PATH"
+          if grep -E '\[(error|critical)\]' "$log"; then
+            echo "::error::Runtime boot smoke logged error/critical lines (see log above)."
+            exit 1
+          fi
+
       - name: Check Lua API artifact drift
         id: lua_drift
         if: matrix.platform == 'linux' && matrix.preset == 'editor-release'


### PR DESCRIPTION
## Summary
- New step on the linux editor-release leg: run the built engine headless (`SDL_VIDEODRIVER=dummy`, `SDL_AUDIODRIVER=dummy`) against Octarine-Engine-Example, bounded to 120 frames by the existing frame-capture auto-quit (`OCTARINE_CAPTURE_PATH`/`OCTARINE_CAPTURE_FRAME` from 8fbc07f) — no new engine flag needed.
- Fails on: non-zero engine exit, missing/empty capture file (render path produced no frames), or any `[error]`/`[critical]` spdlog line — runtime Lua errors log-and-continue, so the exit code alone cannot catch them.
- Windows/macOS legs can pick this up later once it proves stable on linux, per the plan.

## Verification
- Ran locally with both dummy drivers + capture bound to frame 120 against the example project: exit 0, capture written, zero error/critical log lines.