### PR TITLE
Allow blam to take a single entity or a table of entities

### DIFF
--- a/docs/lua-scripting.md
+++ b/docs/lua-scripting.md
@@ -117,7 +117,7 @@ These globals are shorthand for the most common reads and writes:
 | `set_name(entity, name)` | Sets the name |
 | `set_sprite_src_rect(entity, x, y)` | Sets the sprite source-rect origin |
 | `find_entity_by_name(name)` | Returns the entity ID, or `nil` |
-| `blam(entity)` | Destroys the entity |
+| `blam(entity_or_table)` | Destroys an entity, or every entity in a table |
 
 ### Other Lua globals
 

--- a/src/Lua/Modules/EntityModuleLuaBinding.cpp
+++ b/src/Lua/Modules/EntityModuleLuaBinding.cpp
@@ -56,10 +56,22 @@ void SetEntitySpriteSrcRect(Registry* registry, const Entity entity, const float
   sprite.srcRect.x = srcRectX;
   sprite.srcRect.y = srcRectY;
 }
+
+void BlamEntities(Registry* registry, const sol::table& entities) {
+  for (const auto& [key, value] : entities) {
+    if (!value.is<Entity>()) {
+      Logger::Error("blam: table entry is not an entity; skipping.");
+      continue;
+    }
+    registry->BlamEntity(value.as<Entity>());
+  }
+}
 }  // namespace
 
 void LuaModuleBinding<EntityModule>::install(sol::state& lua, LuaBindingContext& ctx) {
-  lua.set_function("blam", [&ctx](const Entity entity) { ctx.GetRegistry()->BlamEntity(entity); });
+  lua.set_function("blam",
+                   sol::overload([&ctx](const Entity entity) { ctx.GetRegistry()->BlamEntity(entity); },
+                                 [&ctx](const sol::table& entities) { BlamEntities(ctx.GetRegistry(), entities); }));
   lua.set_function("get_name", [&ctx](const Entity entity) { return GetEntityName(ctx.GetRegistry(), entity); });
   lua.set_function("set_name", [&ctx](const Entity entity, const std::string& name) {
     SetEntityName(ctx.GetRegistry(), entity, name);

--- a/tests/LuaBehaviorTest.cpp
+++ b/tests/LuaBehaviorTest.cpp
@@ -111,6 +111,27 @@ int main() {
     Check(RunLua(lua, "assert(not registry.has_health(without_health))"), "registry.has_health false for non-owner");
   }
 
+  std::cout << "[blam: single entity and table of entities]\n";
+  {
+    const Entity single = reg->CreateEntity();
+    lua["blam_single"] = single;
+    Check(RunLua(lua, "blam(blam_single)"), "Lua: blam(entity) call succeeds");
+    Check(!reg->IsAlive(single), "blam(entity) destroyed the entity");
+
+    const Entity first = reg->CreateEntity();
+    const Entity second = reg->CreateEntity();
+    const Entity survivor = reg->CreateEntity();
+    lua["blam_first"] = first;
+    lua["blam_second"] = second;
+    Check(RunLua(lua, "blam({ blam_first, blam_second })"), "Lua: blam(table) call succeeds");
+    Check(!reg->IsAlive(first), "blam(table) destroyed the first entity");
+    Check(!reg->IsAlive(second), "blam(table) destroyed the second entity");
+    Check(reg->IsAlive(survivor), "blam(table) left unrelated entities alone");
+
+    // Non-entity entries are skipped with an error log, not a Lua error.
+    Check(RunLua(lua, "blam({ 42, 'nope' })"), "Lua: blam(table) tolerates non-entity entries");
+  }
+
   std::cout << "[fromLua: defaults applied when fields omitted]\n";
   {
     // HealthComponent has no default-constructor (deleted); fromLua must synthesize one


### PR DESCRIPTION
## Summary

- `blam` now accepts either a single entity or a table of entities, via `sol::overload`:

```lua
blam(enemy)                  -- unchanged
blam({ enemy_a, enemy_b })   -- destroys every entity in the table
```

- Non-entity entries in the table are skipped with an error log rather than raising a Lua error, matching the engine's tolerant binding style.
- New `LuaBehaviorTest` block covers the single-entity path, the table path (including that unrelated entities survive), and the non-entity-entry tolerance.
- Documented the new signature in `docs/lua-scripting.md`.

No manifest drift — `lua_api.smoke.lua` emits the same generic `function blam(...) end` stub.

