### PR TITLE
Surface benchmark regression alerts as commit comments

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -60,7 +60,10 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: false
           alert-threshold: '200%'
-          comment-on-alert: false
+          # Alerts were silenced in b14d80e while stabilizing the action itself; the workflow is
+          # nightly-only now, so a >200% regression posts a commit comment instead of vanishing
+          # into the dashboard. fail-on-alert stays off until comment noise proves low.
+          comment-on-alert: true
           fail-on-alert: false
           alert-comment-cc-users: '@mblackman'
 
@@ -86,6 +89,6 @@ jobs:
           skip-fetch-gh-pages: true
           auto-push: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
           alert-threshold: '200%'
-          comment-on-alert: false
+          comment-on-alert: true
           fail-on-alert: false
           alert-comment-cc-users: '@mblackman'


### PR DESCRIPTION
## What

Flips `comment-on-alert: false` to `true` for both the micro- and macro-benchmark `github-action-benchmark` steps. `fail-on-alert` stays `false`.

## Why

`benchmark.yml` sets `alert-threshold: 200%` but with both alert outputs disabled, a regression lands on the gh-pages dashboard and nobody is told. The silence dates to b14d80e (Fix benchmark action error and remove error), which flipped both flags while fixing action errors — a stabilization workaround, not a deliberate policy (the original workflow in 4653b87 shipped with both `true`).

Since 80e708d the workflow runs nightly + dispatch only, so alerts post as commit comments (cc `@mblackman`) rather than PR comments; the job already has `contents: write` / `pull-requests: write`. `fail-on-alert` can follow once comment noise proves low.
