### PR TITLE
Fix setup-engine action: Windows-compatible GITHUB_PATH via cygpath

### DIFF
--- a/.github/actions/setup-engine/action.yml
+++ b/.github/actions/setup-engine/action.yml
@@ -115,6 +115,11 @@ runs:
 
         echo "engine-path=$dest" >> "$GITHUB_OUTPUT"
         echo "engine-bin=$bin"   >> "$GITHUB_OUTPUT"
-        # Add to PATH so callers can invoke OctarineEngine directly
-        echo "$dest" >> "$GITHUB_PATH"
+        # Add to PATH. On Windows, GITHUB_PATH must be a Windows-style path so PowerShell
+        # steps can resolve the binary — write it through cygpath when available.
+        if command -v cygpath &>/dev/null; then
+          echo "$(cygpath -w "$dest")" >> "$GITHUB_PATH"
+        else
+          echo "$dest" >> "$GITHUB_PATH"
+        fi
         echo "Engine installed at $bin"


### PR DESCRIPTION
## Summary

- `setup-engine` action now writes a Windows-style path (e.g. `C:\Users\runner\.octarine-engine`) to `$GITHUB_PATH` on Windows runners by running the path through `cygpath -w`
- On Linux/macOS the POSIX path is written unchanged (no `cygpath` available)
- Fixes the Windows leg of the Octarine-Engine-Example release workflow, where `Get-Command OctarineEngine.exe` failed because PowerShell couldn't resolve the POSIX path written by bash

## Test plan

- [ ] Merge and create a v0.1.x engine tag (or re-run example repo workflow_dispatch) — Windows leg should find `OctarineEngine.exe` in PATH
- [ ] Linux/macOS legs should be unaffected