### PR TITLE
Add p50 and counter series to benchmark parser, dedupe duplicate timer names

### DIFF
--- a/scripts/parse_bench_output.py
+++ b/scripts/parse_bench_output.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
-"""Parse TIMER/ACCUM lines from an OctarineEngine profiling run and emit
+"""Parse TIMER/ACCUM/COUNTER lines from an OctarineEngine profiling run and emit
 percentile-based JSON metrics suitable for github-action-benchmark.
 
 Usage:
     scripts/bench.sh player-profile 8 | python3 scripts/parse_bench_output.py [--warmup SECONDS]
 
 Options:
-    --warmup SECONDS   Discard all TIMER/ACCUM lines from the first SECONDS of
-                       the run (default: 2.0). This excludes the ramp-up transient
+    --warmup SECONDS   Discard all TIMER/ACCUM/COUNTER lines from the first SECONDS
+                       of the run (default: 2.0). This excludes the ramp-up transient
                        where entities are still spawning and the scene hasn't
                        reached steady state.
 """
@@ -21,13 +21,22 @@ from datetime import datetime
 # Regex to match lines like:
 # [2026-05-11 16:11:25.038] [info] TIMER: Registry::Update (total): 5.060000ms
 # [2026-05-11 16:11:25.044] [info] ACCUM: Sweep Bipartite: 4.119000ms
+# [2026-05-11 16:11:25.044] [info] COUNTER: Entities: User: 3383
 timestamp_pattern = re.compile(r'\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3})\]')
 metric_pattern = re.compile(r'\] \[info\] (TIMER|ACCUM):\s+(.*?):\s+([0-9.]+)(ms|ns|s)')
+counter_pattern = re.compile(r'\] \[info\] COUNTER:\s+(.*?):\s+(\d+)\s*$')
 
 
 def parse_timestamp(ts_str):
     """Parse a spdlog timestamp string into a datetime object."""
     return datetime.strptime(ts_str, '%Y-%m-%d %H:%M:%S.%f')
+
+
+def percentile(sorted_values, fraction):
+    """Value at the given fraction (0..1) of an already-sorted list."""
+    idx = int(len(sorted_values) * fraction)
+    idx = min(max(idx, 0), len(sorted_values) - 1)
+    return sorted_values[idx]
 
 
 def main():
@@ -36,13 +45,17 @@ def main():
                         help='Seconds of initial output to discard (default: 2.0)')
     args = parser.parse_args()
 
-    metrics = defaultdict(list)
+    # Timer series keyed by (kind, name) so ACCUM twins of a TIMER scope can be
+    # dropped after parsing instead of silently merging into one distribution.
+    timers = defaultdict(list)
+    counters = defaultdict(list)
     first_timestamp = None
     discarded = 0
 
     for line in sys.stdin:
         match = metric_pattern.search(line)
-        if not match:
+        counter_match = None if match else counter_pattern.search(line)
+        if not match and not counter_match:
             continue
 
         # Extract timestamp for warmup filtering
@@ -57,6 +70,11 @@ def main():
                 discarded += 1
                 continue
 
+        if counter_match:
+            counters[counter_match.group(1).strip()].append(int(counter_match.group(2)))
+            continue
+
+        kind = match.group(1)
         name = match.group(2).strip()
         value = float(match.group(3))
         unit = match.group(4)
@@ -73,10 +91,21 @@ def main():
         if name in ('Game::Render (total)', 'EndScene'):
             continue
 
-        metrics[name].append(value)
+        timers[(kind, name)].append(value)
 
     if discarded > 0:
         print(f"Discarded {discarded} warmup samples ({args.warmup}s)", file=sys.stderr)
+
+    # Registry::Update wraps every system in both a TIMER scope and an ACCUM scope, and the
+    # accumulator map gets dumped to the log each frame. Where both kinds exist for one name,
+    # keep the direct TIMER measurement; ACCUM-only names (e.g. collision sub-phases that only
+    # run on worker threads) still flow through.
+    timer_names = {name for (kind, name) in timers if kind == 'TIMER'}
+    metrics = {
+        name: values
+        for (kind, name), values in timers.items()
+        if kind == 'TIMER' or name not in timer_names
+    }
 
     output = []
 
@@ -84,45 +113,49 @@ def main():
         if not values:
             continue
 
-        # Sort values to calculate percentiles
         values.sort()
+        extra_info = f"Samples: {len(values)}"
 
-        n = len(values)
-
-        # Calculate P95, P99, and Max
-        p95_idx = int(n * 0.95)
-        p99_idx = int(n * 0.99)
-
-        # Ensure indices are within bounds
-        p95_idx = min(max(p95_idx, 0), n - 1)
-        p99_idx = min(max(p99_idx, 0), n - 1)
-
-        p95_val = values[p95_idx]
-        p99_val = values[p99_idx]
-        max_val = values[-1]
-
-        extra_info = f"Samples: {n}"
+        for label, fraction in (('p50', 0.50), ('p95', 0.95), ('p99', 0.99)):
+            output.append({
+                "name": f"{name} [{label}]",
+                "unit": "ms",
+                "value": round(percentile(values, fraction), 4),
+                "range": "0",
+                "extra": extra_info
+            })
 
         output.append({
-            "name": f"{name} [p95]",
+            "name": f"{name} [max]",
             "unit": "ms",
-            "value": round(p95_val, 4),
+            "value": round(values[-1], 4),
             "range": "0",
             "extra": extra_info
         })
 
+    # Per-frame workload counters (entity counts, collision pairs, render-queue size, ...).
+    # These let the dashboard distinguish "the work got slower" from "there was more work".
+    # Always-zero series are skipped: scenes that never exercise a counter would otherwise
+    # add flatline noise to the dashboard.
+    for name, values in counters.items():
+        if not values or max(values) == 0:
+            continue
+
+        values.sort()
+        extra_info = f"Samples: {len(values)}"
+
         output.append({
-            "name": f"{name} [p99]",
-            "unit": "ms",
-            "value": round(p99_val, 4),
+            "name": f"{name} [p50]",
+            "unit": "count",
+            "value": percentile(values, 0.50),
             "range": "0",
             "extra": extra_info
         })
 
         output.append({
             "name": f"{name} [max]",
-            "unit": "ms",
-            "value": round(max_val, 4),
+            "unit": "count",
+            "value": values[-1],
             "range": "0",
             "extra": extra_info
         })

--- a/src/Systems/CollisionSystem.h
+++ b/src/Systems/CollisionSystem.h
@@ -92,8 +92,8 @@ struct Partitions {
 class CollisionSystem {
  public:
   void operator()(const ContextFacade& ctx, const Iterable& /*iter*/) {
-    PROFILE_NAMED_SCOPE("Collision System Update");
-
+    // No scope timer here: Registry::Update already times this span as "CollisionSystem";
+    // a second name for the same span double-counts on the benchmark dashboard.
     auto* registry = ctx.GetRegistry();
     auto* eventBus = registry->Get<EngineContext>().eventBus;
 


### PR DESCRIPTION
## Summary

Three dashboard-quality fixes for the nightly macro benchmark pipeline (`bench.sh` -> `parse_bench_output.py` -> github-action-benchmark):

1. **p50 series.** The parser only emitted p95/p99/max, so a baseline shift was indistinguishable from tail growth. Every timer series now also gets `[p50]`. (ProjectileEmitSystem is the motivating case: p50 0.16 ms vs p99 1.12 ms.)
2. **COUNTER lines parsed.** `PerfCounters::Report()` emits per-frame `COUNTER:` lines (entity count, collision pairs, render-queue size) that the parser dropped. They now land on the dashboard as `[p50]`/`[max]` series with unit `count`, so workload drift no longer masquerades as a perf change. Always-zero series are skipped to avoid flatline noise.
3. **Duplicate-name dedupe.** `Registry::Update` wraps every system in both a TIMER scope and an ACCUM scope, and the accumulator map gets dumped to the log every frame (via CollisionSystem's async-path report session). The parser keyed by name only, silently merging both kinds into one distorted distribution. Series are now keyed by kind and the ACCUM twin is dropped whenever a TIMER series with the same name exists; ACCUM-only names (Sweep Bipartite and the other collision sub-phases) still flow through. CollisionSystem's redundant third name ("Collision System Update" inner scope) is removed engine-side — the Registry-level scope already times the same span.

## Verification

- Replay of a 10 s stress-scene log: 164 metrics, exactly one series per system, counters present, zero-valued counter series skipped.
- Full e2e with the rebuilt profiling binary: `bench.sh 8 | parser` -> 160 valid metrics, "Collision System Update" gone.
- `ctest` 19/19 green.

Dashboard note: new `[p50]` and `count` series appear, and former ACCUM-polluted distributions tighten — expect a one-time discontinuity in the benchmark history.
