### PR TITLE
Add registry.set_parent to the Lua entity API

### DIFF
--- a/docs/lua-scripting.md
+++ b/docs/lua-scripting.md
@@ -105,6 +105,16 @@ rb.velocity.x = 150
 rb.velocity.y = 0
 ```
 
+### Entity hierarchy
+
+| Function | Description |
+|---|---|
+| `registry.get_parent(entity)` | Returns the parent entity, or `nil` if the entity has no parent |
+| `registry.set_parent(child, parent)` | Parents `child` under `parent`, detaching it from any previous parent. Self-parenting and cycles are rejected with an error log. |
+
+Parented entities inherit their parent's transform — see
+[`docs/ecs-architecture.md`](ecs-architecture.md) for how the hierarchy is resolved.
+
 ### Convenience helpers
 
 These globals are shorthand for the most common reads and writes:

--- a/lua_api.smoke.lua
+++ b/lua_api.smoke.lua
@@ -1749,6 +1749,8 @@ function registry.has_text_label(...) end
 
 function registry.has_ui_button(...) end
 
+function registry.set_parent(...) end
+
 
 function reload_scene(...) end
 

--- a/src/Lua/Modules/EntityModuleLuaBinding.cpp
+++ b/src/Lua/Modules/EntityModuleLuaBinding.cpp
@@ -57,6 +57,21 @@ void SetEntitySpriteSrcRect(Registry* registry, const Entity entity, const float
   sprite.srcRect.y = srcRectY;
 }
 
+void SetEntityParent(Registry* registry, const Entity child, const Entity parent) {
+  if (child.id == parent.id) {
+    Logger::Error("set_parent: entity cannot be its own parent.");
+    return;
+  }
+  // Reject cycles: the new parent must not already be a descendant of the child.
+  for (auto ancestor = registry->GetParent(parent); ancestor.has_value(); ancestor = registry->GetParent(*ancestor)) {
+    if (ancestor->id == child.id) {
+      Logger::Error("set_parent: would create a hierarchy cycle.");
+      return;
+    }
+  }
+  registry->SetParent(child, parent);
+}
+
 void BlamEntities(Registry* registry, const sol::table& entities) {
   for (const auto& [key, value] : entities) {
     if (!value.is<Entity>()) {
@@ -95,6 +110,10 @@ void LuaModuleBinding<EntityModule>::install(sol::state& lua, LuaBindingContext&
     const auto parent = ctx.GetRegistry()->GetParent(entity);
     if (!parent.has_value()) return sol::lua_nil;
     return sol::make_object(state, parent.value());
+  });
+
+  reg.set_function("set_parent", [&ctx](const Entity child, const Entity parent) {
+    SetEntityParent(ctx.GetRegistry(), child, parent);
   });
 
   // Component has_/get_ accessors — driven by LuaComponentRegistry. Adding a new

--- a/tests/LuaBehaviorTest.cpp
+++ b/tests/LuaBehaviorTest.cpp
@@ -132,6 +132,35 @@ int main() {
     Check(RunLua(lua, "blam({ 42, 'nope' })"), "Lua: blam(table) tolerates non-entity entries");
   }
 
+  std::cout << "[registry.set_parent / get_parent round-trip]\n";
+  {
+    const Entity parent = reg->CreateEntity();
+    const Entity child = reg->CreateEntity();
+    lua["hier_parent"] = parent;
+    lua["hier_child"] = child;
+
+    Check(RunLua(lua, "assert(registry.get_parent(hier_child) == nil)"), "get_parent is nil before set_parent");
+    Check(RunLua(lua, "registry.set_parent(hier_child, hier_parent)"), "Lua: set_parent call succeeds");
+    Check(reg->GetParent(child).has_value() && reg->GetParent(child)->id == parent.id,
+          "set_parent wired child->parent in the registry");
+    Check(RunLua(lua, "assert(registry.get_parent(hier_child):get_id() == hier_parent:get_id())"),
+          "get_parent returns the parent handle");
+
+    const Entity second = reg->CreateEntity();
+    lua["hier_second"] = second;
+    Check(RunLua(lua, "registry.set_parent(hier_child, hier_second)"), "Lua: reparent call succeeds");
+    Check(reg->GetParent(child).has_value() && reg->GetParent(child)->id == second.id,
+          "reparent moved the child to the new parent");
+    Check(reg->GetChildren(parent).empty(), "reparent detached the child from the old parent");
+
+    // Self-parenting and cycles are rejected with an error log, not a Lua error.
+    Check(RunLua(lua, "registry.set_parent(hier_child, hier_child)"), "Lua: self-parent call tolerated");
+    Check(reg->GetParent(child).has_value() && reg->GetParent(child)->id == second.id,
+          "self-parent rejected, parent unchanged");
+    Check(RunLua(lua, "registry.set_parent(hier_second, hier_child)"), "Lua: cycle call tolerated");
+    Check(!reg->GetParent(second).has_value(), "cycle rejected, would-be grandparent unchanged");
+  }
+
   std::cout << "[load_entity: returns the root entity handle]\n";
   {
     Check(RunLua(lua,


### PR DESCRIPTION
Exposes the existing `Registry::SetParent` to scripts as `registry.set_parent(child, parent)`, alongside the already-bound `registry.get_parent`.

- Reparenting detaches the child from its previous parent (handled by `Registry::SetParent`).
- Self-parenting and hierarchy cycles are rejected with an error log instead of mutating the hierarchy, matching the no-throw error handling of the other entity helpers.
- Behavior coverage in `LuaBehaviorTest`: set/get round-trip, reparent detach, self-parent and cycle rejection.
- Regenerated `lua_api.smoke.lua`; documented the hierarchy functions in `docs/lua-scripting.md`.
