### PR TITLE
Add sprite alpha, color modulation, and blend modes through the render pipeline

### DIFF
--- a/src/Components/SpriteComponent.h
+++ b/src/Components/SpriteComponent.h
@@ -3,6 +3,9 @@
 #include <string>
 #include <utility>
 
+#include "General/BlendMode.h"
+#include "General/Color.h"
+#include "General/Constants.h"
 #include "General/Rect.h"
 #include "General/SpriteFlip.h"
 
@@ -14,6 +17,9 @@ struct SpriteComponent {
   bool isFixed;
   octarine::Rect srcRect{};
   octarine::SpriteFlip flip = octarine::SpriteFlip::None;
+  // rgb tints (multiplies) the texture, a fades it. 255 across the board = draw unmodified.
+  octarine::Color colorMod{Constants::kUint8Max, Constants::kUint8Max, Constants::kUint8Max, Constants::kUint8Max};
+  octarine::BlendMode blendMode = octarine::BlendMode::Blend;
 
   explicit SpriteComponent(std::string t_assetId = "", const float t_width = 0, const float t_height = 0,
                            const int t_layer = 0, const bool t_isFixed = false, const float t_srcRectX = 0,

--- a/src/Components/SquarePrimitiveComponent.h
+++ b/src/Components/SquarePrimitiveComponent.h
@@ -2,6 +2,7 @@
 
 #include <glm/glm.hpp>
 
+#include "General/BlendMode.h"
 #include "General/Color.h"
 #include "General/Constants.h"
 
@@ -10,8 +11,9 @@ struct SquarePrimitiveComponent {
   int layer;
   float width;
   float height;
-  octarine::Color color;
+  octarine::Color color;  // a < 255 fades the square (with the default Blend mode)
   bool isFixed;
+  octarine::BlendMode blendMode = octarine::BlendMode::Blend;
 
   explicit SquarePrimitiveComponent(const glm::vec2 t_position = glm::vec2(0, 0), const int t_layer = 0,
                                     const float t_width = 0, const float t_height = 0,

--- a/src/General/BlendMode.h
+++ b/src/General/BlendMode.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <cstdint>
+#include <string_view>
+
+namespace octarine {
+
+// Blend modes for sprite / primitive rendering. Values are a compact 0..N enum (3 bits —
+// RenderKey packs them into the sort key) rather than SDL's sparse bitmask constants, so
+// component data doesn't depend on SDL headers. Mapping to SDL_BlendMode happens at the
+// renderer boundary.
+enum class BlendMode : std::uint8_t {
+  None = 0,  // No blending: dst = src
+  Blend,     // Alpha blending: dst = src*srcA + dst*(1-srcA)
+  Add,       // Additive: dst = src*srcA + dst
+  Mod,       // Color modulate: dst = src*dst
+  Mul,       // Color multiply: dst = src*dst + dst*(1-srcA)
+};
+
+constexpr const char* ToString(const BlendMode mode) {
+  switch (mode) {
+    case BlendMode::None:
+      return "none";
+    case BlendMode::Add:
+      return "add";
+    case BlendMode::Mod:
+      return "mod";
+    case BlendMode::Mul:
+      return "mul";
+    case BlendMode::Blend:
+    default:
+      return "blend";
+  }
+}
+
+constexpr BlendMode BlendModeFromString(const std::string_view name, const BlendMode fallback = BlendMode::Blend) {
+  if (name == "none") return BlendMode::None;
+  if (name == "blend") return BlendMode::Blend;
+  if (name == "add") return BlendMode::Add;
+  if (name == "mod") return BlendMode::Mod;
+  if (name == "mul") return BlendMode::Mul;
+  return fallback;
+}
+
+}  // namespace octarine

--- a/src/Lua/Bindings/SpriteComponentLuaBinding.h
+++ b/src/Lua/Bindings/SpriteComponentLuaBinding.h
@@ -1,8 +1,13 @@
 #pragma once
 
+#include <cstdint>
 #include <sol/sol.hpp>
+#include <string>
+#include <string_view>
 
 #include "Components/SpriteComponent.h"
+#include "General/BlendMode.h"
+#include "General/Constants.h"
 #include "Lua/Bindings/LuaBinding.h"
 
 template <>
@@ -20,12 +25,27 @@ struct LuaBinding<SpriteComponent> {
     const auto fixed = SafeGetOptionalValue<bool>(t, "fixed", false);
     const auto srcRectX = SafeGetOptionalValue<float>(t, "src_rect_x", 0);
     const auto srcRectY = SafeGetOptionalValue<float>(t, "src_rect_y", 0);
-    return SpriteComponent(textureAssetId, width, height, layer, fixed, srcRectX, srcRectY);
+    SpriteComponent sprite(textureAssetId, width, height, layer, fixed, srcRectX, srcRectY);
+    sprite.colorMod = SafeGetColor(t, "color_mod", Constants::kUint8Max, Constants::kUint8Max, Constants::kUint8Max,
+                                   Constants::kUint8Max);
+    // "alpha" is a convenience alias for color_mod.a; when both are given, alpha wins.
+    sprite.colorMod.a =
+        static_cast<std::uint8_t>(SafeGetOptionalValue<int>(t, "alpha", static_cast<int>(sprite.colorMod.a)));
+    sprite.blendMode = octarine::BlendModeFromString(SafeGetOptionalValue<std::string>(t, "blend_mode", "blend"));
+    return sprite;
   }
 
   static void bindUsertype(sol::state& lua) {
-    lua.new_usertype<SpriteComponent>(kUsertypeName, "width", sol::readonly(&SpriteComponent::width), "height",
-                                      sol::readonly(&SpriteComponent::height), "layer", &SpriteComponent::layer,
-                                      "asset_id", sol::readonly(&SpriteComponent::assetId));
+    lua.new_usertype<SpriteComponent>(
+        kUsertypeName, "width", sol::readonly(&SpriteComponent::width), "height",
+        sol::readonly(&SpriteComponent::height), "layer", &SpriteComponent::layer, "asset_id",
+        sol::readonly(&SpriteComponent::assetId), "color_mod", &SpriteComponent::colorMod, "alpha",
+        sol::property([](const SpriteComponent& s) { return s.colorMod.a; },
+                      [](SpriteComponent& s, const std::uint8_t alpha) { s.colorMod.a = alpha; }),
+        "blend_mode",
+        sol::property([](const SpriteComponent& s) { return octarine::ToString(s.blendMode); },
+                      [](SpriteComponent& s, const std::string_view mode) {
+                        s.blendMode = octarine::BlendModeFromString(mode, s.blendMode);
+                      }));
   }
 };

--- a/src/Lua/Bindings/SquarePrimitiveComponentLuaBinding.h
+++ b/src/Lua/Bindings/SquarePrimitiveComponentLuaBinding.h
@@ -1,8 +1,11 @@
 #pragma once
 
 #include <sol/sol.hpp>
+#include <string>
+#include <string_view>
 
 #include "Components/SquarePrimitiveComponent.h"
+#include "General/BlendMode.h"
 #include "Lua/Bindings/LuaBinding.h"
 
 template <>
@@ -19,13 +22,19 @@ struct LuaBinding<SquarePrimitiveComponent> {
     const auto height = SafeGetOptionalValue<float>(t, "height", 0.0f);
     const octarine::Color color = SafeGetColor(t, "color");
     const auto fixed = SafeGetOptionalValue<bool>(t, "fixed", false);
-    return SquarePrimitiveComponent(position, layer, width, height, color, fixed);
+    SquarePrimitiveComponent square(position, layer, width, height, color, fixed);
+    square.blendMode = octarine::BlendModeFromString(SafeGetOptionalValue<std::string>(t, "blend_mode", "blend"));
+    return square;
   }
 
   static void bindUsertype(sol::state& lua) {
     lua.new_usertype<SquarePrimitiveComponent>(
         kUsertypeName, "width", &SquarePrimitiveComponent::width, "height", &SquarePrimitiveComponent::height, "color",
         &SquarePrimitiveComponent::color, "position", &SquarePrimitiveComponent::position, "layer",
-        &SquarePrimitiveComponent::layer, "is_fixed", &SquarePrimitiveComponent::isFixed);
+        &SquarePrimitiveComponent::layer, "is_fixed", &SquarePrimitiveComponent::isFixed, "blend_mode",
+        sol::property([](const SquarePrimitiveComponent& s) { return octarine::ToString(s.blendMode); },
+                      [](SquarePrimitiveComponent& s, const std::string_view mode) {
+                        s.blendMode = octarine::BlendModeFromString(mode, s.blendMode);
+                      }));
   }
 };

--- a/src/Renderer/RenderCommands.h
+++ b/src/Renderer/RenderCommands.h
@@ -3,6 +3,7 @@
 #include <SDL3/SDL.h>
 
 #include "General/BlendMode.h"
+#include "General/Constants.h"
 
 namespace octarine {
 
@@ -33,7 +34,7 @@ struct SpriteCommand {
   SDL_FlipMode flip{};
   SDL_Texture* texture{};
   // Per-draw modulation: rgb tints (multiplies) the texture, alpha fades it. 255 = no-op.
-  SDL_Color colorMod{255, 255, 255, 255};
+  SDL_Color colorMod{Constants::kUint8Max, Constants::kUint8Max, Constants::kUint8Max, Constants::kUint8Max};
   SDL_BlendMode blendMode{SDL_BLENDMODE_BLEND};
 };
 

--- a/src/Renderer/RenderCommands.h
+++ b/src/Renderer/RenderCommands.h
@@ -2,6 +2,29 @@
 
 #include <SDL3/SDL.h>
 
+#include "General/BlendMode.h"
+
+namespace octarine {
+
+// Boundary translation from the backend-agnostic component enum to SDL's sparse constants.
+inline SDL_BlendMode ToSdlBlendMode(const BlendMode mode) {
+  switch (mode) {
+    case BlendMode::None:
+      return SDL_BLENDMODE_NONE;
+    case BlendMode::Add:
+      return SDL_BLENDMODE_ADD;
+    case BlendMode::Mod:
+      return SDL_BLENDMODE_MOD;
+    case BlendMode::Mul:
+      return SDL_BLENDMODE_MUL;
+    case BlendMode::Blend:
+    default:
+      return SDL_BLENDMODE_BLEND;
+  }
+}
+
+}  // namespace octarine
+
 struct SpriteCommand {
   float destX{}, destY{}, destW{}, destH{};
   SDL_FRect srcRect{};
@@ -9,12 +32,16 @@ struct SpriteCommand {
   SDL_FPoint pivot{};
   SDL_FlipMode flip{};
   SDL_Texture* texture{};
+  // Per-draw modulation: rgb tints (multiplies) the texture, alpha fades it. 255 = no-op.
+  SDL_Color colorMod{255, 255, 255, 255};
+  SDL_BlendMode blendMode{SDL_BLENDMODE_BLEND};
 };
 
 struct SquareCommand {
   SDL_FRect destRect{};
   SDL_Color color{};
   double rotation{};
+  SDL_BlendMode blendMode{SDL_BLENDMODE_BLEND};
 };
 
 struct TextCommand {

--- a/src/Renderer/RenderKey.h
+++ b/src/Renderer/RenderKey.h
@@ -66,7 +66,13 @@ struct RenderKey {
     const std::uint64_t hash21 = static_cast<std::uint64_t>((ptr >> 4) ^ (ptr >> 25)) & 0x1FFFFFu;
     const std::uint64_t blend3 = static_cast<std::uint64_t>(blendBits) & 0x7u;
 
-    return (layer16 << 48) | (band20 << 28) | (type4 << 24) | (blend3 << 21) | hash21;
+    // Field offsets of the packed layout documented at the top of this header.
+    constexpr int kLayerShift = 48;
+    constexpr int kBandShift = 28;
+    constexpr int kTypeShift = 24;
+    constexpr int kBlendShift = 21;
+    return (layer16 << kLayerShift) | (band20 << kBandShift) | (type4 << kTypeShift) | (blend3 << kBlendShift) |
+           hash21;
   }
 
   // Kept for completeness; not used by Sort (radix sort uses sortKey directly).

--- a/src/Renderer/RenderKey.h
+++ b/src/Renderer/RenderKey.h
@@ -18,10 +18,12 @@
 //   bits 63-48 : layer (16 bits, unsigned — 64K layers covers kDebugUIBaseLayer headroom)
 //   bits 47-28 : depthBand + bias (20 bits — ±16M world pixels at 32px bands)
 //   bits 27-24 : type (4 bits)
-//   bits 23- 0 : batchKey hash (24 bits) — clusters same-texture runs within a band so
-//                SDL3's internal renderer can coalesce them. 16M slots makes collisions
-//                vanishingly rare for any realistic texture count; collisions only
-//                degrade batching, never produce wrong pixels.
+//   bits 23-21 : blend mode (3 bits) — clusters same-blend runs within a band so SDL3
+//                doesn't break batches on blend-state changes.
+//   bits 20- 0 : batchKey hash (21 bits) — clusters same-texture runs within a
+//                band+blend so SDL3's internal renderer can coalesce them. 2M slots makes
+//                collisions vanishingly rare for any realistic texture count; collisions
+//                only degrade batching, never produce wrong pixels.
 //
 // type is also stored separately because Renderer::Render dispatches on it to choose the
 // payload union member.
@@ -42,7 +44,8 @@ struct RenderKey {
 
   RenderKey() = default;
 
-  static std::uint64_t ComputeSortKey(unsigned int layer, float depth, RenderableType type, const void* batchKey) {
+  static std::uint64_t ComputeSortKey(unsigned int layer, float depth, RenderableType type, const void* batchKey,
+                                      std::uint8_t blendBits = 0) {
     std::int32_t band = 0;
     if constexpr (Constants::kRenderBatchYBandPx > 0.0f) {
       band = static_cast<std::int32_t>(std::floor(depth / Constants::kRenderBatchYBandPx));
@@ -55,13 +58,15 @@ struct RenderKey {
     const std::uint64_t band20 = static_cast<std::uint64_t>(static_cast<std::uint32_t>(band + kBandBias) & 0xFFFFFu);
     const std::uint64_t type4 = static_cast<std::uint64_t>(static_cast<std::uint8_t>(type)) & 0xFu;
 
-    // 24-bit hash. Shift off allocator alignment noise then XOR-fold; for ~20 textures
-    // mapped into 16M slots the collision probability is effectively zero. nullptr (used
-    // by primitives) hashes to 0, which keeps all primitives clustered.
+    // 21-bit hash. Shift off allocator alignment noise then XOR-fold; for ~20 textures
+    // mapped into 2M slots the collision probability is effectively zero. nullptr (used
+    // by primitives) hashes to 0, which keeps all primitives clustered. Blend mode sits
+    // above the hash so same-blend runs cluster before same-texture runs.
     const auto ptr = reinterpret_cast<std::uintptr_t>(batchKey);
-    const std::uint64_t hash24 = static_cast<std::uint64_t>((ptr >> 4) ^ (ptr >> 28)) & 0xFFFFFFu;
+    const std::uint64_t hash21 = static_cast<std::uint64_t>((ptr >> 4) ^ (ptr >> 25)) & 0x1FFFFFu;
+    const std::uint64_t blend3 = static_cast<std::uint64_t>(blendBits) & 0x7u;
 
-    return (layer16 << 48) | (band20 << 28) | (type4 << 24) | hash24;
+    return (layer16 << 48) | (band20 << 28) | (type4 << 24) | (blend3 << 21) | hash21;
   }
 
   // Kept for completeness; not used by Sort (radix sort uses sortKey directly).

--- a/src/Renderer/RenderKey.h
+++ b/src/Renderer/RenderKey.h
@@ -71,8 +71,7 @@ struct RenderKey {
     constexpr int kBandShift = 28;
     constexpr int kTypeShift = 24;
     constexpr int kBlendShift = 21;
-    return (layer16 << kLayerShift) | (band20 << kBandShift) | (type4 << kTypeShift) | (blend3 << kBlendShift) |
-           hash21;
+    return (layer16 << kLayerShift) | (band20 << kBandShift) | (type4 << kTypeShift) | (blend3 << kBlendShift) | hash21;
   }
 
   // Kept for completeness; not used by Sort (radix sort uses sortKey directly).

--- a/src/Renderer/RenderQueue.h
+++ b/src/Renderer/RenderQueue.h
@@ -47,16 +47,19 @@ class RenderQueue {
     return *this;
   }
 
-  SpriteCommand& EmplaceSprite(unsigned int layer, float depth, const void* batchKey = nullptr) {
+  SpriteCommand& EmplaceSprite(unsigned int layer, float depth, const void* batchKey = nullptr,
+                               octarine::BlendMode blendMode = octarine::BlendMode::Blend) {
     auto& key = ClaimSlot();
-    key.sortKey = RenderKey::ComputeSortKey(layer, depth, SPRITE, batchKey);
+    key.sortKey = RenderKey::ComputeSortKey(layer, depth, SPRITE, batchKey, static_cast<std::uint8_t>(blendMode));
     key.type = SPRITE;
     return key.payload.sprite;
   }
 
-  SquareCommand& EmplaceSquare(unsigned int layer, float depth, const void* batchKey = nullptr) {
+  SquareCommand& EmplaceSquare(unsigned int layer, float depth, const void* batchKey = nullptr,
+                               octarine::BlendMode blendMode = octarine::BlendMode::Blend) {
     auto& key = ClaimSlot();
-    key.sortKey = RenderKey::ComputeSortKey(layer, depth, SQUARE_PRIMITIVE, batchKey);
+    key.sortKey =
+        RenderKey::ComputeSortKey(layer, depth, SQUARE_PRIMITIVE, batchKey, static_cast<std::uint8_t>(blendMode));
     key.type = SQUARE_PRIMITIVE;
     return key.payload.square;
   }

--- a/src/Renderer/Renderer.cpp
+++ b/src/Renderer/Renderer.cpp
@@ -80,11 +80,19 @@ void Renderer::DrawQueue(const RenderQueue& renderQueue, SDL_Renderer* renderer)
         const auto& cmd = key.payload.sprite;
         const SDL_FRect destRect = {cmd.destX, cmd.destY, cmd.destW, cmd.destH};
         const auto deg = static_cast<float>(cmd.rotation * (180.0 / 3.14159265358979323846));
+        // Modulation state lives on the shared SDL_Texture, so set it on every draw — the
+        // previous sprite using this texture may have left different values behind. Same-state
+        // sets are cheap (SDL just stores them; they apply at draw time).
+        SDL_SetTextureColorMod(cmd.texture, cmd.colorMod.r, cmd.colorMod.g, cmd.colorMod.b);
+        SDL_SetTextureAlphaMod(cmd.texture, cmd.colorMod.a);
+        SDL_SetTextureBlendMode(cmd.texture, cmd.blendMode);
         SDL_RenderTextureRotated(renderer, cmd.texture, &cmd.srcRect, &destRect, deg, &cmd.pivot, cmd.flip);
         break;
       }
       case SQUARE_PRIMITIVE: {
         const auto& cmd = key.payload.square;
+        // Applies to both the fill-rect and the SDL_RenderGeometry (untextured) path.
+        SDL_SetRenderDrawBlendMode(renderer, cmd.blendMode);
         if (cmd.rotation == 0.0) {
           SDL_SetRenderDrawColor(renderer, cmd.color.r, cmd.color.g, cmd.color.b, cmd.color.a);
           SDL_RenderFillRect(renderer, &cmd.destRect);

--- a/src/Systems/RenderPrimitiveSystem.h
+++ b/src/Systems/RenderPrimitiveSystem.h
@@ -42,10 +42,12 @@ class RenderPrimitiveSystem {
     const float x = square.isFixed ? origin.x : origin.x - camera_.x;
     const float y = square.isFixed ? origin.y : origin.y - camera_.y;
 
-    auto& cmd = renderQueue_->EmplaceSquare(static_cast<unsigned int>(square.layer), square.position.y);
+    auto& cmd = renderQueue_->EmplaceSquare(static_cast<unsigned int>(square.layer), square.position.y, nullptr,
+                                            square.blendMode);
     cmd.destRect = {x, y, square.width, square.height};
     cmd.color = SDL_Color{square.color.r, square.color.g, square.color.b, square.color.a};
     cmd.rotation = transform.rotation;
+    cmd.blendMode = octarine::ToSdlBlendMode(square.blendMode);
   }
 
  private:

--- a/src/Systems/RenderSpriteSystem.h
+++ b/src/Systems/RenderSpriteSystem.h
@@ -7,6 +7,7 @@
 #include <optional>
 
 #include "AssetManager/AssetManager.h"
+#include "Components/CameraComponents.h"
 #include "Components/GlobalTransformComponent.h"
 #include "Components/SpriteComponent.h"
 #include "ECS/Query.h"

--- a/src/Systems/RenderSpriteSystem.h
+++ b/src/Systems/RenderSpriteSystem.h
@@ -73,7 +73,8 @@ class RenderSpriteSystem {
     const float x = sprite.isFixed ? transform.position.x : transform.position.x - camera_.x;
     const float y = sprite.isFixed ? transform.position.y : transform.position.y - camera_.y;
 
-    auto& cmd = renderQueue_->EmplaceSprite(static_cast<unsigned int>(sprite.layer), transform.position.y, texture);
+    auto& cmd = renderQueue_->EmplaceSprite(static_cast<unsigned int>(sprite.layer), transform.position.y, texture,
+                                            sprite.blendMode);
     cmd.destX = x;
     cmd.destY = y;
     cmd.destW = sprite.width * transform.scale.x;
@@ -89,6 +90,8 @@ class RenderSpriteSystem {
     cmd.pivot = {cmd.destW * 0.5f, cmd.destH * 0.5f};
     cmd.flip = static_cast<SDL_FlipMode>(sprite.flip);
     cmd.texture = texture;
+    cmd.colorMod = SDL_Color{sprite.colorMod.r, sprite.colorMod.g, sprite.colorMod.b, sprite.colorMod.a};
+    cmd.blendMode = octarine::ToSdlBlendMode(sprite.blendMode);
   }
 
  private:


### PR DESCRIPTION
## What

Sprites and square primitives can now fade, tint, and blend additively, end to end from Lua.

- `SpriteCommand` carries `colorMod` (rgb tint + alpha) and `blendMode`; `SquareCommand` carries `blendMode`. `Renderer::DrawQueue` applies `SDL_SetTextureColorMod` / `SDL_SetTextureAlphaMod` / `SDL_SetTextureBlendMode` per sprite draw and `SDL_SetRenderDrawBlendMode` per square draw (both fill-rect and rotated-geometry paths).
- New backend-agnostic `octarine::BlendMode` enum (`General/BlendMode.h`) with string round-trip helpers, mapped to `SDL_BlendMode` at the renderer boundary — component data stays SDL-free, same pattern as `SpriteFlip`.
- Blend mode is folded into the `RenderKey` sort key: the 24-bit batch hash is now 3 bits of blend mode above a 21-bit texture hash, so same-blend runs cluster within a layer/band before texture clustering. 2M texture-hash slots still make collisions vanishingly rare.
- `SpriteComponent.colorMod` (rgb = tint, a = alpha, 255 = no-op) + `blendMode`; `SquarePrimitiveComponent.blendMode` (its `color.a` now actually blends — squares previously drew opaque because the draw blend mode was never set).
- Lua: `sprite.color_mod`, `sprite.alpha` (alias for `color_mod.a`), `sprite.blend_mode`, `square.blend_mode` — settable in the `load_entity` component table and via property access at runtime. Blend modes are strings: `none`, `blend`, `add`, `mod`, `mul`.

## Behavior note

Square primitives previously ignored their color alpha (draw blend mode defaulted to NONE). They now default to `blend`, so a square with `a < 255` fades as the field always suggested. Set `blend_mode = none` to restore the old opaque behavior per entity.

## Verification

- `editor-debug` build + all 17 ctest suites green on Windows/MSVC.
- `LuaApiSmokeTest` regenerated `lua_api.smoke.lua` / `components.json` / `modules.json` — no drift (catalogs don't enumerate usertype fields).
- Headless capture against the example project (`-m play`, frame 30): an untinted tank sprite reads (253,216,164); with `color_mod = {255,40,40}, alpha = 96` the same pixel reads (101,22,32), matching the modulation math over the background exactly. Property setters round-trip from a script (`blend_mode` string get/set, `color_mod.b`, `alpha`).