### PR TITLE
Return the root entity handle from load_entity

### DIFF
--- a/docs/lua-scripting.md
+++ b/docs/lua-scripting.md
@@ -125,7 +125,7 @@ These globals are shorthand for the most common reads and writes:
 |---|---|
 | `log(message)` | Print to the engine console |
 | `load_asset(table)` | Load a texture, font, or sound |
-| `load_entity(table)` | Spawn a new entity |
+| `load_entity(table)` | Spawn a new entity; returns the root entity handle (or `nil` on an invalid table) |
 | `get_asset_path(path)` | Resolve a project-relative path to an absolute path |
 | `fire_projectile(entity, dx, dy)` | Spawn a projectile from the entity's emitter |
 | `play_sound(asset_id)` | Play a sound or music track |

--- a/src/Lua/LuaEntityLoader.h
+++ b/src/Lua/LuaEntityLoader.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <optional>
 #include <stack>
 
 #include "Components/BoxColliderComponent.h"
@@ -122,13 +123,15 @@ class LuaEntityLoader {
    *
    * @param registry A pointer to the game's entity-component-system registry->
    * @param entityData The top-level sol::table containing the entity definition.
+   * @return The root entity created from the table, or std::nullopt when the table is invalid.
    */
-  static void LoadEntityFromLua(Registry* registry, const sol::table& entityData) {
+  static std::optional<Entity> LoadEntityFromLua(Registry* registry, const sol::table& entityData) {
     if (!entityData.valid()) {
       Logger::Error("LoadEntityFromLua: Invalid root entity data table.");
-      return;
+      return std::nullopt;
     }
 
+    std::optional<Entity> rootEntity;
     std::stack<std::pair<sol::table, std::optional<Entity>>> nodesToProcess;
     nodesToProcess.emplace(entityData, std::nullopt);
 
@@ -140,6 +143,8 @@ class LuaEntityLoader {
       const Entity entity = registry->CreateEntity();
       if (parentEntity) {
         registry->SetParent(entity, *parentEntity);
+      } else {
+        rootEntity = entity;
       }
 
       ApplyName(currentData, registry, entity);
@@ -164,6 +169,8 @@ class LuaEntityLoader {
         }
       }
     }
+
+    return rootEntity;
   }
 
  private:

--- a/src/Lua/Modules/SceneModuleLuaBinding.cpp
+++ b/src/Lua/Modules/SceneModuleLuaBinding.cpp
@@ -33,73 +33,78 @@ void LoadAsset(sol::table assetTable, AssetManager& assetManager, SDL_Renderer* 
     Logger::Error("Unknown asset type: " + assetType);
   }
 }
+
+void LoadAssetFromLua(sol::table assetTable, LuaBindingContext& ctx) {
+  auto* registry = ctx.GetRegistry();
+  auto& assetManager = registry->Get<AssetManager>();
+
+  // Under bake there is no renderer/mixer to upload to, so skip the GPU/mixer load. But
+  // load_asset is the explicit-file legacy path (it bypasses the catalog), so the bake's
+  // catalog-membership check never sees these refs — validate the file on disk here instead so
+  // a typo'd path in a direct load_asset call still fails the bake gate. The FS is real at bake.
+  if (ctx.IsBakeMode()) {
+    const std::string file = assetTable["file"].get_or<std::string>("");
+    const std::string id = assetTable["id"].get_or<std::string>("");
+    std::error_code ec;
+    if (file.empty() || !std::filesystem::exists(assetManager.GetFullPath(file), ec)) {
+      Logger::Error("load_asset (bake): id '" + id + "' maps to a missing file: '" +
+                    (file.empty() ? "<none>" : assetManager.GetFullPath(file)) + "'");
+      ctx.RecordBakeValidationFailures(1);
+    }
+    return;
+  }
+
+  LoadAsset(std::move(assetTable), assetManager, ctx.GetRenderer(), ctx.GetContext().mixer);
+}
+
+// Scan a scene table for its required asset ids (sprite/font/audio + tilemap + preload),
+// validate them against the catalog, then acquire each. The data-driven replacement for a
+// manual load_asset loop; scripts using a custom loader call this instead of listing assets by
+// hand. Returns the number of assets successfully acquired. Raises a Lua error when validation
+// fails and the assetValidationFatal dev gate is set.
+int AcquireSceneAssets(const sol::table& scene, LuaBindingContext& ctx) {
+  auto* registry = ctx.GetRegistry();
+  auto& assetManager = registry->Get<AssetManager>();
+  MIX_Mixer* mixer = ctx.GetContext().mixer;
+
+  const std::vector<AssetReference> refs = SceneAssetScanner::CollectRefs(scene);
+  const int failures = assetManager.Validate(refs);
+
+  // Bake: tally unresolved references across every scene the startup script loads, then keep
+  // running (don't throw on the first miss) so one bake run reports them all. No GPU upload.
+  if (ctx.IsBakeMode()) {
+    ctx.RecordBakeValidationFailures(failures);
+    Logger::Info("acquire_scene_assets (bake): validated " + std::to_string(refs.size()) + " reference(s), " +
+                 std::to_string(failures) + " unresolved.");
+    return 0;
+  }
+
+  if (failures > 0 && registry->Get<GameConfig>().GetEngineOptions().assetValidationFatal) {
+    throw std::runtime_error("acquire_scene_assets: " + std::to_string(failures) +
+                             " unresolved asset reference(s); assetValidationFatal is set.");
+  }
+
+  const int acquired = assetManager.AcquireAll(refs, ctx.GetRenderer(), mixer);
+
+  // Record the acquired ids on the Game so the next scene swap / StopScene releases them.
+  // Without this, scenes that load via a side-effect script (rather than returning a table
+  // the C++ loader scans) would acquire on every reload and never release — refcounts climb.
+  std::vector<std::string> ids;
+  std::set<std::string> seen;
+  for (const auto& ref : refs) {
+    if (seen.insert(ref.id).second) ids.push_back(ref.id);
+  }
+  ctx.TrackSceneAssets(ids);
+
+  Logger::Info("acquire_scene_assets: acquired " + std::to_string(acquired) + " asset(s).");
+  return acquired;
+}
 }  // namespace
 
 void LuaModuleBinding<SceneModule>::install(sol::state& lua, LuaBindingContext& ctx) {
-  lua.set_function("load_asset", [&ctx](sol::table assetTable) {
-    auto* registry = ctx.GetRegistry();
-    auto& assetManager = registry->Get<AssetManager>();
-
-    // Under bake there is no renderer/mixer to upload to, so skip the GPU/mixer load. But
-    // load_asset is the explicit-file legacy path (it bypasses the catalog), so the bake's
-    // catalog-membership check never sees these refs — validate the file on disk here instead so
-    // a typo'd path in a direct load_asset call still fails the bake gate. The FS is real at bake.
-    if (ctx.IsBakeMode()) {
-      const std::string file = assetTable["file"].get_or<std::string>("");
-      const std::string id = assetTable["id"].get_or<std::string>("");
-      std::error_code ec;
-      if (file.empty() || !std::filesystem::exists(assetManager.GetFullPath(file), ec)) {
-        Logger::Error("load_asset (bake): id '" + id + "' maps to a missing file: '" +
-                      (file.empty() ? "<none>" : assetManager.GetFullPath(file)) + "'");
-        ctx.RecordBakeValidationFailures(1);
-      }
-      return;
-    }
-
-    LoadAsset(std::move(assetTable), assetManager, ctx.GetRenderer(), ctx.GetContext().mixer);
-  });
-  // Scan a scene table for its required asset ids (sprite/font/audio + tilemap + preload),
-  // validate them against the catalog, then acquire each. The data-driven replacement for a
-  // manual load_asset loop; scripts using a custom loader call this instead of listing assets by
-  // hand. Returns the number of assets successfully acquired. Raises a Lua error when validation
-  // fails and the assetValidationFatal dev gate is set.
-  lua.set_function("acquire_scene_assets", [&ctx](const sol::table& scene) -> int {
-    auto* registry = ctx.GetRegistry();
-    auto& assetManager = registry->Get<AssetManager>();
-    MIX_Mixer* mixer = ctx.GetContext().mixer;
-
-    const std::vector<AssetReference> refs = SceneAssetScanner::CollectRefs(scene);
-    const int failures = assetManager.Validate(refs);
-
-    // Bake: tally unresolved references across every scene the startup script loads, then keep
-    // running (don't throw on the first miss) so one bake run reports them all. No GPU upload.
-    if (ctx.IsBakeMode()) {
-      ctx.RecordBakeValidationFailures(failures);
-      Logger::Info("acquire_scene_assets (bake): validated " + std::to_string(refs.size()) + " reference(s), " +
-                   std::to_string(failures) + " unresolved.");
-      return 0;
-    }
-
-    if (failures > 0 && registry->Get<GameConfig>().GetEngineOptions().assetValidationFatal) {
-      throw std::runtime_error("acquire_scene_assets: " + std::to_string(failures) +
-                               " unresolved asset reference(s); assetValidationFatal is set.");
-    }
-
-    const int acquired = assetManager.AcquireAll(refs, ctx.GetRenderer(), mixer);
-
-    // Record the acquired ids on the Game so the next scene swap / StopScene releases them.
-    // Without this, scenes that load via a side-effect script (rather than returning a table
-    // the C++ loader scans) would acquire on every reload and never release — refcounts climb.
-    std::vector<std::string> ids;
-    std::set<std::string> seen;
-    for (const auto& ref : refs) {
-      if (seen.insert(ref.id).second) ids.push_back(ref.id);
-    }
-    ctx.TrackSceneAssets(ids);
-
-    Logger::Info("acquire_scene_assets: acquired " + std::to_string(acquired) + " asset(s).");
-    return acquired;
-  });
+  lua.set_function("load_asset", [&ctx](sol::table assetTable) { LoadAssetFromLua(std::move(assetTable), ctx); });
+  lua.set_function("acquire_scene_assets",
+                   [&ctx](const sol::table& scene) -> int { return AcquireSceneAssets(scene, ctx); });
   // Returns the root entity handle so scripts can track what they spawned, or nil when the
   // table is invalid.
   lua.set_function("load_entity", [&ctx](const sol::table& assetTable) -> std::optional<Entity> {

--- a/src/Lua/Modules/SceneModuleLuaBinding.cpp
+++ b/src/Lua/Modules/SceneModuleLuaBinding.cpp
@@ -4,6 +4,7 @@
 #include <SDL3_mixer/SDL_mixer.h>
 
 #include <filesystem>
+#include <optional>
 #include <set>
 #include <stdexcept>
 #include <string>
@@ -99,8 +100,10 @@ void LuaModuleBinding<SceneModule>::install(sol::state& lua, LuaBindingContext& 
     Logger::Info("acquire_scene_assets: acquired " + std::to_string(acquired) + " asset(s).");
     return acquired;
   });
-  lua.set_function("load_entity", [&ctx](const sol::table& assetTable) {
-    LuaEntityLoader::LoadEntityFromLua(ctx.GetRegistry(), assetTable);
+  // Returns the root entity handle so scripts can track what they spawned, or nil when the
+  // table is invalid.
+  lua.set_function("load_entity", [&ctx](const sol::table& assetTable) -> std::optional<Entity> {
+    return LuaEntityLoader::LoadEntityFromLua(ctx.GetRegistry(), assetTable);
   });
   lua.set_function("clear_scene", [&ctx]() { ctx.StopScene(); });
   lua.set_function("load_scene", [&ctx](const std::string& path) { ctx.LoadScene(path); });

--- a/tests/LuaBehaviorTest.cpp
+++ b/tests/LuaBehaviorTest.cpp
@@ -111,6 +111,21 @@ int main() {
     Check(RunLua(lua, "assert(not registry.has_health(without_health))"), "registry.has_health false for non-owner");
   }
 
+  std::cout << "[load_entity: returns the root entity handle]\n";
+  {
+    Check(RunLua(lua,
+                 "spawned = load_entity({ name = 'HandleTest', components = { transform = { position = { x = 3, y = "
+                 "4 } } } })"),
+          "Lua: load_entity call succeeds");
+    Check(RunLua(lua, "assert(spawned ~= nil)"), "load_entity returned a non-nil handle");
+    Check(RunLua(lua, "assert(type(spawned:get_id()) == 'number')"), "handle exposes get_id()");
+    Check(RunLua(lua, "assert(registry.has_position(spawned))"), "handle works with registry accessors");
+
+    const Entity spawned = lua["spawned"].get<Entity>();
+    CheckEq(reg->GetComponent<PositionComponent>(spawned).value.x, 3.0F,
+            "handle resolves to the entity built from the table");
+  }
+
   std::cout << "[fromLua: defaults applied when fields omitted]\n";
   {
     // HealthComponent has no default-constructor (deleted); fromLua must synthesize one


### PR DESCRIPTION
## Summary

- `LuaEntityLoader::LoadEntityFromLua` now returns `std::optional<Entity>` — the root entity of the loaded tree, or `std::nullopt` when the root table is invalid.
- The `load_entity` Lua global passes the handle through; sol2 maps `nullopt` to `nil`. Scripts can now track what they spawned:

```lua
local e = load_entity({ name = "Player", components = { ... } })
if e then
    log("spawned entity " .. e:get_id())
    registry.get_position(e).value = vec2.new(100, 100)
end
```

- New `LuaBehaviorTest` block covers the round-trip: handle is non-nil, exposes `get_id()`, works with `registry.*` accessors, and resolves to the entity built from the table.
- Documented the return value in `docs/lua-scripting.md`.

`SceneLoader.cpp` keeps discarding the return — no behavior change for declarative scenes. No manifest drift (`lua_api.smoke.lua` / `modules.json` signatures unchanged).
