### PR TITLE
Add serial fallback cutoff to ParallelForEach

### DIFF
--- a/src/ECS/ArchetypeQuery.h
+++ b/src/ECS/ArchetypeQuery.h
@@ -185,10 +185,27 @@ class ArchetypeQuery {
   // memory region, so concurrent processing is safe for per-entity writes.
   // Func signature: void (Entity, TComponents&...) or void (TComponents&...).
   // IMPORTANT: Func must not access a shared mutable state (e.g. no pushing to shared vectors).
+  //
+  // serialBelowEntities: when the matched entity count is below this, run on the calling thread
+  // instead of dispatching to the pool. Dispatch costs ~13.5 us regardless of N; for a trivial
+  // per-entity body serial wins below ~16k entities, while heavy bodies cross over at a few
+  // hundred — so the cutoff is per call site. Default 0 keeps the current always-parallel path.
   template <typename Func>
-  void ParallelForEach(Func&& func) {
+  void ParallelForEach(Func&& func, const size_t serialBelowEntities = 0) {
     const auto work = CollectChunkWork();
     if (work.empty()) return;
+
+    if (serialBelowEntities > 0) {
+      size_t totalEntities = 0;
+      for (const auto& w : work) {
+        totalEntities += w.entityCount;
+      }
+      if (totalEntities < serialBelowEntities) {
+        PROFILE_COUNTER_ADD("ParallelForEach: SerialGated", 1);
+        ProcessChunks(work, 0, work.size(), func);
+        return;
+      }
+    }
 
     const size_t num_batches = std::min(work.size(), ThreadPool::Instance().Size());
     PROFILE_COUNTER_ADD("ParallelForEach: Batches", static_cast<long long>(num_batches));

--- a/src/ECS/Query.h
+++ b/src/ECS/Query.h
@@ -134,9 +134,11 @@ class ComponentQuery final : public Query {
   // Parallel version of ForEach — distributes chunks across CPU threads.
   // Only safe for funcs that do per-entity independent writes (no shared mutable state).
   // Func signature: void (Entity, TComponents&...) or void(TComponents&...).
+  // serialBelowEntities: run serially on the calling thread when fewer entities match —
+  // see ArchetypeQuery::ParallelForEach for the cost model.
   template <typename Func>
-  void ParallelForEach(Func&& func) {
-    archetype_query_.ParallelForEach(std::forward<Func>(func));
+  void ParallelForEach(Func&& func, const size_t serialBelowEntities = 0) {
+    archetype_query_.ParallelForEach(std::forward<Func>(func), serialBelowEntities);
   }
 
   template <typename Func>

--- a/src/Systems/TransformSystem.h
+++ b/src/Systems/TransformSystem.h
@@ -50,17 +50,24 @@ class TransformSystem {
     globalEntity_ = registry->Component<GlobalTransformComponent>();
   }
 
+  // The per-entity body is a handful of copies, so thread-pool dispatch (~13.5 us fixed) only
+  // pays for itself near the measured serial/parallel crossover of ~16k entities. Half that,
+  // to stay parallel where the win is real and serial where dispatch dominates.
+  static constexpr size_t kFlatSerialBelowEntities = 8192;
+
   // Fast path: no ChildOf hierarchy live. Unrelated relationship pairs do not disable it.
   // Each entity's global is its local (identity for missing slots), in a single parallel pass.
   void UpdateFlat() {
     PROFILE_NAMED_SCOPE("TransformSystem: Fast");
     LogPathOnce("TransformSystem: FAST path (no hierarchy)");
-    optionalQuery_->ParallelForEach([](GlobalTransformComponent& global, const PositionComponent* p,
-                                       const ScaleComponent* s, const RotationComponent* r) {
-      global.position = p ? p->value : glm::vec2(0.0f, 0.0f);
-      global.scale = s ? s->value : glm::vec2(1.0f, 1.0f);
-      global.rotation = r ? r->value : 0.0;
-    });
+    optionalQuery_->ParallelForEach(
+        [](GlobalTransformComponent& global, const PositionComponent* p, const ScaleComponent* s,
+           const RotationComponent* r) {
+          global.position = p ? p->value : glm::vec2(0.0f, 0.0f);
+          global.scale = s ? s->value : glm::vec2(1.0f, 1.0f);
+          global.rotation = r ? r->value : 0.0;
+        },
+        kFlatSerialBelowEntities);
   }
 
   // Hierarchy path, two phases. Phase 1 runs the parallel flat pass over every transform


### PR DESCRIPTION
## Summary

`ArchetypeQuery::ParallelForEach` always dispatched to the thread pool, paying ~13.5 us fixed overhead regardless of entity count. For a trivial per-entity body the serial/parallel crossover measured at ~16k entities, so every small/mid scene paid dispatch cost for nothing. This adds an opt-in `serialBelowEntities` cutoff (default 0 = unchanged behavior) and applies it to `TransformSystem::UpdateFlat` at 8192 — half the measured crossover.

A `ParallelForEach: SerialGated` counter reports gate engagement in profiling builds.

## Measurements (RelWithDebInfo, profiling off, 24-core)

Micro (`BM_TransformAllFlat`, full `registry.Update` per iteration):

| Entities | Before | After |
|---|---|---|
| 512 | 9.7 us | 2.0 us (4.9x) |
| 4096 | 20.8 us | 15.2 us |
| 32768 | 52.2 us | 53.2 us (still parallel, unchanged) |
| 65536 | 63.4 us | 69.0 us (noise) |

`BM_QueryParallelForEach` (no cutoff passed) unchanged at every size.

Macro (10 s example-game stress scene, ~3k entities, profiling on): `TransformSystem: Fast` p50 45 us -> 24 us; `SerialGated` fires every frame; all other system timings within run-to-run noise.

`ctest` 19/19 green.

CollisionSystem and the Registry registered-lambda paths keep the default (always parallel) — their bodies are heavier, so the crossover sits much lower; revisit with data before gating those.
