### PR TITLE
Show runtime script errors as an on-screen toast in ImGui builds

### DIFF
--- a/src/General/Logger.cpp
+++ b/src/General/Logger.cpp
@@ -16,6 +16,8 @@
 std::shared_ptr<spdlog::logger> Logger::lua_logger_;
 std::vector<std::string> Logger::history_;
 std::mutex Logger::history_mutex_;
+std::vector<Logger::ScriptError> Logger::script_errors_;
+std::uint64_t Logger::script_error_sequence_ = 0;
 
 namespace {
 
@@ -110,6 +112,13 @@ void Logger::ErrorLua(const std::string& message) {
   lua_logger_->error(message);
   std::lock_guard<std::mutex> lock(history_mutex_);
   history_.push_back("[Error] [Lua] " + message);
+  // Small ring, not full history: the toast only ever shows the tail, and capping here keeps a
+  // misbehaving per-frame error loop from growing memory.
+  constexpr size_t kMaxScriptErrors = 8;
+  script_errors_.push_back({++script_error_sequence_, message, std::chrono::steady_clock::now()});
+  if (script_errors_.size() > kMaxScriptErrors) {
+    script_errors_.erase(script_errors_.begin());
+  }
 }
 
 void Logger::WarnLua(const std::string& message) {
@@ -139,4 +148,9 @@ void Logger::ForEachHistory(const std::function<void(const std::string&)>& callb
 void Logger::ClearHistory() {
   std::lock_guard<std::mutex> lock(history_mutex_);
   history_.clear();
+}
+
+std::vector<Logger::ScriptError> Logger::RecentScriptErrors() {
+  std::lock_guard<std::mutex> lock(history_mutex_);
+  return script_errors_;
 }

--- a/src/General/Logger.h
+++ b/src/General/Logger.h
@@ -2,15 +2,30 @@
 
 #include <spdlog/logger.h>
 
+#include <chrono>
+#include <cstdint>
 #include <memory>
 #include <mutex>
 #include <string>
 #include <vector>
 
 class Logger {
+ public:
+  // One captured Lua script error for the editor's on-screen toast. `sequence` increases
+  // monotonically across the run so consumers can tell new errors from re-reads; `when` lets
+  // the toast expire entries by age.
+  struct ScriptError {
+    std::uint64_t sequence{};
+    std::string message;
+    std::chrono::steady_clock::time_point when{};
+  };
+
+ private:
   static std::shared_ptr<spdlog::logger> lua_logger_;
   static std::vector<std::string> history_;
   static std::mutex history_mutex_;
+  static std::vector<ScriptError> script_errors_;
+  static std::uint64_t script_error_sequence_;
 
  public:
   static void Init();
@@ -29,4 +44,9 @@ class Logger {
   static std::vector<std::string> GetHistory();
   static void ForEachHistory(const std::function<void(const std::string&)>& callback);
   static void ClearHistory();
+
+  // Snapshot of the most recent script errors (newest last), capped to a small ring. Fed by
+  // ErrorLua — i.e. every runtime Lua failure that log-and-continues — and consumed by the
+  // editor-build error toast so script failures stay visible when the console is hidden.
+  static std::vector<ScriptError> RecentScriptErrors();
 };

--- a/src/Systems/RenderDebugGUISystem.cpp
+++ b/src/Systems/RenderDebugGUISystem.cpp
@@ -134,8 +134,8 @@ namespace {
 constexpr double kScriptErrorToastSeconds = 10.0;
 
 bool IsToastFresh(const Logger::ScriptError& error) {
-  const auto age = std::chrono::duration_cast<std::chrono::duration<double>>(std::chrono::steady_clock::now() -
-                                                                             error.when);
+  const auto age =
+      std::chrono::duration_cast<std::chrono::duration<double>>(std::chrono::steady_clock::now() - error.when);
   return age.count() < kScriptErrorToastSeconds;
 }
 }  // namespace

--- a/src/Systems/RenderDebugGUISystem.cpp
+++ b/src/Systems/RenderDebugGUISystem.cpp
@@ -132,6 +132,9 @@ namespace {
 // How long one script error stays on screen. Each new error restarts the clock for itself only,
 // so a burst shows its tail and quiet errors age out individually.
 constexpr double kScriptErrorToastSeconds = 10.0;
+constexpr float kToastBgAlpha = 0.85f;
+constexpr float kToastWrapWidthPx = 420.0f;
+constexpr ImVec4 kToastHeaderColor{1.0f, 0.35f, 0.35f, 1.0f};
 
 bool IsToastFresh(const Logger::ScriptError& error) {
   const auto age =
@@ -159,16 +162,16 @@ void RenderDebugGUISystem::ScriptErrorToastWindow() {
   ImGui::SetNextWindowPos(ImVec2(viewport->WorkPos.x + viewport->WorkSize.x - kMargin,
                                  viewport->WorkPos.y + viewport->WorkSize.y - kMargin),
                           ImGuiCond_Always, ImVec2(1.0f, 1.0f));
-  ImGui::SetNextWindowBgAlpha(0.85f);
+  ImGui::SetNextWindowBgAlpha(kToastBgAlpha);
   constexpr ImGuiWindowFlags kFlags = ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoMove |
                                       ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoFocusOnAppearing |
                                       ImGuiWindowFlags_NoNav | ImGuiWindowFlags_NoInputs |
                                       ImGuiWindowFlags_AlwaysAutoResize;
   ImGui::Begin("##script-error-toast", nullptr, kFlags);
-  ImGui::TextColored(ImVec4(1.0f, 0.35f, 0.35f, 1.0f), "Script error%s (%d)", fresh.size() == 1 ? "" : "s",
+  ImGui::TextColored(kToastHeaderColor, "Script error%s (%d)", fresh.size() == 1 ? "" : "s",
                      static_cast<int>(fresh.size()));
   ImGui::Separator();
-  ImGui::PushTextWrapPos(420.0f);
+  ImGui::PushTextWrapPos(kToastWrapWidthPx);
   for (const auto* error : fresh) {
     ImGui::TextWrapped("%s", error->message.c_str());
   }

--- a/src/Systems/RenderDebugGUISystem.cpp
+++ b/src/Systems/RenderDebugGUISystem.cpp
@@ -1,6 +1,10 @@
 #include "RenderDebugGUISystem.h"
 
 #ifdef OCTARINE_WITH_IMGUI
+#include <algorithm>
+#include <chrono>
+#include <vector>
+
 #include "Game/Game.h"
 #include "Game/GameConfig.h"
 #include "General/PerfUtils.h"
@@ -36,15 +40,20 @@ void RenderDebugGUISystem::Render(Game* game, SDL_Renderer* renderer, [[maybe_un
 #endif
   const bool showGameOverlays = engineOptions.showDebugGUI;
 
+  // The toast must survive every "nothing else to draw" early-out below, otherwise a script
+  // error in a from-editor play session (editor chrome hidden, overlays off) stays invisible —
+  // the exact failure mode it exists to surface.
+  const bool toastActive = HasActiveScriptErrorToast();
+
 #ifdef OCTARINE_WITH_EDITOR
-  if (!showEditorUI && !showGameOverlays && !engineOptions.showFpsCounter) {
+  if (!showEditorUI && !showGameOverlays && !engineOptions.showFpsCounter && !toastActive) {
     return;
   }
 #else
   // Player-with-ImGui build: the ImGui FPS window is editor-only (showFpsCounter is ignored here);
   // the player-facing FPS readout is the renderer perf overlay (PerfOverlay config). So nothing
-  // ImGui draws unless the in-game debug overlays are toggled on.
-  if (!showGameOverlays) {
+  // ImGui draws unless the in-game debug overlays are toggled on or a script error is toasting.
+  if (!showGameOverlays && !toastActive) {
     return;
   }
 #endif
@@ -86,6 +95,10 @@ void RenderDebugGUISystem::Render(Game* game, SDL_Renderer* renderer, [[maybe_un
   octarine::editor::panels::DrawProjectSelectorIfNeeded(game, projectLoaded);
 #endif
 
+  if (toastActive) {
+    ScriptErrorToastWindow();
+  }
+
   ImGui::Render();
   ImGui_ImplSDLRenderer3_RenderDrawData(ImGui::GetDrawData(), renderer);
 
@@ -112,6 +125,54 @@ void RenderDebugGUISystem::EntityInfoWindow(const Registry* registry) {
   const auto count = registry->GetUserEntityCount();
   ImGui::Begin("Entity Info");
   ImGui::Text("Entity Count: %llu", static_cast<unsigned long long>(count));
+  ImGui::End();
+}
+
+namespace {
+// How long one script error stays on screen. Each new error restarts the clock for itself only,
+// so a burst shows its tail and quiet errors age out individually.
+constexpr double kScriptErrorToastSeconds = 10.0;
+
+bool IsToastFresh(const Logger::ScriptError& error) {
+  const auto age = std::chrono::duration_cast<std::chrono::duration<double>>(std::chrono::steady_clock::now() -
+                                                                             error.when);
+  return age.count() < kScriptErrorToastSeconds;
+}
+}  // namespace
+
+bool RenderDebugGUISystem::HasActiveScriptErrorToast() {
+  const auto errors = Logger::RecentScriptErrors();
+  return std::any_of(errors.begin(), errors.end(), [](const Logger::ScriptError& e) { return IsToastFresh(e); });
+}
+
+void RenderDebugGUISystem::ScriptErrorToastWindow() {
+  const auto errors = Logger::RecentScriptErrors();
+  std::vector<const Logger::ScriptError*> fresh;
+  for (const auto& error : errors) {
+    if (IsToastFresh(error)) fresh.push_back(&error);
+  }
+  if (fresh.empty()) return;
+
+  // Bottom-right overlay: no decoration, no focus steal, no input capture — purely informative.
+  const ImGuiViewport* viewport = ImGui::GetMainViewport();
+  constexpr float kMargin = 12.0f;
+  ImGui::SetNextWindowPos(ImVec2(viewport->WorkPos.x + viewport->WorkSize.x - kMargin,
+                                 viewport->WorkPos.y + viewport->WorkSize.y - kMargin),
+                          ImGuiCond_Always, ImVec2(1.0f, 1.0f));
+  ImGui::SetNextWindowBgAlpha(0.85f);
+  constexpr ImGuiWindowFlags kFlags = ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoMove |
+                                      ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoFocusOnAppearing |
+                                      ImGuiWindowFlags_NoNav | ImGuiWindowFlags_NoInputs |
+                                      ImGuiWindowFlags_AlwaysAutoResize;
+  ImGui::Begin("##script-error-toast", nullptr, kFlags);
+  ImGui::TextColored(ImVec4(1.0f, 0.35f, 0.35f, 1.0f), "Script error%s (%d)", fresh.size() == 1 ? "" : "s",
+                     static_cast<int>(fresh.size()));
+  ImGui::Separator();
+  ImGui::PushTextWrapPos(420.0f);
+  for (const auto* error : fresh) {
+    ImGui::TextWrapped("%s", error->message.c_str());
+  }
+  ImGui::PopTextWrapPos();
   ImGui::End();
 }
 #endif

--- a/src/Systems/RenderDebugGUISystem.h
+++ b/src/Systems/RenderDebugGUISystem.h
@@ -32,5 +32,9 @@ class RenderDebugGUISystem {
  private:
   static void FPSWindow(float deltaTime);
   static void EntityInfoWindow(const Registry* registry);
+  // True while any recent script error is inside its toast window — used both to draw the toast
+  // and to keep the ImGui frame alive when nothing else would render it.
+  static bool HasActiveScriptErrorToast();
+  static void ScriptErrorToastWindow();
 };
 #endif


### PR DESCRIPTION
## What

Runtime Lua errors log-and-continue through the sol exception handler, which makes them invisible whenever the console is hidden. This adds an on-screen toast in ImGui-enabled builds:

- `Logger` keeps a small ring (8 entries) of recent script errors, fed by `ErrorLua` — every script failure path already routes through it (sol exception handler, `ScriptSystem` update errors, `on_debug_gui` errors, hot-reload failures, `log_e`). Each entry carries a monotonic sequence and a steady-clock timestamp; `RecentScriptErrors()` snapshots it under the existing history mutex.
- `RenderDebugGUISystem` draws a bottom-right overlay (no decoration, no input capture) listing errors younger than 10 seconds, wrapped, with a count header. Entries age out individually.
- The toast survives the "nothing else to draw" early-outs: a script error during a from-editor play session (editor chrome hidden, overlays off) still keeps the ImGui frame alive while the toast is active — the exact failure mode this exists to surface. Shipped/no-ImGui builds are untouched.

## Verification

- editor-debug build green; all 17 ctest suites pass.
- Injected a per-frame `error(...)` into the example project's hub scene and ran 60 frames headless (`-m play`): every frame logged the error and drove the toast-active ImGui path; clean exit, no crash.
