### PR TITLE
Add RenderQueue and asset-store test suites

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -607,5 +607,34 @@ if (OCTARINE_ENABLE_TESTS)
     endif ()
     add_test(NAME GameBakeTest COMMAND OctarineGameBakeTest)
 
+    # RenderQueue / RenderKey sort + batching invariants. Header-only code under test, but it
+    # speaks SDL types — linking octarine_engine keeps the include/link surface identical to the
+    # other engine-facing tests with one TU.
+    add_executable(OctarineRenderQueueTest tests/RenderQueueTest.cpp)
+    set_target_properties(OctarineRenderQueueTest PROPERTIES
+            CXX_STANDARD 20
+            CXX_STANDARD_REQUIRED ON
+            CXX_EXTENSIONS OFF)
+    target_link_libraries(OctarineRenderQueueTest PRIVATE octarine_engine)
+    if (MSVC)
+        target_compile_options(OctarineRenderQueueTest PRIVATE /MP /bigobj /permissive- /wd4201 /wd5321)
+    endif ()
+    add_test(NAME RenderQueueTest COMMAND OctarineRenderQueueTest)
+
+    # Typed asset-store lifecycle: TextureStore generation/ownership plus AssetManager
+    # acquire/release, hot-reload swap, and missing-asset paths against a headless software
+    # renderer and a temp-dir catalog (the checked-in fixture images are placeholder bytes that
+    # don't decode, so the test writes real PNGs at runtime).
+    add_executable(OctarineAssetStoreTest tests/AssetStoreTest.cpp)
+    set_target_properties(OctarineAssetStoreTest PROPERTIES
+            CXX_STANDARD 20
+            CXX_STANDARD_REQUIRED ON
+            CXX_EXTENSIONS OFF)
+    target_link_libraries(OctarineAssetStoreTest PRIVATE octarine_engine)
+    if (MSVC)
+        target_compile_options(OctarineAssetStoreTest PRIVATE /MP /bigobj /permissive- /wd4201 /wd5321)
+    endif ()
+    add_test(NAME AssetStoreTest COMMAND OctarineAssetStoreTest)
+
     message(STATUS "Octarine: Tests ENABLED")
 endif ()

--- a/src/Components/SpriteComponent.h
+++ b/src/Components/SpriteComponent.h
@@ -3,6 +3,9 @@
 #include <string>
 #include <utility>
 
+#include "General/BlendMode.h"
+#include "General/Color.h"
+#include "General/Constants.h"
 #include "General/Rect.h"
 #include "General/SpriteFlip.h"
 
@@ -14,6 +17,9 @@ struct SpriteComponent {
   bool isFixed;
   octarine::Rect srcRect{};
   octarine::SpriteFlip flip = octarine::SpriteFlip::None;
+  // rgb tints (multiplies) the texture, a fades it. 255 across the board = draw unmodified.
+  octarine::Color colorMod{Constants::kUint8Max, Constants::kUint8Max, Constants::kUint8Max, Constants::kUint8Max};
+  octarine::BlendMode blendMode = octarine::BlendMode::Blend;
 
   explicit SpriteComponent(std::string t_assetId = "", const float t_width = 0, const float t_height = 0,
                            const int t_layer = 0, const bool t_isFixed = false, const float t_srcRectX = 0,

--- a/src/Components/SquarePrimitiveComponent.h
+++ b/src/Components/SquarePrimitiveComponent.h
@@ -2,6 +2,7 @@
 
 #include <glm/glm.hpp>
 
+#include "General/BlendMode.h"
 #include "General/Color.h"
 #include "General/Constants.h"
 
@@ -10,8 +11,9 @@ struct SquarePrimitiveComponent {
   int layer;
   float width;
   float height;
-  octarine::Color color;
+  octarine::Color color;  // a < 255 fades the square (with the default Blend mode)
   bool isFixed;
+  octarine::BlendMode blendMode = octarine::BlendMode::Blend;
 
   explicit SquarePrimitiveComponent(const glm::vec2 t_position = glm::vec2(0, 0), const int t_layer = 0,
                                     const float t_width = 0, const float t_height = 0,

--- a/src/General/BlendMode.h
+++ b/src/General/BlendMode.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <cstdint>
+#include <string_view>
+
+namespace octarine {
+
+// Blend modes for sprite / primitive rendering. Values are a compact 0..N enum (3 bits —
+// RenderKey packs them into the sort key) rather than SDL's sparse bitmask constants, so
+// component data doesn't depend on SDL headers. Mapping to SDL_BlendMode happens at the
+// renderer boundary.
+enum class BlendMode : std::uint8_t {
+  None = 0,  // No blending: dst = src
+  Blend,     // Alpha blending: dst = src*srcA + dst*(1-srcA)
+  Add,       // Additive: dst = src*srcA + dst
+  Mod,       // Color modulate: dst = src*dst
+  Mul,       // Color multiply: dst = src*dst + dst*(1-srcA)
+};
+
+constexpr const char* ToString(const BlendMode mode) {
+  switch (mode) {
+    case BlendMode::None:
+      return "none";
+    case BlendMode::Add:
+      return "add";
+    case BlendMode::Mod:
+      return "mod";
+    case BlendMode::Mul:
+      return "mul";
+    case BlendMode::Blend:
+    default:
+      return "blend";
+  }
+}
+
+constexpr BlendMode BlendModeFromString(const std::string_view name, const BlendMode fallback = BlendMode::Blend) {
+  if (name == "none") return BlendMode::None;
+  if (name == "blend") return BlendMode::Blend;
+  if (name == "add") return BlendMode::Add;
+  if (name == "mod") return BlendMode::Mod;
+  if (name == "mul") return BlendMode::Mul;
+  return fallback;
+}
+
+}  // namespace octarine

--- a/src/Lua/Bindings/SpriteComponentLuaBinding.h
+++ b/src/Lua/Bindings/SpriteComponentLuaBinding.h
@@ -1,8 +1,13 @@
 #pragma once
 
+#include <cstdint>
 #include <sol/sol.hpp>
+#include <string>
+#include <string_view>
 
 #include "Components/SpriteComponent.h"
+#include "General/BlendMode.h"
+#include "General/Constants.h"
 #include "Lua/Bindings/LuaBinding.h"
 
 template <>
@@ -20,12 +25,27 @@ struct LuaBinding<SpriteComponent> {
     const auto fixed = SafeGetOptionalValue<bool>(t, "fixed", false);
     const auto srcRectX = SafeGetOptionalValue<float>(t, "src_rect_x", 0);
     const auto srcRectY = SafeGetOptionalValue<float>(t, "src_rect_y", 0);
-    return SpriteComponent(textureAssetId, width, height, layer, fixed, srcRectX, srcRectY);
+    SpriteComponent sprite(textureAssetId, width, height, layer, fixed, srcRectX, srcRectY);
+    sprite.colorMod = SafeGetColor(t, "color_mod", Constants::kUint8Max, Constants::kUint8Max, Constants::kUint8Max,
+                                   Constants::kUint8Max);
+    // "alpha" is a convenience alias for color_mod.a; when both are given, alpha wins.
+    sprite.colorMod.a =
+        static_cast<std::uint8_t>(SafeGetOptionalValue<int>(t, "alpha", static_cast<int>(sprite.colorMod.a)));
+    sprite.blendMode = octarine::BlendModeFromString(SafeGetOptionalValue<std::string>(t, "blend_mode", "blend"));
+    return sprite;
   }
 
   static void bindUsertype(sol::state& lua) {
-    lua.new_usertype<SpriteComponent>(kUsertypeName, "width", sol::readonly(&SpriteComponent::width), "height",
-                                      sol::readonly(&SpriteComponent::height), "layer", &SpriteComponent::layer,
-                                      "asset_id", sol::readonly(&SpriteComponent::assetId));
+    lua.new_usertype<SpriteComponent>(
+        kUsertypeName, "width", sol::readonly(&SpriteComponent::width), "height",
+        sol::readonly(&SpriteComponent::height), "layer", &SpriteComponent::layer, "asset_id",
+        sol::readonly(&SpriteComponent::assetId), "color_mod", &SpriteComponent::colorMod, "alpha",
+        sol::property([](const SpriteComponent& s) { return s.colorMod.a; },
+                      [](SpriteComponent& s, const std::uint8_t alpha) { s.colorMod.a = alpha; }),
+        "blend_mode",
+        sol::property([](const SpriteComponent& s) { return octarine::ToString(s.blendMode); },
+                      [](SpriteComponent& s, const std::string_view mode) {
+                        s.blendMode = octarine::BlendModeFromString(mode, s.blendMode);
+                      }));
   }
 };

--- a/src/Lua/Bindings/SquarePrimitiveComponentLuaBinding.h
+++ b/src/Lua/Bindings/SquarePrimitiveComponentLuaBinding.h
@@ -1,8 +1,11 @@
 #pragma once
 
 #include <sol/sol.hpp>
+#include <string>
+#include <string_view>
 
 #include "Components/SquarePrimitiveComponent.h"
+#include "General/BlendMode.h"
 #include "Lua/Bindings/LuaBinding.h"
 
 template <>
@@ -19,13 +22,19 @@ struct LuaBinding<SquarePrimitiveComponent> {
     const auto height = SafeGetOptionalValue<float>(t, "height", 0.0f);
     const octarine::Color color = SafeGetColor(t, "color");
     const auto fixed = SafeGetOptionalValue<bool>(t, "fixed", false);
-    return SquarePrimitiveComponent(position, layer, width, height, color, fixed);
+    SquarePrimitiveComponent square(position, layer, width, height, color, fixed);
+    square.blendMode = octarine::BlendModeFromString(SafeGetOptionalValue<std::string>(t, "blend_mode", "blend"));
+    return square;
   }
 
   static void bindUsertype(sol::state& lua) {
     lua.new_usertype<SquarePrimitiveComponent>(
         kUsertypeName, "width", &SquarePrimitiveComponent::width, "height", &SquarePrimitiveComponent::height, "color",
         &SquarePrimitiveComponent::color, "position", &SquarePrimitiveComponent::position, "layer",
-        &SquarePrimitiveComponent::layer, "is_fixed", &SquarePrimitiveComponent::isFixed);
+        &SquarePrimitiveComponent::layer, "is_fixed", &SquarePrimitiveComponent::isFixed, "blend_mode",
+        sol::property([](const SquarePrimitiveComponent& s) { return octarine::ToString(s.blendMode); },
+                      [](SquarePrimitiveComponent& s, const std::string_view mode) {
+                        s.blendMode = octarine::BlendModeFromString(mode, s.blendMode);
+                      }));
   }
 };

--- a/src/Renderer/RenderCommands.h
+++ b/src/Renderer/RenderCommands.h
@@ -2,6 +2,29 @@
 
 #include <SDL3/SDL.h>
 
+#include "General/BlendMode.h"
+
+namespace octarine {
+
+// Boundary translation from the backend-agnostic component enum to SDL's sparse constants.
+inline SDL_BlendMode ToSdlBlendMode(const BlendMode mode) {
+  switch (mode) {
+    case BlendMode::None:
+      return SDL_BLENDMODE_NONE;
+    case BlendMode::Add:
+      return SDL_BLENDMODE_ADD;
+    case BlendMode::Mod:
+      return SDL_BLENDMODE_MOD;
+    case BlendMode::Mul:
+      return SDL_BLENDMODE_MUL;
+    case BlendMode::Blend:
+    default:
+      return SDL_BLENDMODE_BLEND;
+  }
+}
+
+}  // namespace octarine
+
 struct SpriteCommand {
   float destX{}, destY{}, destW{}, destH{};
   SDL_FRect srcRect{};
@@ -9,12 +32,16 @@ struct SpriteCommand {
   SDL_FPoint pivot{};
   SDL_FlipMode flip{};
   SDL_Texture* texture{};
+  // Per-draw modulation: rgb tints (multiplies) the texture, alpha fades it. 255 = no-op.
+  SDL_Color colorMod{255, 255, 255, 255};
+  SDL_BlendMode blendMode{SDL_BLENDMODE_BLEND};
 };
 
 struct SquareCommand {
   SDL_FRect destRect{};
   SDL_Color color{};
   double rotation{};
+  SDL_BlendMode blendMode{SDL_BLENDMODE_BLEND};
 };
 
 struct TextCommand {

--- a/src/Renderer/RenderKey.h
+++ b/src/Renderer/RenderKey.h
@@ -18,10 +18,12 @@
 //   bits 63-48 : layer (16 bits, unsigned — 64K layers covers kDebugUIBaseLayer headroom)
 //   bits 47-28 : depthBand + bias (20 bits — ±16M world pixels at 32px bands)
 //   bits 27-24 : type (4 bits)
-//   bits 23- 0 : batchKey hash (24 bits) — clusters same-texture runs within a band so
-//                SDL3's internal renderer can coalesce them. 16M slots makes collisions
-//                vanishingly rare for any realistic texture count; collisions only
-//                degrade batching, never produce wrong pixels.
+//   bits 23-21 : blend mode (3 bits) — clusters same-blend runs within a band so SDL3
+//                doesn't break batches on blend-state changes.
+//   bits 20- 0 : batchKey hash (21 bits) — clusters same-texture runs within a
+//                band+blend so SDL3's internal renderer can coalesce them. 2M slots makes
+//                collisions vanishingly rare for any realistic texture count; collisions
+//                only degrade batching, never produce wrong pixels.
 //
 // type is also stored separately because Renderer::Render dispatches on it to choose the
 // payload union member.
@@ -42,7 +44,8 @@ struct RenderKey {
 
   RenderKey() = default;
 
-  static std::uint64_t ComputeSortKey(unsigned int layer, float depth, RenderableType type, const void* batchKey) {
+  static std::uint64_t ComputeSortKey(unsigned int layer, float depth, RenderableType type, const void* batchKey,
+                                      std::uint8_t blendBits = 0) {
     std::int32_t band = 0;
     if constexpr (Constants::kRenderBatchYBandPx > 0.0f) {
       band = static_cast<std::int32_t>(std::floor(depth / Constants::kRenderBatchYBandPx));
@@ -55,13 +58,15 @@ struct RenderKey {
     const std::uint64_t band20 = static_cast<std::uint64_t>(static_cast<std::uint32_t>(band + kBandBias) & 0xFFFFFu);
     const std::uint64_t type4 = static_cast<std::uint64_t>(static_cast<std::uint8_t>(type)) & 0xFu;
 
-    // 24-bit hash. Shift off allocator alignment noise then XOR-fold; for ~20 textures
-    // mapped into 16M slots the collision probability is effectively zero. nullptr (used
-    // by primitives) hashes to 0, which keeps all primitives clustered.
+    // 21-bit hash. Shift off allocator alignment noise then XOR-fold; for ~20 textures
+    // mapped into 2M slots the collision probability is effectively zero. nullptr (used
+    // by primitives) hashes to 0, which keeps all primitives clustered. Blend mode sits
+    // above the hash so same-blend runs cluster before same-texture runs.
     const auto ptr = reinterpret_cast<std::uintptr_t>(batchKey);
-    const std::uint64_t hash24 = static_cast<std::uint64_t>((ptr >> 4) ^ (ptr >> 28)) & 0xFFFFFFu;
+    const std::uint64_t hash21 = static_cast<std::uint64_t>((ptr >> 4) ^ (ptr >> 25)) & 0x1FFFFFu;
+    const std::uint64_t blend3 = static_cast<std::uint64_t>(blendBits) & 0x7u;
 
-    return (layer16 << 48) | (band20 << 28) | (type4 << 24) | hash24;
+    return (layer16 << 48) | (band20 << 28) | (type4 << 24) | (blend3 << 21) | hash21;
   }
 
   // Kept for completeness; not used by Sort (radix sort uses sortKey directly).

--- a/src/Renderer/RenderQueue.h
+++ b/src/Renderer/RenderQueue.h
@@ -47,16 +47,19 @@ class RenderQueue {
     return *this;
   }
 
-  SpriteCommand& EmplaceSprite(unsigned int layer, float depth, const void* batchKey = nullptr) {
+  SpriteCommand& EmplaceSprite(unsigned int layer, float depth, const void* batchKey = nullptr,
+                               octarine::BlendMode blendMode = octarine::BlendMode::Blend) {
     auto& key = ClaimSlot();
-    key.sortKey = RenderKey::ComputeSortKey(layer, depth, SPRITE, batchKey);
+    key.sortKey = RenderKey::ComputeSortKey(layer, depth, SPRITE, batchKey, static_cast<std::uint8_t>(blendMode));
     key.type = SPRITE;
     return key.payload.sprite;
   }
 
-  SquareCommand& EmplaceSquare(unsigned int layer, float depth, const void* batchKey = nullptr) {
+  SquareCommand& EmplaceSquare(unsigned int layer, float depth, const void* batchKey = nullptr,
+                               octarine::BlendMode blendMode = octarine::BlendMode::Blend) {
     auto& key = ClaimSlot();
-    key.sortKey = RenderKey::ComputeSortKey(layer, depth, SQUARE_PRIMITIVE, batchKey);
+    key.sortKey =
+        RenderKey::ComputeSortKey(layer, depth, SQUARE_PRIMITIVE, batchKey, static_cast<std::uint8_t>(blendMode));
     key.type = SQUARE_PRIMITIVE;
     return key.payload.square;
   }

--- a/src/Renderer/Renderer.cpp
+++ b/src/Renderer/Renderer.cpp
@@ -80,11 +80,19 @@ void Renderer::DrawQueue(const RenderQueue& renderQueue, SDL_Renderer* renderer)
         const auto& cmd = key.payload.sprite;
         const SDL_FRect destRect = {cmd.destX, cmd.destY, cmd.destW, cmd.destH};
         const auto deg = static_cast<float>(cmd.rotation * (180.0 / 3.14159265358979323846));
+        // Modulation state lives on the shared SDL_Texture, so set it on every draw — the
+        // previous sprite using this texture may have left different values behind. Same-state
+        // sets are cheap (SDL just stores them; they apply at draw time).
+        SDL_SetTextureColorMod(cmd.texture, cmd.colorMod.r, cmd.colorMod.g, cmd.colorMod.b);
+        SDL_SetTextureAlphaMod(cmd.texture, cmd.colorMod.a);
+        SDL_SetTextureBlendMode(cmd.texture, cmd.blendMode);
         SDL_RenderTextureRotated(renderer, cmd.texture, &cmd.srcRect, &destRect, deg, &cmd.pivot, cmd.flip);
         break;
       }
       case SQUARE_PRIMITIVE: {
         const auto& cmd = key.payload.square;
+        // Applies to both the fill-rect and the SDL_RenderGeometry (untextured) path.
+        SDL_SetRenderDrawBlendMode(renderer, cmd.blendMode);
         if (cmd.rotation == 0.0) {
           SDL_SetRenderDrawColor(renderer, cmd.color.r, cmd.color.g, cmd.color.b, cmd.color.a);
           SDL_RenderFillRect(renderer, &cmd.destRect);

--- a/src/Systems/RenderPrimitiveSystem.h
+++ b/src/Systems/RenderPrimitiveSystem.h
@@ -42,10 +42,12 @@ class RenderPrimitiveSystem {
     const float x = square.isFixed ? origin.x : origin.x - camera_.x;
     const float y = square.isFixed ? origin.y : origin.y - camera_.y;
 
-    auto& cmd = renderQueue_->EmplaceSquare(static_cast<unsigned int>(square.layer), square.position.y);
+    auto& cmd = renderQueue_->EmplaceSquare(static_cast<unsigned int>(square.layer), square.position.y, nullptr,
+                                            square.blendMode);
     cmd.destRect = {x, y, square.width, square.height};
     cmd.color = SDL_Color{square.color.r, square.color.g, square.color.b, square.color.a};
     cmd.rotation = transform.rotation;
+    cmd.blendMode = octarine::ToSdlBlendMode(square.blendMode);
   }
 
  private:

--- a/src/Systems/RenderSpriteSystem.h
+++ b/src/Systems/RenderSpriteSystem.h
@@ -73,7 +73,8 @@ class RenderSpriteSystem {
     const float x = sprite.isFixed ? transform.position.x : transform.position.x - camera_.x;
     const float y = sprite.isFixed ? transform.position.y : transform.position.y - camera_.y;
 
-    auto& cmd = renderQueue_->EmplaceSprite(static_cast<unsigned int>(sprite.layer), transform.position.y, texture);
+    auto& cmd = renderQueue_->EmplaceSprite(static_cast<unsigned int>(sprite.layer), transform.position.y, texture,
+                                            sprite.blendMode);
     cmd.destX = x;
     cmd.destY = y;
     cmd.destW = sprite.width * transform.scale.x;
@@ -89,6 +90,8 @@ class RenderSpriteSystem {
     cmd.pivot = {cmd.destW * 0.5f, cmd.destH * 0.5f};
     cmd.flip = static_cast<SDL_FlipMode>(sprite.flip);
     cmd.texture = texture;
+    cmd.colorMod = SDL_Color{sprite.colorMod.r, sprite.colorMod.g, sprite.colorMod.b, sprite.colorMod.a};
+    cmd.blendMode = octarine::ToSdlBlendMode(sprite.blendMode);
   }
 
  private:

--- a/tests/AssetStoreTest.cpp
+++ b/tests/AssetStoreTest.cpp
@@ -1,0 +1,201 @@
+// Typed-store lifecycle checks beyond AssetRefcounterTest's pure bookkeeping: TextureStore
+// handle ownership + generation bumps, and AssetManager's Acquire/Release orchestration,
+// hot-reload swap path, and missing-asset error paths — all against a real (software, headless)
+// SDL renderer and a temp-dir catalog built at runtime, since the checked-in fixture images are
+// placeholder bytes that don't decode. gtest-free; exit code is the number of failed checks.
+// Registered with ctest as AssetStoreTest.
+
+#include <SDL3/SDL.h>
+
+#include <sol/sol.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "AssetManager/AssetCatalog.h"
+#include "AssetManager/AssetManager.h"
+#include "AssetManager/TextureStore.h"
+#include "General/Logger.h"
+#include "TestHarness.h"
+#include "stb/stb_image_write.h"  // header-only; IMPL lives in AtlasBaker.cpp
+
+using octarine::test::Check;
+using octarine::test::CheckEq;
+
+namespace {
+
+// Write a real, decodable PNG (solid color) so IMG_LoadTexture_IO succeeds.
+bool WritePng(const std::string& path, const unsigned char r, const unsigned char g, const unsigned char b) {
+  std::vector<unsigned char> pixels;
+  pixels.reserve(8 * 8 * 4);
+  for (int i = 0; i < 8 * 8; ++i) {
+    pixels.push_back(r);
+    pixels.push_back(g);
+    pixels.push_back(b);
+    pixels.push_back(255);
+  }
+  return stbi_write_png(path.c_str(), 8, 8, 4, pixels.data(), 8 * 4) != 0;
+}
+
+}  // namespace
+
+int main() {
+  Logger::Init();
+
+  // Headless render target: a software renderer over a plain surface needs no window, no GPU,
+  // and no video driver — exactly what the store needs to create real SDL_Texture handles in CI.
+  SDL_Init(0);
+  SDL_Surface* surface = SDL_CreateSurface(64, 64, SDL_PIXELFORMAT_RGBA32);
+  SDL_Renderer* renderer = surface != nullptr ? SDL_CreateSoftwareRenderer(surface) : nullptr;
+  Check(renderer != nullptr, "software renderer created headlessly");
+  if (renderer == nullptr) return octarine::test::ReportSummary("AssetStoreTest");
+
+  const std::filesystem::path tmpDir = std::filesystem::temp_directory_path() / "octarine_asset_store_test";
+  std::error_code ec;
+  std::filesystem::remove_all(tmpDir, ec);
+  std::filesystem::create_directories(tmpDir / "images", ec);
+
+  std::cout << "[texture store] add / replace / remove drive the generation counter\n";
+  {
+    const std::string pngPath = (tmpDir / "images" / "store.png").string();
+    Check(WritePng(pngPath, 255, 0, 0), "test PNG written");
+
+    TextureStore store;
+    const std::uint64_t gen0 = store.Generation();
+
+    SDL_Texture* added = store.Add(renderer, "store", SDL_IOFromFile(pngPath.c_str(), "rb"), pngPath);
+    Check(added != nullptr, "Add returns the resident texture");
+    Check(store.Get("store") == added && store.Contains("store"), "Get/Contains resolve the added id");
+    CheckEq(store.Generation(), gen0 + 1, "Add bumps the generation");
+
+    SDL_Texture* replaced = store.Add(renderer, "store", SDL_IOFromFile(pngPath.c_str(), "rb"), pngPath);
+    Check(replaced != nullptr && store.Get("store") == replaced, "re-Add under the same id replaces the handle");
+    CheckEq(store.Generation(), gen0 + 2, "replace bumps the generation");
+
+    // Undecodable bytes: loader fails, store state and generation stay untouched.
+    const std::string bogusPath = (tmpDir / "images" / "bogus.txt").string();
+    std::ofstream(bogusPath) << "not an image";
+    SDL_Texture* bogus = store.Add(renderer, "bogus", SDL_IOFromFile(bogusPath.c_str(), "rb"), bogusPath);
+    Check(bogus == nullptr, "Add returns nullptr for undecodable bytes");
+    Check(!store.Contains("bogus"), "failed load leaves no store entry");
+    CheckEq(store.Generation(), gen0 + 2, "failed load does not bump the generation");
+
+    Check(store.Remove("store"), "Remove reports an erased entry");
+    Check(store.Get("store") == nullptr, "removed id no longer resolves");
+    CheckEq(store.Generation(), gen0 + 3, "Remove bumps the generation");
+    Check(!store.Remove("store"), "second Remove is a no-op");
+    CheckEq(store.Generation(), gen0 + 3, "no-op Remove does not bump the generation");
+  }
+
+  std::cout << "[asset manager] acquire/release lifecycle against a runtime catalog\n";
+  {
+    Check(WritePng((tmpDir / "images" / "sprite.png").string(), 0, 255, 0), "catalog PNG written");
+
+    sol::state lua;
+    lua.open_libraries(sol::lib::base, sol::lib::table);
+
+    AssetManager manager;
+    Check(manager.GetCatalog().Build(tmpDir.string(), lua, std::optional<ScaleMode>(ScaleMode::Nearest)),
+          "catalog builds over the temp asset tree");
+    Check(manager.GetCatalog().Find("sprite") != nullptr, "catalog indexed the texture id");
+
+    // Missing-asset error path: unknown ids fail without touching the stores.
+    Check(!manager.Acquire("definitely_missing", renderer, nullptr), "Acquire of an unknown id returns false");
+    CheckEq(manager.RefCount("definitely_missing"), 0, "failed Acquire leaves no refcount");
+
+    Check(manager.Acquire("sprite", renderer, nullptr), "first Acquire loads the texture");
+    Check(manager.GetTexture("sprite") != nullptr, "texture resident after Acquire");
+    CheckEq(manager.RefCount("sprite"), 1, "first Acquire counts 1");
+
+    const std::uint64_t genAfterLoad = manager.TextureGeneration();
+    Check(manager.Acquire("sprite", renderer, nullptr), "second Acquire succeeds");
+    CheckEq(manager.RefCount("sprite"), 2, "second Acquire counts 2");
+    CheckEq(manager.TextureGeneration(), genAfterLoad, "re-Acquire does not reload (generation unchanged)");
+
+    manager.Release("sprite");
+    CheckEq(manager.RefCount("sprite"), 1, "Release walks the count down");
+    Check(manager.GetTexture("sprite") != nullptr, "still resident while referenced");
+
+    manager.Release("sprite");
+    CheckEq(manager.RefCount("sprite"), 0, "last Release zeroes the count");
+    Check(manager.GetTexture("sprite") == nullptr, "last Release unloads the handle");
+
+    manager.Release("sprite");  // untracked — must be ignored, not underflow
+    CheckEq(manager.RefCount("sprite"), 0, "Release of an untracked id is a no-op");
+
+    Check(manager.Acquire("sprite", renderer, nullptr), "id is re-acquirable after full release");
+    CheckEq(manager.RefCount("sprite"), 1, "re-acquire restarts the count at 1");
+    manager.Release("sprite");
+  }
+
+  std::cout << "[asset manager] hot-reload swap preserves references, bumps the generation\n";
+  {
+    const std::string spritePath = (tmpDir / "images" / "swap.png").string();
+    Check(WritePng(spritePath, 0, 0, 255), "initial swap PNG written");
+
+    sol::state lua;
+    lua.open_libraries(sol::lib::base, sol::lib::table);
+
+    AssetManager manager;
+    Check(manager.GetCatalog().Build(tmpDir.string(), lua, std::optional<ScaleMode>(ScaleMode::Nearest)),
+          "catalog builds for the reload run");
+
+    Check(!manager.Reload("swap", renderer, nullptr), "Reload of a non-resident id is a no-op");
+    Check(!manager.Reload("definitely_missing", renderer, nullptr), "Reload of an unknown id is a no-op");
+
+    Check(manager.Acquire("swap", renderer, nullptr), "texture acquired before reload");
+    Check(manager.Acquire("swap", renderer, nullptr), "second reference taken before reload");
+    const std::uint64_t genBefore = manager.TextureGeneration();
+
+    // New bytes on disk, then the dev hot-push path: handle swaps, refcount must survive.
+    Check(WritePng(spritePath, 255, 255, 0), "swap PNG overwritten with new bytes");
+    Check(manager.Reload("swap", renderer, nullptr), "Reload swaps the resident handle");
+    Check(manager.GetTexture("swap") != nullptr, "texture resident after reload");
+    CheckEq(manager.RefCount("swap"), 2, "reload preserves the acquire count");
+    Check(manager.TextureGeneration() > genBefore, "reload bumps the texture generation");
+
+    // Path-driven variant used by the file watcher: resolves the absolute path back to its ids.
+    CheckEq(manager.ReloadByPath(spritePath, renderer, nullptr), 1, "ReloadByPath reloads the backing id");
+    CheckEq(manager.ReloadByPath((tmpDir / "images" / "unknown.png").string(), renderer, nullptr), 0,
+            "ReloadByPath of an untracked path reloads nothing");
+
+    const std::vector<std::string> resident = manager.ResidentSourcePaths();
+    Check(std::find(resident.begin(), resident.end(),
+                    manager.GetCatalog().Find("swap")->fullPath) != resident.end(),
+          "ResidentSourcePaths reports the resident texture's source file");
+
+    manager.ReleaseAll({"swap", "swap"});
+    Check(manager.GetTexture("swap") == nullptr, "ReleaseAll drops both references");
+  }
+
+  std::cout << "[asset manager] audio acquire fails cleanly with no mixer\n";
+  {
+    // The headless/disabled-audio path: a catalog audio entry acquired with a null mixer must
+    // report failure (and leave no refcount) instead of crashing or half-loading.
+    std::filesystem::create_directories(tmpDir / "sounds", ec);
+    std::ofstream((tmpDir / "sounds" / "clip.wav").string(), std::ios::binary) << "RIFF stub";
+
+    sol::state lua;
+    lua.open_libraries(sol::lib::base, sol::lib::table);
+
+    AssetManager manager;
+    Check(manager.GetCatalog().Build(tmpDir.string(), lua, std::optional<ScaleMode>(ScaleMode::Nearest)),
+          "catalog builds with the audio entry");
+    Check(manager.GetCatalog().Find("clip") != nullptr, "catalog indexed the audio id");
+    Check(!manager.Acquire("clip", renderer, nullptr), "audio Acquire with null mixer returns false");
+    CheckEq(manager.RefCount("clip"), 0, "failed audio Acquire leaves no refcount");
+  }
+
+  SDL_DestroyRenderer(renderer);
+  SDL_DestroySurface(surface);
+  std::filesystem::remove_all(tmpDir, ec);
+  SDL_Quit();
+
+  return octarine::test::ReportSummary("AssetStoreTest");
+}

--- a/tests/RenderQueueTest.cpp
+++ b/tests/RenderQueueTest.cpp
@@ -1,0 +1,168 @@
+// Unit checks for RenderKey::ComputeSortKey packing and RenderQueue's radix sort: field
+// precedence (layer > depth band > type > blend > batch hash), tie stability, and the
+// clustering invariants the renderer's draw batching relies on. gtest-free; exit code is
+// the number of failed checks. Registered with ctest as RenderQueueTest.
+
+#include <SDL3/SDL.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "General/BlendMode.h"
+#include "General/Constants.h"
+#include "Renderer/RenderKey.h"
+#include "Renderer/RenderQueue.h"
+#include "TestHarness.h"
+
+using octarine::BlendMode;
+using octarine::test::Check;
+using octarine::test::CheckEq;
+
+namespace {
+
+std::uint64_t Key(const unsigned int layer, const float depth, const RenderableType type, const void* batchKey,
+                  const BlendMode blend = BlendMode::Blend) {
+  return RenderKey::ComputeSortKey(layer, depth, type, batchKey, static_cast<std::uint8_t>(blend));
+}
+
+// Fake texture handles — ComputeSortKey only hashes the pointer value. 64-byte alignment keeps
+// the two values apart in the bits the hash actually reads (it shifts off the low 4).
+alignas(64) char g_texMemA[64];
+alignas(64) char g_texMemB[64];
+
+}  // namespace
+
+int main() {
+  const void* texA = g_texMemA;
+  const void* texB = g_texMemB;
+
+  std::cout << "[sortkey] field precedence\n";
+  {
+    Check(Key(1, 0.0f, SPRITE, nullptr) > Key(0, 1000000.0f, SPRITE, nullptr),
+          "layer outranks any depth difference");
+    Check(Key(0, 2.0f * Constants::kRenderBatchYBandPx, SPRITE, nullptr) > Key(0, 0.0f, SPRITE, nullptr),
+          "deeper band sorts later within a layer");
+    CheckEq(Key(0, 0.0f, SPRITE, nullptr), Key(0, Constants::kRenderBatchYBandPx - 1.0f, SPRITE, nullptr),
+            "depths inside one band share a key");
+    Check(Key(0, -2.0f * Constants::kRenderBatchYBandPx, SPRITE, nullptr) < Key(0, 0.0f, SPRITE, nullptr),
+          "negative depth sorts before zero (band bias)");
+    Check(Key(0, 0.0f, SPRITE, nullptr) != Key(0, 0.0f, SQUARE_PRIMITIVE, nullptr), "type participates in the key");
+    Check(Key(0, 0.0f, SPRITE, texA) != Key(0, 0.0f, SPRITE, texB), "distinct textures get distinct batch hashes");
+    CheckEq(Key(0, 0.0f, SPRITE, texA), Key(0, 0.0f, SPRITE, texA), "key is deterministic");
+    // Blend sits above the texture hash inside the batch bits, so every same-blend run clusters
+    // before texture clustering — regardless of which texture pointers are involved.
+    Check(Key(0, 0.0f, SPRITE, texA, BlendMode::Blend) < Key(0, 0.0f, SPRITE, texB, BlendMode::Add) &&
+              Key(0, 0.0f, SPRITE, texB, BlendMode::Blend) < Key(0, 0.0f, SPRITE, texA, BlendMode::Add),
+          "blend mode outranks texture hash");
+  }
+
+  std::cout << "[sort] orders by key, ties keep insertion order\n";
+  {
+    RenderQueue queue(1024);
+    // Three layers emplaced in reverse; four entries per layer marked with their insertion index.
+    int idx = 0;
+    for (const unsigned int layer : {2u, 1u, 0u}) {
+      for (int i = 0; i < 4; ++i) {
+        auto& cmd = queue.EmplaceSprite(layer, 0.0f, texA);
+        cmd.destX = static_cast<float>(idx++);
+      }
+    }
+    queue.Sort();
+    CheckEq(queue.Size(), static_cast<size_t>(12), "Size unchanged by Sort");
+
+    bool ascending = true;
+    std::vector<float> markers;
+    std::uint64_t prev = 0;
+    for (const RenderKey& key : queue) {
+      if (!markers.empty() && key.sortKey < prev) ascending = false;
+      prev = key.sortKey;
+      markers.push_back(key.payload.sprite.destX);
+    }
+    Check(ascending, "sortKey is non-decreasing after Sort");
+    Check(markers[0] == 8 && markers[4] == 4 && markers[8] == 0, "layer groups come out 0, 1, 2");
+    bool stable = true;
+    for (int group = 0; group < 3; ++group) {
+      for (int i = 1; i < 4; ++i) {
+        if (markers[group * 4 + i] != markers[group * 4 + i - 1] + 1.0f) stable = false;
+      }
+    }
+    Check(stable, "tied keys keep insertion order (stable radix passes)");
+  }
+
+  std::cout << "[sort] blend + texture clustering within one layer/band\n";
+  {
+    RenderQueue queue(1024);
+    // Worst-case interleave of (blend, texture) combos: 16 sprites alternating blend every entry
+    // and texture every other entry. After Sort the queue must contain exactly one blend boundary
+    // and one texture boundary inside each blend run.
+    const BlendMode blends[2] = {BlendMode::Blend, BlendMode::Add};
+    const void* textures[2] = {texA, texB};
+    for (int i = 0; i < 16; ++i) {
+      const BlendMode blend = blends[i % 2];
+      const void* texture = textures[(i / 2) % 2];
+      auto& cmd = queue.EmplaceSprite(0, 0.0f, texture, blend);
+      cmd.texture = static_cast<SDL_Texture*>(const_cast<void*>(texture));
+      cmd.blendMode = octarine::ToSdlBlendMode(blend);
+    }
+    queue.Sort();
+
+    int blendTransitions = 0;
+    int textureTransitions = 0;
+    SDL_BlendMode prevBlend{};
+    SDL_Texture* prevTexture{};
+    bool first = true;
+    for (const RenderKey& key : queue) {
+      const auto& cmd = key.payload.sprite;
+      if (!first) {
+        if (cmd.blendMode != prevBlend) {
+          ++blendTransitions;
+        } else if (cmd.texture != prevTexture) {
+          ++textureTransitions;
+        }
+      }
+      prevBlend = cmd.blendMode;
+      prevTexture = cmd.texture;
+      first = false;
+    }
+    CheckEq(blendTransitions, 1, "same-blend runs cluster (one blend boundary)");
+    CheckEq(textureTransitions, 2, "textures cluster within each blend run");
+  }
+
+  std::cout << "[sort] type clusters within one layer/band\n";
+  {
+    RenderQueue queue(256);
+    queue.EmplaceSquare(0, 0.0f);
+    queue.EmplaceSprite(0, 0.0f, texA);
+    queue.EmplaceText(0, 0.0f);
+    queue.EmplaceSquare(0, 0.0f);
+    queue.EmplaceSprite(0, 0.0f, texA);
+    queue.Sort();
+
+    int typeTransitions = 0;
+    RenderableType prevType{};
+    bool first = true;
+    for (const RenderKey& key : queue) {
+      if (!first && key.type != prevType) ++typeTransitions;
+      prevType = key.type;
+      first = false;
+    }
+    CheckEq(typeTransitions, 2, "three types -> two type boundaries");
+  }
+
+  std::cout << "[lifecycle] Clear resets, queue is reusable\n";
+  {
+    RenderQueue queue(64);
+    queue.EmplaceSprite(0, 0.0f, nullptr);
+    Check(!queue.IsEmpty(), "queue non-empty after emplace");
+    queue.Clear();
+    Check(queue.IsEmpty() && queue.Size() == 0 && queue.begin() == queue.end(), "Clear resets the queue");
+    auto& cmd = queue.EmplaceSprite(0, 0.0f, nullptr);
+    cmd.destX = 42.0f;
+    queue.Sort();
+    CheckEq(queue.Size(), static_cast<size_t>(1), "queue reusable after Clear");
+    CheckEq(queue.begin()->payload.sprite.destX, 42.0f, "payload survives the post-Clear sort");
+  }
+
+  return octarine::test::ReportSummary("RenderQueueTest");
+}


### PR DESCRIPTION
## What

Two new ctest suites closing the coverage gap on the render queue and asset stores. Stacked on #152 (the blend-clustering checks exercise the blend bits #152 adds to the sort key); GitHub will retarget this to `main` when that merges.

**RenderQueueTest**
- `RenderKey::ComputeSortKey` field precedence: layer > depth band > type > blend > batch hash, band sharing, negative-depth bias, hash determinism.
- Radix sort: keys non-decreasing, ties keep insertion order (stability), `Size` unchanged.
- Clustering invariants the draw batching relies on: one blend boundary across a worst-case interleave, textures clustered within each blend run, types clustered within a band.
- `Clear`/reuse lifecycle.

**AssetStoreTest**
- `TextureStore`: add/replace/remove drive the generation counter, failed decode leaves no entry and no bump, handle ownership.
- `AssetManager` acquire/release: refcount walk-up/down, unload at zero, untracked-release no-op, re-acquire after full release, re-acquire does not reload.
- Hot-reload swap: `Reload` preserves the acquire count and bumps the texture generation; non-resident/unknown ids are no-ops; `ReloadByPath` resolves a source path back to its id; `ResidentSourcePaths` reports the file.
- Error paths: unknown id acquire, audio acquire with a null mixer (headless/disabled-audio).

Runs fully headless via `SDL_CreateSoftwareRenderer` over a plain surface — no window, video driver, or GPU — and builds its catalog over a temp dir with PNGs written at runtime (the checked-in fixture images are placeholder bytes that don't decode).

## Skipped (and why)

A golden-image smoke via the headless frame capture was considered and deliberately not included: BMP output depends on renderer backend rasterization (software vs. GPU paths differ per runner), so it would be flaky across CI hosts. The Stage-4 PR verified pixels manually with the software path instead.

## Verification

Full ctest suite (19 tests including the two new ones) green on Windows/MSVC editor-debug.
