### PR TITLE
Add versioning and release system

### DIFF
--- a/.github/actions/setup-engine/action.yml
+++ b/.github/actions/setup-engine/action.yml
@@ -1,0 +1,113 @@
+name: Setup Octarine Engine
+description: |
+  Download and extract a versioned Octarine Engine SDK binary for the current
+  runner platform. After this action runs, `OctarineEngine` (or
+  `OctarineEngine.exe` on Windows) is on PATH and available as the `engine-bin`
+  output.
+
+  Assets are downloaded from the engine's GitHub Releases. The release tag must
+  match `v{engine-version}` (e.g. engine-version: '0.1.0' → tag v0.1.0).
+
+  Typical usage in a game repo:
+    - uses: mblackman/Octarine-Engine/.github/actions/setup-engine@v0.1.0
+      with:
+        engine-version: '0.1.0'
+    - run: OctarineEngine . -m bake
+
+inputs:
+  engine-version:
+    description: >
+      Engine version to download, without the 'v' prefix (e.g. '0.1.0').
+      Must match an existing GitHub Release tag (v{engine-version}).
+    required: true
+  token:
+    description: >
+      GitHub token used to authenticate the release download. Defaults to the
+      calling workflow's GITHUB_TOKEN, which is sufficient for public repos.
+    required: false
+    default: ${{ github.token }}
+  install-dir:
+    description: >
+      Directory to extract the engine into. Defaults to ~/.octarine-engine.
+      The directory is created if it does not exist.
+    required: false
+    default: ''
+
+outputs:
+  engine-path:
+    description: Absolute path to the directory containing the engine binary.
+    value: ${{ steps.extract.outputs.engine-path }}
+  engine-bin:
+    description: Absolute path to the OctarineEngine binary.
+    value: ${{ steps.extract.outputs.engine-bin }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve platform
+      id: platform
+      shell: bash
+      run: |
+        case "${{ runner.os }}" in
+          Linux)   echo "os=linux"   >> "$GITHUB_OUTPUT"; echo "ext=tar.gz" >> "$GITHUB_OUTPUT" ;;
+          Windows) echo "os=windows" >> "$GITHUB_OUTPUT"; echo "ext=zip"    >> "$GITHUB_OUTPUT" ;;
+          macOS)   echo "os=macos"   >> "$GITHUB_OUTPUT"; echo "ext=tar.gz" >> "$GITHUB_OUTPUT" ;;
+          *)       echo "Unsupported runner OS: ${{ runner.os }}"; exit 1 ;;
+        esac
+
+    - name: Download engine release asset
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+      run: |
+        version="${{ inputs.engine-version }}"
+        os="${{ steps.platform.outputs.os }}"
+        ext="${{ steps.platform.outputs.ext }}"
+        filename="OctarineEngine-${version}-${os}.${ext}"
+        echo "Downloading $filename from release v${version}"
+        # Use $RUNNER_TEMP (env var) instead of ${{ runner.temp }} so Git Bash on Windows
+        # sees a POSIX-style path rather than a raw Windows path literal.
+        gh release download "v${version}" \
+          --repo mblackman/Octarine-Engine \
+          --pattern "$filename" \
+          --dir "$RUNNER_TEMP/octarine-download"
+
+    - name: Extract engine binary
+      id: extract
+      shell: bash
+      run: |
+        version="${{ inputs.engine-version }}"
+        os="${{ steps.platform.outputs.os }}"
+        ext="${{ steps.platform.outputs.ext }}"
+        filename="OctarineEngine-${version}-${os}.${ext}"
+
+        # Resolve install directory
+        if [ -n "${{ inputs.install-dir }}" ]; then
+          dest="${{ inputs.install-dir }}"
+        else
+          dest="${HOME}/.octarine-engine"
+        fi
+        mkdir -p "$dest"
+
+        case "$ext" in
+          tar.gz)
+            tar -xzf "$RUNNER_TEMP/octarine-download/$filename" -C "$dest"
+            ;;
+          zip)
+            unzip -q "$RUNNER_TEMP/octarine-download/$filename" -d "$dest"
+            ;;
+        esac
+
+        # Locate binary
+        if [ "$os" = "windows" ]; then
+          bin="$dest/OctarineEngine.exe"
+        else
+          bin="$dest/OctarineEngine"
+          chmod +x "$bin"
+        fi
+
+        echo "engine-path=$dest" >> "$GITHUB_OUTPUT"
+        echo "engine-bin=$bin"   >> "$GITHUB_OUTPUT"
+        # Add to PATH so callers can invoke OctarineEngine directly
+        echo "$dest" >> "$GITHUB_PATH"
+        echo "Engine installed at $bin"

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -235,3 +235,171 @@ jobs:
           name: OctarineEngine-${{ matrix.platform }}
           path: ${{ matrix.pkg_glob }}
           if-no-files-found: error
+
+  # Build standalone editor-release binaries (no game project bundled) for use as SDK artifacts
+  # in game repo CI. Only runs on v* tag pushes — sdk builds are validated implicitly by build.yml
+  # running editor-release on every PR/push; here we just add artifact collection + archiving.
+  sdk:
+    name: SDK binary — ${{ matrix.platform }}
+    runs-on: ${{ matrix.os }}
+    if: startsWith(github.ref, 'refs/tags/v')
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platform: linux
+            preset: editor-release
+          - os: windows-latest
+            platform: windows
+            preset: editor-release
+          - os: macos-latest
+            platform: macos
+            preset: editor-release
+
+    steps:
+      - name: Checkout engine
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Export GitHub Actions cache env (vcpkg binary cache)
+        uses: ./.github/actions/vcpkg-cache-env
+
+      - name: Install Linux build deps (SDL3 / X11 / Wayland)
+        if: matrix.platform == 'linux'
+        uses: ./.github/actions/linux-build-deps
+
+      - name: Install Ninja (Windows/macOS)
+        if: matrix.platform != 'linux'
+        uses: seanmiddleditch/gha-setup-ninja@v6
+
+      - name: Setup MSVC dev environment (Windows)
+        if: matrix.platform == 'windows'
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+
+      - name: Configure CMake
+        run: cmake --preset ${{ matrix.preset }}
+
+      - name: Build
+        run: cmake --build build/${{ matrix.preset }} --config Release --parallel
+
+      # Stage the binary (+ any runtime dylibs/DLLs for dynamic triplets) into a flat directory
+      # and pack it. Linux/macOS default vcpkg triplets are static so the lib glob hits nothing;
+      # on Windows DLLs are always copied beside the exe by vcpkg app-local.
+      - name: Archive SDK binary (Linux / macOS)
+        if: matrix.platform != 'windows'
+        shell: bash
+        run: |
+          bin_dir="build/${{ matrix.preset }}/bin/release"
+          staging="_sdk_staging"
+          mkdir -p "$staging"
+          cp "$bin_dir/OctarineEngine" "$staging/"
+          for f in "$bin_dir"/*.so* "$bin_dir"/*.dylib; do
+            [ -f "$f" ] && cp "$f" "$staging/" || true
+          done
+          tar -czf "OctarineEngine-sdk.tar.gz" -C "$staging" .
+
+      - name: Archive SDK binary (Windows)
+        if: matrix.platform == 'windows'
+        shell: pwsh
+        run: |
+          $binDir = "build\${{ matrix.preset }}\bin\release"
+          $staging = "_sdk_staging"
+          New-Item -ItemType Directory -Force -Path $staging | Out-Null
+          Copy-Item "$binDir\OctarineEngine.exe" "$staging\"
+          Get-ChildItem "$binDir\*.dll" -ErrorAction SilentlyContinue | Copy-Item -Destination "$staging\"
+          Compress-Archive -Path "$staging\*" -DestinationPath "OctarineEngine-sdk.zip" -Force
+
+      - name: Upload SDK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: OctarineEngine-sdk-${{ matrix.platform }}
+          path: OctarineEngine-sdk.*
+          if-no-files-found: error
+
+  # Create the GitHub Release and attach all platform assets. Runs only on v* tag pushes after
+  # both the game package matrix and the SDK binary matrix complete. Game packages (CPack, engine +
+  # example game) are uploaded as OctarineEngine-example-* for reference/demo use; SDK binaries
+  # (standalone editor build, no game project) are uploaded as OctarineEngine-* for game CI use.
+  publish:
+    name: Publish GitHub Release
+    needs: [package, sdk]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download game packages
+        uses: actions/download-artifact@v4
+        with:
+          pattern: OctarineEngine-linux
+          path: release-assets/packages/linux/
+
+      - name: Download game packages (windows)
+        uses: actions/download-artifact@v4
+        with:
+          pattern: OctarineEngine-windows
+          path: release-assets/packages/windows/
+
+      - name: Download game packages (macos)
+        uses: actions/download-artifact@v4
+        with:
+          pattern: OctarineEngine-macos
+          path: release-assets/packages/macos/
+
+      - name: Download SDK binaries
+        uses: actions/download-artifact@v4
+        with:
+          pattern: OctarineEngine-sdk-*
+          merge-multiple: false
+          path: release-assets/sdk/
+
+      - name: Rename to canonical filenames
+        shell: bash
+        run: |
+          set -e
+          version="${GITHUB_REF#refs/tags/v}"
+
+          # SDK binaries → OctarineEngine-{version}-{platform}.{ext}
+          for dir in release-assets/sdk/OctarineEngine-sdk-*/; do
+            platform=$(basename "$dir" | sed 's/^OctarineEngine-sdk-//')
+            src=$(ls "$dir" | head -n 1)
+            case "$src" in *.tar.gz) ext=tar.gz ;; *.zip) ext=zip ;; esac
+            cp "$dir/$src" "OctarineEngine-${version}-${platform}.${ext}"
+          done
+
+          # Game packages → OctarineEngine-example-{version}-{platform}.{ext}
+          # download-artifact@v4 places each artifact's files in a subdirectory named after the
+          # artifact (e.g. release-assets/packages/linux/OctarineEngine-linux/<file>).
+          for platform in linux windows macos; do
+            dir="release-assets/packages/${platform}/OctarineEngine-${platform}/"
+            [ -d "$dir" ] || continue
+            src=$(ls "$dir" | head -n 1)
+            case "$src" in *.tar.gz) ext=tar.gz ;; *.zip) ext=zip ;; *.dmg) ext=dmg ;; esac
+            cp "$dir/$src" "OctarineEngine-example-${version}-${platform}.${ext}"
+          done
+
+          echo "--- staged release assets ---"
+          ls -la OctarineEngine-*
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          version="${GITHUB_REF#refs/tags/v}"
+          # Collect all staged assets (sdk + example packages)
+          assets=()
+          for f in OctarineEngine-*; do
+            [ -f "$f" ] && assets+=("$f")
+          done
+          gh release create "$GITHUB_REF_NAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "Octarine Engine v${version}" \
+            --generate-notes \
+            "${assets[@]}"

--- a/cmake/OctarinePackage.cmake
+++ b/cmake/OctarinePackage.cmake
@@ -368,6 +368,18 @@ function(octarine_package TARGET)
     _octarine_resolve_identity(_pkg_id          "${OCTARINE_PACKAGE_ID}"           "${_pi_package_id}"   "")
     _octarine_validate_identity("${OP_PROJECT}" "${_pkg_name}" "${_pkg_id}" "${_pkg_version}" ON)
 
+    # Soft engine version check: warn when project.ini declares an engine_version that doesn't
+    # match the engine being built against. Not fatal — the developer may be intentionally
+    # testing a newer engine — but surfacing the mismatch at configure time avoids surprises.
+    if (DEFINED _pi_engine_version AND NOT "${_pi_engine_version}" STREQUAL "")
+        if (NOT "${_pi_engine_version}" VERSION_EQUAL "${PROJECT_VERSION}")
+            message(WARNING
+                "Octarine: project.ini engine_version=${_pi_engine_version} does not match "
+                "building engine ${PROJECT_VERSION}. Update engine_version in project.ini "
+                "once you have validated the game against this engine build.")
+        endif ()
+    endif ()
+
     # ---- Per-project platform knobs ------------------------------------------------------------
     # Same CLI > project.ini > default precedence as identity. Resolved here so the desktop branch
     # (orientation/fullscreen reserved for downstream consumers) and the Android Gradle host

--- a/docs/making-games.md
+++ b/docs/making-games.md
@@ -24,7 +24,8 @@ it alongside this guide whenever an example would help.
 10. [Audio](#10-audio)
 11. [Camera](#11-camera)
 12. [Using the Editor](#12-using-the-editor)
-13. [Further Reading](#13-further-reading)
+13. [Game CI](#13-game-ci)
+14. [Further Reading](#14-further-reading)
 
 ---
 
@@ -32,29 +33,31 @@ it alongside this guide whenever an example would help.
 
 Before writing game code you need a built copy of the engine.
 
-### Option A — Download a pre-built binary (recommended)
+### Option A — Download a versioned release (recommended)
 
-CI builds the engine for Windows, macOS, and Linux on every push to `main`.
-Download the artifact for your platform from the
-[Actions tab](https://github.com/mblackman/Octarine-Engine/actions) on GitHub:
+Pre-built engine binaries are published as assets on every
+[GitHub Release](https://github.com/mblackman/Octarine-Engine/releases).
 
-1. Open the latest successful **Build** workflow run.
-2. Scroll to **Artifacts** at the bottom.
-3. Download `OctarineEngine-<platform>-editor-release` for day-to-day development
-   or `OctarineEngine-<platform>-player-release` for a runtime-only build with no
-   editor tools.
-4. Unzip and run the binary directly — no install step required.
+1. Open the release matching your target engine version (e.g. `v0.1.0`).
+2. Download the SDK binary for your platform:
 
-Available artifact names:
-
-| Artifact | Contents |
+| Asset | Platform |
 |---|---|
-| `OctarineEngine-windows-editor-release` | Windows editor build |
-| `OctarineEngine-windows-player-release` | Windows player-only build |
-| `OctarineEngine-macos-editor-release` | macOS editor build |
-| `OctarineEngine-macos-player-release` | macOS player-only build |
-| `OctarineEngine-linux-editor-release` | Linux editor build |
-| `OctarineEngine-linux-player-release` | Linux player-only build |
+| `OctarineEngine-{version}-linux.tar.gz` | Linux x64 |
+| `OctarineEngine-{version}-windows.zip` | Windows x64 |
+| `OctarineEngine-{version}-macos.tar.gz` | macOS (arm64) |
+
+3. Extract the archive and run the binary directly — no install step required:
+
+```bash
+# Linux / macOS
+tar -xzf OctarineEngine-0.1.0-linux.tar.gz
+./OctarineEngine path/to/MyGame
+
+# Windows (PowerShell)
+Expand-Archive OctarineEngine-0.1.0-windows.zip
+.\OctarineEngine.exe path/to/MyGame
+```
 
 ### Option B — Build from source
 
@@ -111,6 +114,8 @@ script — organise the rest however suits your project.
 
 ## 3. Configuration
 
+### `config.ini` — runtime window settings
+
 `config.ini` lives at the project root and controls window setup:
 
 ```ini
@@ -125,6 +130,39 @@ DefaultScalingMode=nearest      # 'nearest' for pixel art, 'linear' for smooth
 
 `StartupScript` is the first Lua file that runs. Everything else — scenes,
 assets, entities — is loaded from there.
+
+### `project.ini` — packaging and release identity
+
+`project.ini` is the single source of truth for your game's release identity.
+It is read by the engine's CMake packaging helper, Android Gradle build, and
+the engine version check. The format is flat `key = value` (no sections).
+
+```ini
+name          = My Awesome Game
+package_id    = com.studio.myawesomegame    # reverse-DNS, required for shipping
+version_name  = 1.0.0                       # semver displayed in stores / About
+version_code  = 1                           # monotonic integer for store updates
+vendor        = My Studio
+description   = A short description for store listings.
+icon          = images/icon.png             # source PNG for icon generation
+engine_version = 0.1.0                     # engine version this project targets
+```
+
+| Key | Required for shipping | Notes |
+|---|---|---|
+| `name` | Yes | Display name |
+| `package_id` | Yes | Reverse-DNS (e.g. `com.studio.mygame`) |
+| `version_name` | Yes | SemVer string |
+| `version_code` | No | Monotonic int; defaults to 1 |
+| `vendor` | No | Studio / publisher name |
+| `description` | No | One-line store summary |
+| `icon` | No | Source image for icon generation |
+| `engine_version` | No | Declared engine version; checked at package time |
+
+The `engine_version` field is used by the `setup-engine` action in game CI (see
+[Game CI](#game-ci)) and checked at CMake configure time — a mismatch emits a
+warning so you know when a game project is being built against a newer or older
+engine than intended.
 
 ---
 
@@ -405,7 +443,68 @@ reference and keyboard shortcuts.
 
 ---
 
-## 13. Further Reading
+## 13. Game CI
+
+The `setup-engine` composite action downloads the right SDK binary for the
+current runner platform and adds it to `PATH`. Use it in game repo workflows to
+bake assets or run the game headlessly without building the engine from source.
+
+### Basic usage
+
+```yaml
+# .github/workflows/ci.yml (in your game repo)
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: mblackman/Octarine-Engine/.github/actions/setup-engine@v0.1.0
+        with:
+          engine-version: '0.1.0'   # pin to the version in project.ini
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Bake the asset manifest (validates all asset references)
+      - run: OctarineEngine . -m bake
+```
+
+### Pinning the engine version
+
+Declare the engine version in your `project.ini` so it is visible alongside
+your other identity metadata:
+
+```ini
+engine_version = 0.1.0
+```
+
+When you package the game (`cmake --preset ship-release ...`) the engine
+compares this value against its own version at configure time and warns if
+they differ, making version drift visible before it reaches CI.
+
+### Available outputs
+
+| Output | Description |
+|---|---|
+| `engine-path` | Directory containing the engine binary |
+| `engine-bin` | Full path to the `OctarineEngine` binary |
+
+### Multi-platform matrix
+
+```yaml
+strategy:
+  matrix:
+    os: [ubuntu-latest, windows-latest, macos-latest]
+runs-on: ${{ matrix.os }}
+steps:
+  - uses: mblackman/Octarine-Engine/.github/actions/setup-engine@v0.1.0
+    with:
+      engine-version: '0.1.0'
+  - run: OctarineEngine . -m bake
+```
+
+---
+
+## 14. Further Reading
 
 ### Engine documentation
 


### PR DESCRIPTION
## Summary

- **GitHub Releases**: `package.yml` gains two new jobs (`sdk` and `publish`) that run only on `v*` tag pushes. `sdk` builds standalone editor-release binaries per platform and archives them. `publish` collects both the SDK binaries and the CPack game packages, renames them to canonical predictable names, and creates a GitHub Release with `gh release create --generate-notes`.

- **`setup-engine` action**: New composite action at `.github/actions/setup-engine/`. Game repos can reference `mblackman/Octarine-Engine/.github/actions/setup-engine@v{ver}` to download the SDK binary for their runner platform, extract it, and get `OctarineEngine` on `PATH` — no source build required.

- **`engine_version` in `project.ini`**: `OctarinePackage.cmake` now reads `engine_version` from the game project's `project.ini` and emits a configure-time `WARNING` if it differs from the building engine's version. Soft check — never blocks the build.

- **Docs**: `making-games.md` updated to reference versioned GitHub Releases (not ephemeral CI artifacts), adds a `project.ini` reference table with all keys including `engine_version`, and adds a new "Game CI" section with `setup-engine` usage examples.

## Release asset naming

| Asset | Purpose |
|---|---|
| `OctarineEngine-{ver}-linux.tar.gz` | SDK binary — Linux x64 |
| `OctarineEngine-{ver}-windows.zip` | SDK binary — Windows x64 |
| `OctarineEngine-{ver}-macos.tar.gz` | SDK binary — macOS arm64 |
| `OctarineEngine-example-{ver}-linux.tar.gz` | CPack game package — Linux |
| `OctarineEngine-example-{ver}-windows.zip` | CPack game package — Windows |
| `OctarineEngine-example-{ver}-macos.dmg` | CPack game package — macOS |

## Test plan

- [ ] Push a `v0.1.0` tag — confirm `sdk` legs build and `publish` job creates a GitHub Release with all 6 assets
- [ ] In a game repo, add `setup-engine@v0.1.0` step and verify `OctarineEngine . -m bake` succeeds
- [ ] Add `engine_version = 0.1.0` to a game `project.ini`, run `cmake --preset ship-release -DOCTARINE_PACKAGE_PROJECT=...` — no warning when matching, WARNING when mismatched
- [ ] Non-tag pushes and PRs: confirm `sdk` and `publish` jobs are skipped, `package` job still runs as before