### PR TITLE
Fix benchmark pipeline: Logger history cap, collision bench hang, parser syntax, CI exit-code masking

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -20,6 +20,9 @@ jobs:
   benchmark:
     name: Run Benchmarks
     runs-on: self-hosted
+    # A wedged benchmark (infinite spin, leak-into-swap) should fail the run, not squat the
+    # self-hosted runner until someone notices. A healthy full run takes well under an hour.
+    timeout-minutes: 60
 
     steps:
       - name: Checkout
@@ -48,8 +51,12 @@ jobs:
       - name: Build Benchmarks
         run: cmake --build build/player-profile --target OctarineBenchmarks --parallel
 
+      # Write the JSON via --benchmark_out rather than piping stdout through tee: the profiling
+      # build logs TIMER/ACCUM lines to stdout, which both pollutes a stdout-captured JSON and,
+      # through the pipe, makes the step's exit code tee's (always 0) instead of the benchmark's —
+      # a crashed benchmark exe then "passes" and only the store step fails on the bad file.
       - name: Run Micro-Benchmarks
-        run: ./build/player-profile/bin/relwithdebinfo/OctarineBenchmarks --benchmark_format=json | tee benchmark_result.json
+        run: ./build/player-profile/bin/relwithdebinfo/OctarineBenchmarks --benchmark_out=benchmark_result.json --benchmark_out_format=json > /dev/null
 
       - name: Store micro-benchmark result
         uses: benchmark-action/github-action-benchmark@v1

--- a/scripts/parse_bench_output.py
+++ b/scripts/parse_bench_output.py
@@ -68,12 +68,12 @@ def main():
             value /= 1000000
 
         # Game::Render (total) and EndScene are dominated by the SDL dummy-driver's
-    # SDL_RenderClear CPU memset under SDL_VIDEODRIVER=dummy and don't reflect
-    # real GPU cost. Drop them so the CI dashboard tracks actionable CPU phases only.
-    if name in ('Game::Render (total)', 'EndScene'):
-      continue
+        # SDL_RenderClear CPU memset under SDL_VIDEODRIVER=dummy and don't reflect
+        # real GPU cost. Drop them so the CI dashboard tracks actionable CPU phases only.
+        if name in ('Game::Render (total)', 'EndScene'):
+            continue
 
-    metrics[name].append(value)
+        metrics[name].append(value)
 
     if discarded > 0:
         print(f"Discarded {discarded} warmup samples ({args.warmup}s)", file=sys.stderr)

--- a/src/General/Logger.cpp
+++ b/src/General/Logger.cpp
@@ -81,40 +81,44 @@ void Logger::SetLevel(const std::string& level) {
   }
 }
 
-void Logger::Error(const std::string& message) {
-  spdlog::error(message);
+void Logger::PushHistory(std::string entry) {
+  // Capped, not unbounded: instrumented builds log per-frame TIMER/ACCUM lines, so an uncapped
+  // history grows by gigabytes over a long run. The console only ever shows the tail.
+  constexpr size_t kMaxHistory = 1000;
   std::lock_guard<std::mutex> lock(history_mutex_);
-  history_.push_back("[Error] " + message);
-}
-
-void Logger::Warn(const std::string& message) {
-  spdlog::warn(message);
-  std::lock_guard<std::mutex> lock(history_mutex_);
-  history_.push_back("[Warn] " + message);
-}
-
-void Logger::Info(const std::string& message) {
-  spdlog::info(message);
-  std::lock_guard<std::mutex> lock(history_mutex_);
-  history_.push_back("[Info] " + message);
-}
-
-void Logger::LogLua(const std::string& message) {
-  lua_logger_->info(message);
-  std::lock_guard<std::mutex> lock(history_mutex_);
-  history_.push_back(message);
-  if (history_.size() > 1000) {
+  history_.push_back(std::move(entry));
+  if (history_.size() > kMaxHistory) {
     history_.erase(history_.begin());
   }
 }
 
+void Logger::Error(const std::string& message) {
+  spdlog::error(message);
+  PushHistory("[Error] " + message);
+}
+
+void Logger::Warn(const std::string& message) {
+  spdlog::warn(message);
+  PushHistory("[Warn] " + message);
+}
+
+void Logger::Info(const std::string& message) {
+  spdlog::info(message);
+  PushHistory("[Info] " + message);
+}
+
+void Logger::LogLua(const std::string& message) {
+  lua_logger_->info(message);
+  PushHistory(message);
+}
+
 void Logger::ErrorLua(const std::string& message) {
   lua_logger_->error(message);
-  std::lock_guard<std::mutex> lock(history_mutex_);
-  history_.push_back("[Error] [Lua] " + message);
+  PushHistory("[Error] [Lua] " + message);
   // Small ring, not full history: the toast only ever shows the tail, and capping here keeps a
   // misbehaving per-frame error loop from growing memory.
   constexpr size_t kMaxScriptErrors = 8;
+  std::lock_guard<std::mutex> lock(history_mutex_);
   script_errors_.push_back({++script_error_sequence_, message, std::chrono::steady_clock::now()});
   if (script_errors_.size() > kMaxScriptErrors) {
     script_errors_.erase(script_errors_.begin());
@@ -123,14 +127,12 @@ void Logger::ErrorLua(const std::string& message) {
 
 void Logger::WarnLua(const std::string& message) {
   lua_logger_->warn(message);
-  std::lock_guard<std::mutex> lock(history_mutex_);
-  history_.push_back("[Warn] [Lua] " + message);
+  PushHistory("[Warn] [Lua] " + message);
 }
 
 void Logger::InfoLua(const std::string& message) {
   lua_logger_->info(message);
-  std::lock_guard<std::mutex> lock(history_mutex_);
-  history_.push_back("[Info] [Lua] " + message);
+  PushHistory("[Info] [Lua] " + message);
 }
 
 std::vector<std::string> Logger::GetHistory() {

--- a/src/General/Logger.h
+++ b/src/General/Logger.h
@@ -27,6 +27,11 @@ class Logger {
   static std::vector<ScriptError> script_errors_;
   static std::uint64_t script_error_sequence_;
 
+  // Appends to history_ under history_mutex_ and trims to the cap. Every log path must go
+  // through this: instrumented builds emit per-frame TIMER/ACCUM lines, and an uncapped
+  // history grows without bound over a session.
+  static void PushHistory(std::string entry);
+
  public:
   static void Init();
   // Apply a runtime log level override (trace|debug|info|warn|error|critical|off). Case-insensitive;

--- a/tests/benchmarks/CollisionSystemBenchmark.cpp
+++ b/tests/benchmarks/CollisionSystemBenchmark.cpp
@@ -39,9 +39,11 @@ class StubContext final : public AnyContext {
 
 struct CollisionCounter {
   std::uint64_t count = 0;
-  // CollisionSystem emits one batched event per collect cycle; the overlapping pair guarantees
-  // pairs is non-empty, so count advances once per cycle (what the timing loop below keys on).
-  void OnCollisionBatch(const CollisionBatchEvent& e) { count += e.pairs.size(); }
+  // CollisionSystem emits exactly one batched event per collect cycle, so counting events (not
+  // pairs) advances once per cycle — what the timing loop below keys on. Counting pairs would
+  // hang: only *entering* pairs are emitted, so a sustained overlap reports its pair on the
+  // first cycle and every later batch is empty.
+  void OnCollisionBatch(const CollisionBatchEvent& /*e*/) { ++count; }
 };
 
 // CollisionSystem builds its own query and ignores the Iterable argument, but the call signature
@@ -51,9 +53,10 @@ Iterable MakeUnusedIterable() {
           []() -> AnyIterator { throw std::logic_error("unused"); }};
 }
 
-// Two boxes overlap at the origin (guaranteeing >=1 collision per cycle, so every collect emits an
-// event we can count); the rest sit on a wide diagonal grid, non-overlapping, to keep narrowphase
-// cheap and the dispatch overhead visible.
+// Two boxes overlap at the origin so the narrowphase has at least one hit to process; the rest sit
+// on a wide diagonal grid, non-overlapping, to keep narrowphase cheap and the dispatch overhead
+// visible. (The overlap is sustained, so after the first cycle it is deduplicated out of the
+// entering-pairs batches — the timing loop counts batch events, not pairs.)
 void BuildBoxes(Registry& registry, int n) {
   EntityMask mask;
   mask.set(0);


### PR DESCRIPTION
The nightly Benchmark workflow has been red since 2026-06-02, failing at "Store micro-benchmark result" every night. Four independent defects line up to produce that:

1. **Logger history never trimmed** — `Logger::Info/Warn/Error` (and the Lua variants except `LogLua`) push every message into the static `history_` vector unbounded. Profiling builds emit TIMER/ACCUM lines per system per cycle; a local benchmark run reached 44 GB RSS. On the CI runner this plausibly OOM-kills the benchmark exe mid-run.
2. **`BM_CollisionDispatch` spins forever** — since #128, CollisionSystem emits only *entering* collision pairs. The bench's two boxes overlap permanently, so their pair is reported once; the timing loop waits for `pairs.size()` to advance and never returns from the second iteration.
3. **The CI step masks the death** — `OctarineBenchmarks --benchmark_format=json | tee benchmark_result.json` takes its exit code from `tee`, so a crashed exe still "passes" the run step and only the store step fails on the truncated, log-polluted JSON.
4. **`scripts/parse_bench_output.py` has a SyntaxError** — the `Game::Render (total)`/`EndScene` filter added in #129 was indented outside the parse loop, dragging `metrics[name].append` out with it, so macro parsing dies immediately when reached.

Changes:

- `Logger`: new `PushHistory` helper caps history at 1000 entries (same erase-from-front pattern `LogLua` already used); all seven log methods route through it.
- `CollisionSystemBenchmark`: count one batch event per collect cycle instead of summing pair counts — CollisionSystem emits exactly one `CollisionBatchEvent` per cycle regardless of dedup, which is the cycle boundary the bench times. Stale comments updated.
- `parse_bench_output.py`: re-indented the filter block back inside the parse loop.
- `benchmark.yml`: micro run writes JSON via `--benchmark_out` (exit code comes from the exe, JSON can't be polluted by stdout logging, and the multi-GB step log goes away) and the job gets `timeout-minutes: 60` so a future hang fails fast instead of squatting the runner.

Verification (Windows, player-profile + benchmarks + tests):

- Full micro suite completes in 91 s with 24 MB peak working set (previously: never completed, 44 GB and climbing); all 81 cases present in the JSON including `BM_CollisionDispatch/8..512`.
- `ctest`: 19/19 pass.
- Macro path end-to-end: `bench.sh 8 | parse_bench_output.py --warmup 2` against the example game emits 105 valid metrics.

After merge, a `workflow_dispatch` run of Benchmark should confirm both store steps go green.
