### PR TITLE
Add RenderQueue and asset-store test suites

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -607,5 +607,34 @@ if (OCTARINE_ENABLE_TESTS)
     endif ()
     add_test(NAME GameBakeTest COMMAND OctarineGameBakeTest)
 
+    # RenderQueue / RenderKey sort + batching invariants. Header-only code under test, but it
+    # speaks SDL types — linking octarine_engine keeps the include/link surface identical to the
+    # other engine-facing tests with one TU.
+    add_executable(OctarineRenderQueueTest tests/RenderQueueTest.cpp)
+    set_target_properties(OctarineRenderQueueTest PROPERTIES
+            CXX_STANDARD 20
+            CXX_STANDARD_REQUIRED ON
+            CXX_EXTENSIONS OFF)
+    target_link_libraries(OctarineRenderQueueTest PRIVATE octarine_engine)
+    if (MSVC)
+        target_compile_options(OctarineRenderQueueTest PRIVATE /MP /bigobj /permissive- /wd4201 /wd5321)
+    endif ()
+    add_test(NAME RenderQueueTest COMMAND OctarineRenderQueueTest)
+
+    # Typed asset-store lifecycle: TextureStore generation/ownership plus AssetManager
+    # acquire/release, hot-reload swap, and missing-asset paths against a headless software
+    # renderer and a temp-dir catalog (the checked-in fixture images are placeholder bytes that
+    # don't decode, so the test writes real PNGs at runtime).
+    add_executable(OctarineAssetStoreTest tests/AssetStoreTest.cpp)
+    set_target_properties(OctarineAssetStoreTest PROPERTIES
+            CXX_STANDARD 20
+            CXX_STANDARD_REQUIRED ON
+            CXX_EXTENSIONS OFF)
+    target_link_libraries(OctarineAssetStoreTest PRIVATE octarine_engine)
+    if (MSVC)
+        target_compile_options(OctarineAssetStoreTest PRIVATE /MP /bigobj /permissive- /wd4201 /wd5321)
+    endif ()
+    add_test(NAME AssetStoreTest COMMAND OctarineAssetStoreTest)
+
     message(STATUS "Octarine: Tests ENABLED")
 endif ()

--- a/tests/AssetStoreTest.cpp
+++ b/tests/AssetStoreTest.cpp
@@ -1,0 +1,201 @@
+// Typed-store lifecycle checks beyond AssetRefcounterTest's pure bookkeeping: TextureStore
+// handle ownership + generation bumps, and AssetManager's Acquire/Release orchestration,
+// hot-reload swap path, and missing-asset error paths — all against a real (software, headless)
+// SDL renderer and a temp-dir catalog built at runtime, since the checked-in fixture images are
+// placeholder bytes that don't decode. gtest-free; exit code is the number of failed checks.
+// Registered with ctest as AssetStoreTest.
+
+#include <SDL3/SDL.h>
+
+#include <sol/sol.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "AssetManager/AssetCatalog.h"
+#include "AssetManager/AssetManager.h"
+#include "AssetManager/TextureStore.h"
+#include "General/Logger.h"
+#include "TestHarness.h"
+#include "stb/stb_image_write.h"  // header-only; IMPL lives in AtlasBaker.cpp
+
+using octarine::test::Check;
+using octarine::test::CheckEq;
+
+namespace {
+
+// Write a real, decodable PNG (solid color) so IMG_LoadTexture_IO succeeds.
+bool WritePng(const std::string& path, const unsigned char r, const unsigned char g, const unsigned char b) {
+  std::vector<unsigned char> pixels;
+  pixels.reserve(8 * 8 * 4);
+  for (int i = 0; i < 8 * 8; ++i) {
+    pixels.push_back(r);
+    pixels.push_back(g);
+    pixels.push_back(b);
+    pixels.push_back(255);
+  }
+  return stbi_write_png(path.c_str(), 8, 8, 4, pixels.data(), 8 * 4) != 0;
+}
+
+}  // namespace
+
+int main() {
+  Logger::Init();
+
+  // Headless render target: a software renderer over a plain surface needs no window, no GPU,
+  // and no video driver — exactly what the store needs to create real SDL_Texture handles in CI.
+  SDL_Init(0);
+  SDL_Surface* surface = SDL_CreateSurface(64, 64, SDL_PIXELFORMAT_RGBA32);
+  SDL_Renderer* renderer = surface != nullptr ? SDL_CreateSoftwareRenderer(surface) : nullptr;
+  Check(renderer != nullptr, "software renderer created headlessly");
+  if (renderer == nullptr) return octarine::test::ReportSummary("AssetStoreTest");
+
+  const std::filesystem::path tmpDir = std::filesystem::temp_directory_path() / "octarine_asset_store_test";
+  std::error_code ec;
+  std::filesystem::remove_all(tmpDir, ec);
+  std::filesystem::create_directories(tmpDir / "images", ec);
+
+  std::cout << "[texture store] add / replace / remove drive the generation counter\n";
+  {
+    const std::string pngPath = (tmpDir / "images" / "store.png").string();
+    Check(WritePng(pngPath, 255, 0, 0), "test PNG written");
+
+    TextureStore store;
+    const std::uint64_t gen0 = store.Generation();
+
+    SDL_Texture* added = store.Add(renderer, "store", SDL_IOFromFile(pngPath.c_str(), "rb"), pngPath);
+    Check(added != nullptr, "Add returns the resident texture");
+    Check(store.Get("store") == added && store.Contains("store"), "Get/Contains resolve the added id");
+    CheckEq(store.Generation(), gen0 + 1, "Add bumps the generation");
+
+    SDL_Texture* replaced = store.Add(renderer, "store", SDL_IOFromFile(pngPath.c_str(), "rb"), pngPath);
+    Check(replaced != nullptr && store.Get("store") == replaced, "re-Add under the same id replaces the handle");
+    CheckEq(store.Generation(), gen0 + 2, "replace bumps the generation");
+
+    // Undecodable bytes: loader fails, store state and generation stay untouched.
+    const std::string bogusPath = (tmpDir / "images" / "bogus.txt").string();
+    std::ofstream(bogusPath) << "not an image";
+    SDL_Texture* bogus = store.Add(renderer, "bogus", SDL_IOFromFile(bogusPath.c_str(), "rb"), bogusPath);
+    Check(bogus == nullptr, "Add returns nullptr for undecodable bytes");
+    Check(!store.Contains("bogus"), "failed load leaves no store entry");
+    CheckEq(store.Generation(), gen0 + 2, "failed load does not bump the generation");
+
+    Check(store.Remove("store"), "Remove reports an erased entry");
+    Check(store.Get("store") == nullptr, "removed id no longer resolves");
+    CheckEq(store.Generation(), gen0 + 3, "Remove bumps the generation");
+    Check(!store.Remove("store"), "second Remove is a no-op");
+    CheckEq(store.Generation(), gen0 + 3, "no-op Remove does not bump the generation");
+  }
+
+  std::cout << "[asset manager] acquire/release lifecycle against a runtime catalog\n";
+  {
+    Check(WritePng((tmpDir / "images" / "sprite.png").string(), 0, 255, 0), "catalog PNG written");
+
+    sol::state lua;
+    lua.open_libraries(sol::lib::base, sol::lib::table);
+
+    AssetManager manager;
+    Check(manager.GetCatalog().Build(tmpDir.string(), lua, std::optional<ScaleMode>(ScaleMode::Nearest)),
+          "catalog builds over the temp asset tree");
+    Check(manager.GetCatalog().Find("sprite") != nullptr, "catalog indexed the texture id");
+
+    // Missing-asset error path: unknown ids fail without touching the stores.
+    Check(!manager.Acquire("definitely_missing", renderer, nullptr), "Acquire of an unknown id returns false");
+    CheckEq(manager.RefCount("definitely_missing"), 0, "failed Acquire leaves no refcount");
+
+    Check(manager.Acquire("sprite", renderer, nullptr), "first Acquire loads the texture");
+    Check(manager.GetTexture("sprite") != nullptr, "texture resident after Acquire");
+    CheckEq(manager.RefCount("sprite"), 1, "first Acquire counts 1");
+
+    const std::uint64_t genAfterLoad = manager.TextureGeneration();
+    Check(manager.Acquire("sprite", renderer, nullptr), "second Acquire succeeds");
+    CheckEq(manager.RefCount("sprite"), 2, "second Acquire counts 2");
+    CheckEq(manager.TextureGeneration(), genAfterLoad, "re-Acquire does not reload (generation unchanged)");
+
+    manager.Release("sprite");
+    CheckEq(manager.RefCount("sprite"), 1, "Release walks the count down");
+    Check(manager.GetTexture("sprite") != nullptr, "still resident while referenced");
+
+    manager.Release("sprite");
+    CheckEq(manager.RefCount("sprite"), 0, "last Release zeroes the count");
+    Check(manager.GetTexture("sprite") == nullptr, "last Release unloads the handle");
+
+    manager.Release("sprite");  // untracked — must be ignored, not underflow
+    CheckEq(manager.RefCount("sprite"), 0, "Release of an untracked id is a no-op");
+
+    Check(manager.Acquire("sprite", renderer, nullptr), "id is re-acquirable after full release");
+    CheckEq(manager.RefCount("sprite"), 1, "re-acquire restarts the count at 1");
+    manager.Release("sprite");
+  }
+
+  std::cout << "[asset manager] hot-reload swap preserves references, bumps the generation\n";
+  {
+    const std::string spritePath = (tmpDir / "images" / "swap.png").string();
+    Check(WritePng(spritePath, 0, 0, 255), "initial swap PNG written");
+
+    sol::state lua;
+    lua.open_libraries(sol::lib::base, sol::lib::table);
+
+    AssetManager manager;
+    Check(manager.GetCatalog().Build(tmpDir.string(), lua, std::optional<ScaleMode>(ScaleMode::Nearest)),
+          "catalog builds for the reload run");
+
+    Check(!manager.Reload("swap", renderer, nullptr), "Reload of a non-resident id is a no-op");
+    Check(!manager.Reload("definitely_missing", renderer, nullptr), "Reload of an unknown id is a no-op");
+
+    Check(manager.Acquire("swap", renderer, nullptr), "texture acquired before reload");
+    Check(manager.Acquire("swap", renderer, nullptr), "second reference taken before reload");
+    const std::uint64_t genBefore = manager.TextureGeneration();
+
+    // New bytes on disk, then the dev hot-push path: handle swaps, refcount must survive.
+    Check(WritePng(spritePath, 255, 255, 0), "swap PNG overwritten with new bytes");
+    Check(manager.Reload("swap", renderer, nullptr), "Reload swaps the resident handle");
+    Check(manager.GetTexture("swap") != nullptr, "texture resident after reload");
+    CheckEq(manager.RefCount("swap"), 2, "reload preserves the acquire count");
+    Check(manager.TextureGeneration() > genBefore, "reload bumps the texture generation");
+
+    // Path-driven variant used by the file watcher: resolves the absolute path back to its ids.
+    CheckEq(manager.ReloadByPath(spritePath, renderer, nullptr), 1, "ReloadByPath reloads the backing id");
+    CheckEq(manager.ReloadByPath((tmpDir / "images" / "unknown.png").string(), renderer, nullptr), 0,
+            "ReloadByPath of an untracked path reloads nothing");
+
+    const std::vector<std::string> resident = manager.ResidentSourcePaths();
+    Check(std::find(resident.begin(), resident.end(),
+                    manager.GetCatalog().Find("swap")->fullPath) != resident.end(),
+          "ResidentSourcePaths reports the resident texture's source file");
+
+    manager.ReleaseAll({"swap", "swap"});
+    Check(manager.GetTexture("swap") == nullptr, "ReleaseAll drops both references");
+  }
+
+  std::cout << "[asset manager] audio acquire fails cleanly with no mixer\n";
+  {
+    // The headless/disabled-audio path: a catalog audio entry acquired with a null mixer must
+    // report failure (and leave no refcount) instead of crashing or half-loading.
+    std::filesystem::create_directories(tmpDir / "sounds", ec);
+    std::ofstream((tmpDir / "sounds" / "clip.wav").string(), std::ios::binary) << "RIFF stub";
+
+    sol::state lua;
+    lua.open_libraries(sol::lib::base, sol::lib::table);
+
+    AssetManager manager;
+    Check(manager.GetCatalog().Build(tmpDir.string(), lua, std::optional<ScaleMode>(ScaleMode::Nearest)),
+          "catalog builds with the audio entry");
+    Check(manager.GetCatalog().Find("clip") != nullptr, "catalog indexed the audio id");
+    Check(!manager.Acquire("clip", renderer, nullptr), "audio Acquire with null mixer returns false");
+    CheckEq(manager.RefCount("clip"), 0, "failed audio Acquire leaves no refcount");
+  }
+
+  SDL_DestroyRenderer(renderer);
+  SDL_DestroySurface(surface);
+  std::filesystem::remove_all(tmpDir, ec);
+  SDL_Quit();
+
+  return octarine::test::ReportSummary("AssetStoreTest");
+}

--- a/tests/AssetStoreTest.cpp
+++ b/tests/AssetStoreTest.cpp
@@ -7,14 +7,13 @@
 
 #include <SDL3/SDL.h>
 
-#include <sol/sol.hpp>
-
 #include <algorithm>
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <optional>
+#include <sol/sol.hpp>
 #include <string>
 #include <vector>
 
@@ -166,8 +165,7 @@ int main() {
             "ReloadByPath of an untracked path reloads nothing");
 
     const std::vector<std::string> resident = manager.ResidentSourcePaths();
-    Check(std::find(resident.begin(), resident.end(),
-                    manager.GetCatalog().Find("swap")->fullPath) != resident.end(),
+    Check(std::find(resident.begin(), resident.end(), manager.GetCatalog().Find("swap")->fullPath) != resident.end(),
           "ResidentSourcePaths reports the resident texture's source file");
 
     manager.ReleaseAll({"swap", "swap"});

--- a/tests/RenderQueueTest.cpp
+++ b/tests/RenderQueueTest.cpp
@@ -39,8 +39,7 @@ int main() {
 
   std::cout << "[sortkey] field precedence\n";
   {
-    Check(Key(1, 0.0f, SPRITE, nullptr) > Key(0, 1000000.0f, SPRITE, nullptr),
-          "layer outranks any depth difference");
+    Check(Key(1, 0.0f, SPRITE, nullptr) > Key(0, 1000000.0f, SPRITE, nullptr), "layer outranks any depth difference");
     Check(Key(0, 2.0f * Constants::kRenderBatchYBandPx, SPRITE, nullptr) > Key(0, 0.0f, SPRITE, nullptr),
           "deeper band sorts later within a layer");
     CheckEq(Key(0, 0.0f, SPRITE, nullptr), Key(0, Constants::kRenderBatchYBandPx - 1.0f, SPRITE, nullptr),

--- a/tests/RenderQueueTest.cpp
+++ b/tests/RenderQueueTest.cpp
@@ -1,0 +1,168 @@
+// Unit checks for RenderKey::ComputeSortKey packing and RenderQueue's radix sort: field
+// precedence (layer > depth band > type > blend > batch hash), tie stability, and the
+// clustering invariants the renderer's draw batching relies on. gtest-free; exit code is
+// the number of failed checks. Registered with ctest as RenderQueueTest.
+
+#include <SDL3/SDL.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "General/BlendMode.h"
+#include "General/Constants.h"
+#include "Renderer/RenderKey.h"
+#include "Renderer/RenderQueue.h"
+#include "TestHarness.h"
+
+using octarine::BlendMode;
+using octarine::test::Check;
+using octarine::test::CheckEq;
+
+namespace {
+
+std::uint64_t Key(const unsigned int layer, const float depth, const RenderableType type, const void* batchKey,
+                  const BlendMode blend = BlendMode::Blend) {
+  return RenderKey::ComputeSortKey(layer, depth, type, batchKey, static_cast<std::uint8_t>(blend));
+}
+
+// Fake texture handles — ComputeSortKey only hashes the pointer value. 64-byte alignment keeps
+// the two values apart in the bits the hash actually reads (it shifts off the low 4).
+alignas(64) char g_texMemA[64];
+alignas(64) char g_texMemB[64];
+
+}  // namespace
+
+int main() {
+  const void* texA = g_texMemA;
+  const void* texB = g_texMemB;
+
+  std::cout << "[sortkey] field precedence\n";
+  {
+    Check(Key(1, 0.0f, SPRITE, nullptr) > Key(0, 1000000.0f, SPRITE, nullptr),
+          "layer outranks any depth difference");
+    Check(Key(0, 2.0f * Constants::kRenderBatchYBandPx, SPRITE, nullptr) > Key(0, 0.0f, SPRITE, nullptr),
+          "deeper band sorts later within a layer");
+    CheckEq(Key(0, 0.0f, SPRITE, nullptr), Key(0, Constants::kRenderBatchYBandPx - 1.0f, SPRITE, nullptr),
+            "depths inside one band share a key");
+    Check(Key(0, -2.0f * Constants::kRenderBatchYBandPx, SPRITE, nullptr) < Key(0, 0.0f, SPRITE, nullptr),
+          "negative depth sorts before zero (band bias)");
+    Check(Key(0, 0.0f, SPRITE, nullptr) != Key(0, 0.0f, SQUARE_PRIMITIVE, nullptr), "type participates in the key");
+    Check(Key(0, 0.0f, SPRITE, texA) != Key(0, 0.0f, SPRITE, texB), "distinct textures get distinct batch hashes");
+    CheckEq(Key(0, 0.0f, SPRITE, texA), Key(0, 0.0f, SPRITE, texA), "key is deterministic");
+    // Blend sits above the texture hash inside the batch bits, so every same-blend run clusters
+    // before texture clustering — regardless of which texture pointers are involved.
+    Check(Key(0, 0.0f, SPRITE, texA, BlendMode::Blend) < Key(0, 0.0f, SPRITE, texB, BlendMode::Add) &&
+              Key(0, 0.0f, SPRITE, texB, BlendMode::Blend) < Key(0, 0.0f, SPRITE, texA, BlendMode::Add),
+          "blend mode outranks texture hash");
+  }
+
+  std::cout << "[sort] orders by key, ties keep insertion order\n";
+  {
+    RenderQueue queue(1024);
+    // Three layers emplaced in reverse; four entries per layer marked with their insertion index.
+    int idx = 0;
+    for (const unsigned int layer : {2u, 1u, 0u}) {
+      for (int i = 0; i < 4; ++i) {
+        auto& cmd = queue.EmplaceSprite(layer, 0.0f, texA);
+        cmd.destX = static_cast<float>(idx++);
+      }
+    }
+    queue.Sort();
+    CheckEq(queue.Size(), static_cast<size_t>(12), "Size unchanged by Sort");
+
+    bool ascending = true;
+    std::vector<float> markers;
+    std::uint64_t prev = 0;
+    for (const RenderKey& key : queue) {
+      if (!markers.empty() && key.sortKey < prev) ascending = false;
+      prev = key.sortKey;
+      markers.push_back(key.payload.sprite.destX);
+    }
+    Check(ascending, "sortKey is non-decreasing after Sort");
+    Check(markers[0] == 8 && markers[4] == 4 && markers[8] == 0, "layer groups come out 0, 1, 2");
+    bool stable = true;
+    for (int group = 0; group < 3; ++group) {
+      for (int i = 1; i < 4; ++i) {
+        if (markers[group * 4 + i] != markers[group * 4 + i - 1] + 1.0f) stable = false;
+      }
+    }
+    Check(stable, "tied keys keep insertion order (stable radix passes)");
+  }
+
+  std::cout << "[sort] blend + texture clustering within one layer/band\n";
+  {
+    RenderQueue queue(1024);
+    // Worst-case interleave of (blend, texture) combos: 16 sprites alternating blend every entry
+    // and texture every other entry. After Sort the queue must contain exactly one blend boundary
+    // and one texture boundary inside each blend run.
+    const BlendMode blends[2] = {BlendMode::Blend, BlendMode::Add};
+    const void* textures[2] = {texA, texB};
+    for (int i = 0; i < 16; ++i) {
+      const BlendMode blend = blends[i % 2];
+      const void* texture = textures[(i / 2) % 2];
+      auto& cmd = queue.EmplaceSprite(0, 0.0f, texture, blend);
+      cmd.texture = static_cast<SDL_Texture*>(const_cast<void*>(texture));
+      cmd.blendMode = octarine::ToSdlBlendMode(blend);
+    }
+    queue.Sort();
+
+    int blendTransitions = 0;
+    int textureTransitions = 0;
+    SDL_BlendMode prevBlend{};
+    SDL_Texture* prevTexture{};
+    bool first = true;
+    for (const RenderKey& key : queue) {
+      const auto& cmd = key.payload.sprite;
+      if (!first) {
+        if (cmd.blendMode != prevBlend) {
+          ++blendTransitions;
+        } else if (cmd.texture != prevTexture) {
+          ++textureTransitions;
+        }
+      }
+      prevBlend = cmd.blendMode;
+      prevTexture = cmd.texture;
+      first = false;
+    }
+    CheckEq(blendTransitions, 1, "same-blend runs cluster (one blend boundary)");
+    CheckEq(textureTransitions, 2, "textures cluster within each blend run");
+  }
+
+  std::cout << "[sort] type clusters within one layer/band\n";
+  {
+    RenderQueue queue(256);
+    queue.EmplaceSquare(0, 0.0f);
+    queue.EmplaceSprite(0, 0.0f, texA);
+    queue.EmplaceText(0, 0.0f);
+    queue.EmplaceSquare(0, 0.0f);
+    queue.EmplaceSprite(0, 0.0f, texA);
+    queue.Sort();
+
+    int typeTransitions = 0;
+    RenderableType prevType{};
+    bool first = true;
+    for (const RenderKey& key : queue) {
+      if (!first && key.type != prevType) ++typeTransitions;
+      prevType = key.type;
+      first = false;
+    }
+    CheckEq(typeTransitions, 2, "three types -> two type boundaries");
+  }
+
+  std::cout << "[lifecycle] Clear resets, queue is reusable\n";
+  {
+    RenderQueue queue(64);
+    queue.EmplaceSprite(0, 0.0f, nullptr);
+    Check(!queue.IsEmpty(), "queue non-empty after emplace");
+    queue.Clear();
+    Check(queue.IsEmpty() && queue.Size() == 0 && queue.begin() == queue.end(), "Clear resets the queue");
+    auto& cmd = queue.EmplaceSprite(0, 0.0f, nullptr);
+    cmd.destX = 42.0f;
+    queue.Sort();
+    CheckEq(queue.Size(), static_cast<size_t>(1), "queue reusable after Clear");
+    CheckEq(queue.begin()->payload.sprite.destX, 42.0f, "payload survives the post-Clear sort");
+  }
+
+  return octarine::test::ReportSummary("RenderQueueTest");
+}


### PR DESCRIPTION
## What

Two new ctest suites closing the coverage gap on the render queue and asset stores. The blend-clustering checks exercise the blend bits #152 added to the sort key. (Replaces #154, which GitHub auto-closed when its stacked base branch was deleted on #152's merge.)

**RenderQueueTest**
- `RenderKey::ComputeSortKey` field precedence: layer > depth band > type > blend > batch hash, band sharing, negative-depth bias, hash determinism.
- Radix sort: keys non-decreasing, ties keep insertion order (stability), `Size` unchanged.
- Clustering invariants the draw batching relies on: one blend boundary across a worst-case interleave, textures clustered within each blend run, types clustered within a band.
- `Clear`/reuse lifecycle.

**AssetStoreTest**
- `TextureStore`: add/replace/remove drive the generation counter, failed decode leaves no entry and no bump, handle ownership.
- `AssetManager` acquire/release: refcount walk-up/down, unload at zero, untracked-release no-op, re-acquire after full release, re-acquire does not reload.
- Hot-reload swap: `Reload` preserves the acquire count and bumps the texture generation; non-resident/unknown ids are no-ops; `ReloadByPath` resolves a source path back to its id; `ResidentSourcePaths` reports the file.
- Error paths: unknown id acquire, audio acquire with a null mixer (headless/disabled-audio).

Runs fully headless via `SDL_CreateSoftwareRenderer` over a plain surface — no window, video driver, or GPU — and builds its catalog over a temp dir with PNGs written at runtime (the checked-in fixture images are placeholder bytes that don't decode).

## Skipped (and why)

A golden-image smoke via the headless frame capture was considered and deliberately not included: BMP output depends on renderer backend rasterization (software vs. GPU paths differ per runner), so it would be flaky across CI hosts. The Stage-4 PR verified pixels manually with the software path instead.

## Verification

Full ctest suite (19 tests including the two new ones) green on Windows/MSVC editor-debug.
