### PR TITLE
Fix setup-engine: convert step outputs to Windows paths via cygpath

### DIFF
--- a/.github/actions/setup-engine/action.yml
+++ b/.github/actions/setup-engine/action.yml
@@ -113,13 +113,15 @@ runs:
           chmod +x "$bin"
         fi
 
-        echo "engine-path=$dest" >> "$GITHUB_OUTPUT"
-        echo "engine-bin=$bin"   >> "$GITHUB_OUTPUT"
-        # Add to PATH. On Windows, GITHUB_PATH must be a Windows-style path so PowerShell
-        # steps can resolve the binary — write it through cygpath when available.
+        # On Windows, GITHUB_PATH and step outputs must use Windows-style paths so
+        # PowerShell steps can resolve them — convert through cygpath when available.
         if command -v cygpath &>/dev/null; then
+          echo "engine-path=$(cygpath -w "$dest")" >> "$GITHUB_OUTPUT"
+          echo "engine-bin=$(cygpath -w "$bin")"   >> "$GITHUB_OUTPUT"
           echo "$(cygpath -w "$dest")" >> "$GITHUB_PATH"
         else
+          echo "engine-path=$dest" >> "$GITHUB_OUTPUT"
+          echo "engine-bin=$bin"   >> "$GITHUB_OUTPUT"
           echo "$dest" >> "$GITHUB_PATH"
         fi
         echo "Engine installed at $bin"


### PR DESCRIPTION
## Summary

Follow-up to #165. The previous cygpath fix only converted `GITHUB_PATH` to a Windows-style path; the `engine-path` and `engine-bin` step outputs were still POSIX paths (e.g. `/c/Users/runner/.octarine-engine/OctarineEngine.exe`).

When a downstream PowerShell step uses `${{ steps.engine-sdk.outputs.engine-bin }}`, PowerShell resolves `/c/...` as `D:\c\...` (current drive + relative path), causing `Copy-Item` to fail with "path does not exist".

This fix runs both outputs through `cygpath -w` alongside `GITHUB_PATH` so all three are consistent Windows paths on Windows runners.

## Test plan

- [ ] Merge and re-run the Octarine-Engine-Example release workflow — Windows leg should copy `OctarineEngine.exe` cleanly