### PR TITLE
Add native anchor-based UI layout system

### DIFF
--- a/components.json
+++ b/components.json
@@ -98,10 +98,28 @@
       "get_accessor": "registry.get_text_label"
     },
     {
+      "lua_key": "ui_anchor",
+      "usertype": "ui_anchor_component",
+      "has_accessor": "registry.has_ui_anchor",
+      "get_accessor": "registry.get_ui_anchor"
+    },
+    {
       "lua_key": "ui_button",
       "usertype": "ui_button_component",
       "has_accessor": "registry.has_ui_button",
       "get_accessor": "registry.get_ui_button"
+    },
+    {
+      "lua_key": "ui_canvas",
+      "usertype": "ui_canvas_component",
+      "has_accessor": "registry.has_ui_canvas",
+      "get_accessor": "registry.get_ui_canvas"
+    },
+    {
+      "lua_key": "ui_rect",
+      "usertype": "ui_rect_component",
+      "has_accessor": "registry.has_ui_rect",
+      "get_accessor": "registry.get_ui_rect"
     }
   ]
 }

--- a/events.json
+++ b/events.json
@@ -115,7 +115,7 @@
         },
         {
           "file": "src/Systems/UIButtonSystem.h",
-          "line": 24,
+          "line": 25,
           "owner": "UIButtonSystem"
         }
       ]

--- a/lua_api.smoke.lua
+++ b/lua_api.smoke.lua
@@ -1713,7 +1713,13 @@ function registry.get_square(...) end
 
 function registry.get_text_label(...) end
 
+function registry.get_ui_anchor(...) end
+
 function registry.get_ui_button(...) end
+
+function registry.get_ui_canvas(...) end
+
+function registry.get_ui_rect(...) end
 
 function registry.has_animation(...) end
 
@@ -1747,7 +1753,13 @@ function registry.has_square(...) end
 
 function registry.has_text_label(...) end
 
+function registry.has_ui_anchor(...) end
+
 function registry.has_ui_button(...) end
+
+function registry.has_ui_canvas(...) end
+
+function registry.has_ui_rect(...) end
 
 function registry.set_parent(...) end
 
@@ -1794,8 +1806,30 @@ function stop_scene(...) end
 text_label_component = {}
 
 
+---@class ui
+ui = {}
+
+function ui.anchor(...) end
+
+function ui.canvas(...) end
+
+function ui.flex(...) end
+
+
+---@class ui_anchor_component
+ui_anchor_component = {}
+
+
 ---@class ui_button_component
 ui_button_component = {}
+
+
+---@class ui_canvas_component
+ui_canvas_component = {}
+
+
+---@class ui_rect_component
+ui_rect_component = {}
 
 
 ---@class vec2

--- a/modules.json
+++ b/modules.json
@@ -35,6 +35,11 @@
       "name": "Game",
       "binding_header": "src/Lua/Modules/GameModuleLuaBinding.h",
       "globals": ["fire_projectile", "get_camera_position", "get_game_map_dimensions", "quit_game", "set_game_map_dimensions", "set_perf_overlay"]
+    },
+    {
+      "name": "UI",
+      "binding_header": "src/Lua/Modules/UIModuleLuaBinding.h",
+      "globals": ["ui"]
     }
   ]
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -122,6 +122,7 @@ octarine_library(octarine_lua
         Lua/Modules/LogModuleLuaBinding.cpp
         Lua/Modules/RegisterAllModules.cpp
         Lua/Modules/SceneModuleLuaBinding.cpp
+        Lua/Modules/UIModuleLuaBinding.cpp
 )
 target_link_libraries(octarine_lua PUBLIC
         octarine_core

--- a/src/Components/UIAnchorComponent.h
+++ b/src/Components/UIAnchorComponent.h
@@ -1,0 +1,25 @@
+#pragma once
+
+struct UIAnchorComponent {
+  float anchorLeft = 0.f;
+  float anchorTop = 0.f;
+  float anchorRight = 1.f;
+  float anchorBottom = 1.f;
+  float offsetLeft = 0.f;
+  float offsetTop = 0.f;
+  float offsetRight = 0.f;
+  float offsetBottom = 0.f;
+
+  explicit UIAnchorComponent(const float t_anchorLeft = 0.f, const float t_anchorTop = 0.f,
+                             const float t_anchorRight = 1.f, const float t_anchorBottom = 1.f,
+                             const float t_offsetLeft = 0.f, const float t_offsetTop = 0.f,
+                             const float t_offsetRight = 0.f, const float t_offsetBottom = 0.f)
+      : anchorLeft(t_anchorLeft),
+        anchorTop(t_anchorTop),
+        anchorRight(t_anchorRight),
+        anchorBottom(t_anchorBottom),
+        offsetLeft(t_offsetLeft),
+        offsetTop(t_offsetTop),
+        offsetRight(t_offsetRight),
+        offsetBottom(t_offsetBottom) {}
+};

--- a/src/Components/UICanvasComponent.h
+++ b/src/Components/UICanvasComponent.h
@@ -1,0 +1,10 @@
+#pragma once
+
+struct UICanvasComponent {
+  bool isFixed = true;
+  float width = 0.f;   // 0 = use viewport width at layout time
+  float height = 0.f;  // 0 = use viewport height at layout time
+
+  explicit UICanvasComponent(const bool t_isFixed = true, const float t_width = 0.f, const float t_height = 0.f)
+      : isFixed(t_isFixed), width(t_width), height(t_height) {}
+};

--- a/src/Components/UIRectComponent.h
+++ b/src/Components/UIRectComponent.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <glm/glm.hpp>
+
+struct UIRectComponent {
+  float left = 0.f;
+  float top = 0.f;
+  float right = 0.f;
+  float bottom = 0.f;
+
+  explicit UIRectComponent(const float t_left = 0.f, const float t_top = 0.f, const float t_right = 0.f,
+                           const float t_bottom = 0.f)
+      : left(t_left), top(t_top), right(t_right), bottom(t_bottom) {}
+
+  [[nodiscard]] float Width() const { return right - left; }
+  [[nodiscard]] float Height() const { return bottom - top; }
+  [[nodiscard]] glm::vec2 Center() const {
+    static constexpr float kHalf = 0.5f;
+    return {(left + right) * kHalf, (top + bottom) * kHalf};
+  }
+};

--- a/src/Game/Game.cpp
+++ b/src/Game/Game.cpp
@@ -76,10 +76,12 @@
 #include "Systems/RenderPrimitiveSystem.h"
 #include "Systems/RenderSpriteSystem.h"
 #include "Systems/RenderTextSystem.h"
+#include "Systems/RenderUISpriteSystem.h"
 #include "Systems/ScriptSystem.h"
 #include "Systems/SpatialAudioSystem.h"
 #include "Systems/TransformSystem.h"
 #include "Systems/UIButtonSystem.h"
+#include "Systems/UILayoutSystem.h"
 #include "Systems/UpdateListenerTransformSystem.h"
 #include "Systems/VelocityIntegrationSystem.h"
 
@@ -620,8 +622,14 @@ void Game::Setup() {
 
   auto cameraFollow = registry_->RegisterSystem<PositionComponent, CameraFollowComponent>(CameraFollowSystem());
 
+  // UI layout pass: resolves UIRectComponent for all canvas descendants. Runs after TransformSystem
+  // so world-parented canvases see up-to-date globals; runs before render systems that read UIRectComponent.
+  auto uiLayout = registry_->RegisterBulkSystem(UILayoutSystem());
+  registry_->Order(uiLayout).After(transform);
+
   // Render queue producers
   registry_->RegisterParallelSystem<GlobalTransformComponent, SpriteComponent>(RenderSpriteSystem());
+  registry_->RegisterSystem<UIRectComponent, SpriteComponent>(RenderUISpriteSystem());
   registry_->RegisterSystem<TextLabelComponent>(RenderTextSystem());
   registry_->RegisterParallelSystem<SquarePrimitiveComponent, GlobalTransformComponent>(RenderPrimitiveSystem());
 

--- a/src/Lua/Bindings/RegisterAllBindings.cpp
+++ b/src/Lua/Bindings/RegisterAllBindings.cpp
@@ -17,7 +17,10 @@
 #include "Lua/Bindings/SpriteComponentLuaBinding.h"
 #include "Lua/Bindings/SquarePrimitiveComponentLuaBinding.h"
 #include "Lua/Bindings/TextLabelComponentLuaBinding.h"
+#include "Lua/Bindings/UIAnchorComponentLuaBinding.h"
 #include "Lua/Bindings/UIButtonComponentLuaBinding.h"
+#include "Lua/Bindings/UICanvasComponentLuaBinding.h"
+#include "Lua/Bindings/UIRectComponentLuaBinding.h"
 
 void RegisterAllLuaBindings() {
   LuaComponentRegistry::clear();
@@ -38,4 +41,7 @@ void RegisterAllLuaBindings() {
   LuaComponentRegistry::registerComponent<ScaleComponent>();
   LuaComponentRegistry::registerComponent<PositionComponent>();
   LuaComponentRegistry::registerComponent<RotationComponent>();
+  LuaComponentRegistry::registerComponent<UICanvasComponent>();
+  LuaComponentRegistry::registerComponent<UIAnchorComponent>();
+  LuaComponentRegistry::registerComponent<UIRectComponent>();
 }

--- a/src/Lua/Bindings/UIAnchorComponentLuaBinding.h
+++ b/src/Lua/Bindings/UIAnchorComponentLuaBinding.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <sol/sol.hpp>
+
+#include "Components/UIAnchorComponent.h"
+#include "Lua/Bindings/LuaBinding.h"
+
+template <>
+struct LuaBinding<UIAnchorComponent> {
+  static constexpr const char* kLuaKey = "ui_anchor";
+  static constexpr const char* kUsertypeName = "ui_anchor_component";
+
+  static UIAnchorComponent fromLua(const sol::object& data) {
+    const auto t = data.as<sol::table>();
+    using namespace LuaComponentHelpers;
+    return UIAnchorComponent(
+        SafeGetOptionalValue<float>(t, "left", 0.f), SafeGetOptionalValue<float>(t, "top", 0.f),
+        SafeGetOptionalValue<float>(t, "right", 1.f), SafeGetOptionalValue<float>(t, "bottom", 1.f),
+        SafeGetOptionalValue<float>(t, "offset_left", 0.f), SafeGetOptionalValue<float>(t, "offset_top", 0.f),
+        SafeGetOptionalValue<float>(t, "offset_right", 0.f), SafeGetOptionalValue<float>(t, "offset_bottom", 0.f));
+  }
+
+  static void bindUsertype(sol::state& lua) {
+    lua.new_usertype<UIAnchorComponent>(
+        kUsertypeName, "anchor_left", &UIAnchorComponent::anchorLeft, "anchor_top", &UIAnchorComponent::anchorTop,
+        "anchor_right", &UIAnchorComponent::anchorRight, "anchor_bottom", &UIAnchorComponent::anchorBottom,
+        "offset_left", &UIAnchorComponent::offsetLeft, "offset_top", &UIAnchorComponent::offsetTop, "offset_right",
+        &UIAnchorComponent::offsetRight, "offset_bottom", &UIAnchorComponent::offsetBottom);
+  }
+};

--- a/src/Lua/Bindings/UICanvasComponentLuaBinding.h
+++ b/src/Lua/Bindings/UICanvasComponentLuaBinding.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <sol/sol.hpp>
+
+#include "Components/UICanvasComponent.h"
+#include "Lua/Bindings/LuaBinding.h"
+
+template <>
+struct LuaBinding<UICanvasComponent> {
+  static constexpr const char* kLuaKey = "ui_canvas";
+  static constexpr const char* kUsertypeName = "ui_canvas_component";
+
+  static UICanvasComponent fromLua(const sol::object& data) {
+    const auto t = data.as<sol::table>();
+    using namespace LuaComponentHelpers;
+    return UICanvasComponent(SafeGetOptionalValue<bool>(t, "is_fixed", true),
+                             SafeGetOptionalValue<float>(t, "width", 0.f),
+                             SafeGetOptionalValue<float>(t, "height", 0.f));
+  }
+
+  static void bindUsertype(sol::state& lua) {
+    lua.new_usertype<UICanvasComponent>(kUsertypeName, "is_fixed", &UICanvasComponent::isFixed, "width",
+                                        &UICanvasComponent::width, "height", &UICanvasComponent::height);
+  }
+};

--- a/src/Lua/Bindings/UIRectComponentLuaBinding.h
+++ b/src/Lua/Bindings/UIRectComponentLuaBinding.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <sol/sol.hpp>
+
+#include "Components/UIRectComponent.h"
+#include "Lua/Bindings/LuaBinding.h"
+
+template <>
+struct LuaBinding<UIRectComponent> {
+  static constexpr const char* kLuaKey = "ui_rect";
+  static constexpr const char* kUsertypeName = "ui_rect_component";
+
+  // UIRectComponent is written by UILayoutSystem; fromLua is a stub for registry accessor symmetry.
+  static UIRectComponent fromLua(const sol::object&) { return UIRectComponent{}; }
+
+  static void bindUsertype(sol::state& lua) {
+    lua.new_usertype<UIRectComponent>(
+        kUsertypeName, "left", sol::property([](const UIRectComponent& r) { return r.left; }), "top",
+        sol::property([](const UIRectComponent& r) { return r.top; }), "right",
+        sol::property([](const UIRectComponent& r) { return r.right; }), "bottom",
+        sol::property([](const UIRectComponent& r) { return r.bottom; }), "width",
+        sol::property(&UIRectComponent::Width), "height", sol::property(&UIRectComponent::Height), "center",
+        sol::property(&UIRectComponent::Center));
+  }
+};

--- a/src/Lua/Modules/RegisterAllModules.cpp
+++ b/src/Lua/Modules/RegisterAllModules.cpp
@@ -8,12 +8,13 @@
 #include "Lua/Modules/LogModuleLuaBinding.h"
 #include "Lua/Modules/LuaModule.h"
 #include "Lua/Modules/SceneModuleLuaBinding.h"
+#include "Lua/Modules/UIModuleLuaBinding.h"
 
 const std::vector<LuaModuleDescriptor> kLuaModules = {
     {"Log", &LuaModuleBinding<LogModule>::install},       {"Io", &LuaModuleBinding<IoModule>::install},
     {"Assets", &LuaModuleBinding<AssetsModule>::install}, {"Audio", &LuaModuleBinding<AudioModule>::install},
     {"Entity", &LuaModuleBinding<EntityModule>::install}, {"Scene", &LuaModuleBinding<SceneModule>::install},
-    {"Game", &LuaModuleBinding<GameModule>::install},
+    {"Game", &LuaModuleBinding<GameModule>::install},     {"UI", &LuaModuleBinding<UIModule>::install},
 };
 
 void RegisterAllLuaModules(sol::state& lua, LuaBindingContext& ctx) {

--- a/src/Lua/Modules/UIModuleLuaBinding.cpp
+++ b/src/Lua/Modules/UIModuleLuaBinding.cpp
@@ -1,0 +1,97 @@
+#include "Lua/Modules/UIModuleLuaBinding.h"
+
+#include <string>
+
+#include "Components/UIAnchorComponent.h"
+#include "Components/UICanvasComponent.h"
+#include "Components/UIRectComponent.h"
+#include "ECS/Registry.h"
+#include "General/Logger.h"
+#include "Lua/LuaBindingContext.h"
+
+namespace {
+
+constexpr float kHalf = 0.5f;
+constexpr float kCenter = 0.5f;
+
+UIAnchorComponent ResolvePreset(const std::string& name, const float w, const float h, const float margin) {
+  if (name == "fill") return UIAnchorComponent{0.f, 0.f, 1.f, 1.f, margin, margin, -margin, -margin};
+  if (name == "center")
+    return UIAnchorComponent{kCenter, kCenter, kCenter, kCenter, -w * kHalf, -h * kHalf, w * kHalf, h * kHalf};
+  if (name == "top_left") return UIAnchorComponent{0.f, 0.f, 0.f, 0.f, 0.f, 0.f, w, h};
+  if (name == "top_right") return UIAnchorComponent{1.f, 0.f, 1.f, 0.f, -w, 0.f, 0.f, h};
+  if (name == "bottom_left") return UIAnchorComponent{0.f, 1.f, 0.f, 1.f, 0.f, -h, w, 0.f};
+  if (name == "bottom_right") return UIAnchorComponent{1.f, 1.f, 1.f, 1.f, -w, -h, 0.f, 0.f};
+  if (name == "top_center") return UIAnchorComponent{kCenter, 0.f, kCenter, 0.f, -w * kHalf, 0.f, w * kHalf, h};
+  if (name == "bottom_center") return UIAnchorComponent{kCenter, 1.f, kCenter, 1.f, -w * kHalf, -h, w * kHalf, 0.f};
+  if (name == "left") return UIAnchorComponent{0.f, 0.f, 0.f, 1.f, 0.f, 0.f, w, 0.f};
+  if (name == "right") return UIAnchorComponent{1.f, 0.f, 1.f, 1.f, -w, 0.f, 0.f, 0.f};
+  Logger::Warn("ui.anchor: unknown preset '" + name + "'; defaulting to fill.");
+  return UIAnchorComponent{0.f, 0.f, 1.f, 1.f, margin, margin, -margin, -margin};
+}
+
+void AttachAnchor(Registry* r, const Entity entity, const UIAnchorComponent& anchor) {
+  if (r->HasComponent<UIAnchorComponent>(entity)) {
+    r->GetComponent<UIAnchorComponent>(entity) = anchor;
+  } else {
+    r->AddComponent(entity, anchor);
+  }
+  if (!r->HasComponent<UIRectComponent>(entity)) {
+    r->AddComponent(entity, UIRectComponent{});
+  }
+}
+
+}  // namespace
+
+void LuaModuleBinding<UIModule>::install(sol::state& lua, LuaBindingContext& ctx) {
+  sol::table ui = lua.create_table();
+
+  ui.set_function("canvas", [&ctx](const Entity entity, sol::optional<sol::table> opts) {
+    Registry* r = ctx.GetRegistry();
+    UICanvasComponent canvas;
+    if (opts) {
+      canvas.isFixed = (*opts)["fixed"].get_or(true);
+      canvas.width = static_cast<float>((*opts)["width"].get_or(0.0));
+      canvas.height = static_cast<float>((*opts)["height"].get_or(0.0));
+    }
+    r->AddComponent(entity, canvas);
+    if (!r->HasComponent<UIRectComponent>(entity)) {
+      r->AddComponent(entity, UIRectComponent{});
+    }
+  });
+
+  ui.set_function("anchor",
+                  [&ctx](const Entity entity, const sol::object& preset_or_table, sol::optional<sol::table> opts) {
+                    Registry* r = ctx.GetRegistry();
+                    if (preset_or_table.is<std::string>()) {
+                      float w = 0.f, h = 0.f, margin = 0.f;
+                      if (opts) {
+                        w = static_cast<float>((*opts)["width"].get_or(0.0));
+                        h = static_cast<float>((*opts)["height"].get_or(0.0));
+                        margin = static_cast<float>((*opts)["margin"].get_or(0.0));
+                      }
+                      AttachAnchor(r, entity, ResolvePreset(preset_or_table.as<std::string>(), w, h, margin));
+                    } else if (preset_or_table.is<sol::table>()) {
+                      const auto t = preset_or_table.as<sol::table>();
+                      UIAnchorComponent anchor;
+                      anchor.anchorLeft = t["left"].get_or(0.f);
+                      anchor.anchorTop = t["top"].get_or(0.f);
+                      anchor.anchorRight = t["right"].get_or(1.f);
+                      anchor.anchorBottom = t["bottom"].get_or(1.f);
+                      anchor.offsetLeft = t["offset_left"].get_or(0.f);
+                      anchor.offsetTop = t["offset_top"].get_or(0.f);
+                      anchor.offsetRight = t["offset_right"].get_or(0.f);
+                      anchor.offsetBottom = t["offset_bottom"].get_or(0.f);
+                      AttachAnchor(r, entity, anchor);
+                    } else {
+                      Logger::Warn("ui.anchor: second argument must be a preset name (string) or an anchor table.");
+                    }
+                  });
+
+  // Phase 4 slot — warns and does nothing until flex containers are implemented.
+  ui.set_function("flex", [](const Entity /*entity*/, const sol::optional<sol::table>& /*opts*/) {
+    Logger::Warn("ui.flex: flex containers are not yet implemented. This call has no effect.");
+  });
+
+  lua["ui"] = ui;
+}

--- a/src/Lua/Modules/UIModuleLuaBinding.h
+++ b/src/Lua/Modules/UIModuleLuaBinding.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "Lua/Modules/LuaModule.h"
+
+struct UIModule {};
+
+template <>
+struct LuaModuleBinding<UIModule> {
+  static void install(sol::state& lua, LuaBindingContext& ctx);
+};

--- a/src/Systems/RenderTextSystem.h
+++ b/src/Systems/RenderTextSystem.h
@@ -16,6 +16,7 @@
 #include "Components/CameraComponents.h"
 #include "Components/GlobalTransformComponent.h"
 #include "Components/TextLabelComponent.h"
+#include "Components/UIRectComponent.h"
 #include "ECS/Entity.h"
 #include "ECS/Iterable.h"
 #include "ECS/Registry.h"
@@ -76,15 +77,22 @@ class RenderTextSystem {
       it = StoreEntry(it, entity, text, packedColor, texture, w, h);
     }
 
+    // UIRectComponent (written by UILayoutSystem) takes priority over GlobalTransform for position.
+    // text.position acts as a local pixel offset within the rect (e.g., padding).
     glm::vec2 origin = text.position;
-    if (registry->HasComponent<GlobalTransformComponent>(entity)) {
+    bool effectivelyFixed = text.isFixed;
+    if (registry->HasComponent<UIRectComponent>(entity)) {
+      const auto& rect = registry->GetComponent<UIRectComponent>(entity);
+      origin = glm::vec2(rect.left, rect.top) + text.position;
+      effectivelyFixed = true;
+    } else if (registry->HasComponent<GlobalTransformComponent>(entity)) {
       const auto& transform = registry->GetComponent<GlobalTransformComponent>(entity);
       origin += transform.position;
     }
 
     const auto& gameConfig = registry->Get<GameConfig>();
     const bool isOutsideCamera = IsRenderableOutsideViewport(
-        origin.x, origin.y, it->second.width, it->second.height, text.isFixed, camera,
+        origin.x, origin.y, it->second.width, it->second.height, effectivelyFixed, camera,
         static_cast<float>(gameConfig.windowWidth), static_cast<float>(gameConfig.windowHeight));
 
 #ifdef OCTARINE_PROFILING
@@ -98,8 +106,8 @@ class RenderTextSystem {
     }
     PROFILE_COUNTER_INC(emplacedCounter);
 
-    const float x = text.isFixed ? origin.x : origin.x - camera.x;
-    const float y = text.isFixed ? origin.y : origin.y - camera.y;
+    const float x = effectivelyFixed ? origin.x : origin.x - camera.x;
+    const float y = effectivelyFixed ? origin.y : origin.y - camera.y;
 
     auto& cmd = renderQueue.EmplaceText(static_cast<unsigned int>(text.layer), text.position.y, it->second.texture);
     cmd.destRect = {x, y, it->second.width, it->second.height};

--- a/src/Systems/RenderUISpriteSystem.h
+++ b/src/Systems/RenderUISpriteSystem.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <SDL3/SDL.h>
+
+#include <memory>
+#include <optional>
+
+#include "AssetManager/AssetManager.h"
+#include "Components/SpriteComponent.h"
+#include "Components/UIRectComponent.h"
+#include "ECS/Query.h"
+#include "ECS/Registry.h"
+#include "General/PerfUtils.h"
+#include "General/SpriteFlip.h"
+#include "Renderer/RenderQueue.h"
+#include "Renderer/SpriteRenderCache.h"
+
+// Renders SpriteComponent entities whose position is driven by UIRectComponent (layout-driven UI
+// sprites). Runs as a serial RegisterSystem after UILayoutSystem. World sprites without
+// UIRectComponent continue through the parallel RenderSpriteSystem path unchanged.
+class RenderUISpriteSystem {
+ public:
+  void Prepare(Registry* registry) {
+    assetManager_ = &registry->Get<AssetManager>();
+    renderQueue_ = &registry->Get<RenderQueue>();
+    spriteCache_ = &registry->Get<SpriteRenderCache>();
+  }
+
+  void operator()(Entity entity, const UIRectComponent& rect, const SpriteComponent& sprite) const {
+    const SpriteRenderCache::Entry* entry = spriteCache_->Lookup(entity, assetManager_->TextureGeneration());
+    if (!entry || !entry->texture) {
+      // Warm the cache entry on demand (should rarely happen; the world sprite warming path
+      // covers most entities, but pure-UI sprites without GlobalTransformComponent are missed).
+      SDL_Texture* texture = assetManager_->GetTexture(sprite.assetId);
+      const auto slice = assetManager_->GetAtlasSlice(sprite.assetId);
+      const SDL_FRect atlasOffset = slice.has_value() ? *slice : SDL_FRect{0, 0, 0, 0};
+      spriteCache_->Store(entity, texture, atlasOffset, assetManager_->TextureGeneration());
+      entry = spriteCache_->Lookup(entity, assetManager_->TextureGeneration());
+      if (!entry) return;
+    }
+
+    SDL_Texture* texture = entry->texture;
+    const SDL_FRect atlasOffset = entry->atlasOffset;
+
+    const float destW = rect.Width();
+    const float destH = rect.Height();
+
+    auto& cmd =
+        renderQueue_->EmplaceSprite(static_cast<unsigned int>(sprite.layer), rect.top, texture, sprite.blendMode);
+    cmd.destX = rect.left;
+    cmd.destY = rect.top;
+    cmd.destW = destW;
+    cmd.destH = destH;
+    cmd.srcRect.x = sprite.srcRect.x + atlasOffset.x;
+    cmd.srcRect.y = sprite.srcRect.y + atlasOffset.y;
+    cmd.srcRect.w = sprite.srcRect.w;
+    cmd.srcRect.h = sprite.srcRect.h;
+    static constexpr float kHalf = 0.5f;
+    cmd.rotation = 0.0;
+    cmd.pivot = {destW * kHalf, destH * kHalf};
+    cmd.flip = static_cast<SDL_FlipMode>(sprite.flip);
+    cmd.texture = texture;
+    cmd.colorMod = SDL_Color{sprite.colorMod.r, sprite.colorMod.g, sprite.colorMod.b, sprite.colorMod.a};
+    cmd.blendMode = octarine::ToSdlBlendMode(sprite.blendMode);
+  }
+
+ private:
+  AssetManager* assetManager_ = nullptr;
+  RenderQueue* renderQueue_ = nullptr;
+  SpriteRenderCache* spriteCache_ = nullptr;
+};

--- a/src/Systems/UIButtonSystem.h
+++ b/src/Systems/UIButtonSystem.h
@@ -9,6 +9,7 @@
 #include "Components/CameraComponents.h"
 #include "Components/GlobalTransformComponent.h"
 #include "Components/UIButtonComponent.h"
+#include "Components/UIRectComponent.h"
 #include "Components/ViewportInfo.h"
 #include "ECS/Query.h"
 #include "ECS/Registry.h"
@@ -48,30 +49,14 @@ class UIButtonSystem {
       mouseY = transformed.y;
     }
 
-    auto query = registry_->CreateQuery<UIButtonComponent, GlobalTransformComponent, BoxColliderComponent>();
+    auto query = registry_->CreateQuery<UIButtonComponent, GlobalTransformComponent, Opt<BoxColliderComponent>>();
     const auto& camera = registry_->Get<CameraComponent>().viewport;
     auto handler = [&](Entity entity, UIButtonComponent& button, const GlobalTransformComponent& transform,
-                       const BoxColliderComponent& collider) {
+                       const BoxColliderComponent* collider) {
       if (!button.isActive || button.clickFunction == sol::lua_nil) {
         return;
       }
-
-      // transform.position is top-left. apply collider offset (scaled).
-      float x = transform.position.x + collider.offset.x * transform.scale.x;
-      float y = transform.position.y + collider.offset.y * transform.scale.y;
-
-      if (!button.isFixed) {
-        x -= camera.x;
-        y -= camera.y;
-      }
-
-      const float w = static_cast<float>(collider.width) * transform.scale.x;
-      const float h = static_cast<float>(collider.height) * transform.scale.y;
-
-      const bool isClick = mouseX >= x && mouseX <= x + w && mouseY >= y && mouseY <= y + h;
-
-      if (!isClick) return;
-
+      if (!HitTest(entity, button, transform, collider, camera, mouseX, mouseY)) return;
       if (auto result = button.clickFunction(button.buttonTable, entity); !result.valid()) {
         const sol::error err = result;
         Logger::ErrorLua(std::string(err.what()));
@@ -81,6 +66,27 @@ class UIButtonSystem {
   }
 
  private:
+  [[nodiscard]] bool HitTest(const Entity entity, const UIButtonComponent& button,
+                             const GlobalTransformComponent& transform, const BoxColliderComponent* collider,
+                             const octarine::Rect& camera, const float mouseX, const float mouseY) const {
+    if (registry_->HasComponent<UIRectComponent>(entity)) {
+      const auto& rect = registry_->GetComponent<UIRectComponent>(entity);
+      return mouseX >= rect.left && mouseX <= rect.right && mouseY >= rect.top && mouseY <= rect.bottom;
+    }
+    if (collider) {
+      float x = transform.position.x + collider->offset.x * transform.scale.x;
+      float y = transform.position.y + collider->offset.y * transform.scale.y;
+      if (!button.isFixed) {
+        x -= camera.x;
+        y -= camera.y;
+      }
+      const float w = static_cast<float>(collider->width) * transform.scale.x;
+      const float h = static_cast<float>(collider->height) * transform.scale.y;
+      return mouseX >= x && mouseX <= x + w && mouseY >= y && mouseY <= y + h;
+    }
+    return false;
+  }
+
   Registry* registry_ = nullptr;
   EventBus::SubscriptionHandle subscription_;
 };

--- a/src/Systems/UILayoutSystem.h
+++ b/src/Systems/UILayoutSystem.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "Components/UIAnchorComponent.h"
+#include "Components/UICanvasComponent.h"
+#include "Components/UIRectComponent.h"
+#include "ECS/Iterable.h"
+#include "ECS/Query.h"
+#include "ECS/Registry.h"
+#include "Game/GameConfig.h"
+
+class UILayoutSystem {
+ public:
+  void operator()(const ContextFacade& ctx, const Iterable& /*iter*/) {
+    auto* registry = ctx.GetRegistry();
+    EnsureInitialized(registry);
+    canvasQuery_->Update();
+
+    const auto& gameConfig = registry->Get<GameConfig>();
+
+    canvasQuery_->ForEach([&](const Entity canvasEntity, const UICanvasComponent& canvas) {
+      const float cw = (canvas.width > 0.f) ? canvas.width : static_cast<float>(gameConfig.windowWidth);
+      const float ch = (canvas.height > 0.f) ? canvas.height : static_cast<float>(gameConfig.windowHeight);
+      const UIRectComponent canvasRect{0.f, 0.f, cw, ch};
+      WriteRect(registry, canvasEntity, canvasRect);
+      ResolveChildren(registry, canvasEntity, canvasRect);
+    });
+  }
+
+ private:
+  using CanvasQuery = ComponentQuery<UICanvasComponent>;
+
+  void EnsureInitialized(Registry* registry) {
+    if (canvasQuery_) return;
+    canvasQuery_ = registry->CreateQuery<UICanvasComponent>();
+  }
+
+  static void WriteRect(Registry* registry, const Entity entity, const UIRectComponent& rect) {
+    if (registry->HasComponent<UIRectComponent>(entity)) {
+      registry->GetComponent<UIRectComponent>(entity) = rect;
+    } else {
+      registry->AddComponent(entity, rect);
+    }
+  }
+
+  void ResolveChildren(Registry* registry, const Entity root, const UIRectComponent& rootRect) const {
+    std::vector<std::pair<Entity, UIRectComponent>> pending;
+    pending.emplace_back(root, rootRect);
+    while (!pending.empty()) {
+      auto [parent, parentRect] = pending.back();
+      pending.pop_back();
+      registry->ForEachChild(parent, [&](const Entity child) {
+        UIRectComponent childRect = parentRect;
+        if (registry->HasComponent<UIAnchorComponent>(child)) {
+          const auto& anchor = registry->GetComponent<UIAnchorComponent>(child);
+          const float pw = parentRect.Width();
+          const float ph = parentRect.Height();
+          childRect = UIRectComponent{
+              parentRect.left + pw * anchor.anchorLeft + anchor.offsetLeft,
+              parentRect.top + ph * anchor.anchorTop + anchor.offsetTop,
+              parentRect.left + pw * anchor.anchorRight + anchor.offsetRight,
+              parentRect.top + ph * anchor.anchorBottom + anchor.offsetBottom,
+          };
+          WriteRect(registry, child, childRect);
+        }
+        pending.emplace_back(child, childRect);
+      });
+    }
+  }
+
+  std::unique_ptr<CanvasQuery> canvasQuery_;
+};

--- a/systems.json
+++ b/systems.json
@@ -209,7 +209,7 @@
       "name": "RenderPrimitiveSystem",
       "source": "src/Systems/RenderPrimitiveSystem.h",
       "tier": "parallel",
-      "setup_order": 15,
+      "setup_order": 17,
       "queried_components": [
         "SquarePrimitiveComponent",
         "GlobalTransformComponent"
@@ -222,7 +222,7 @@
       "name": "RenderSpriteSystem",
       "source": "src/Systems/RenderSpriteSystem.h",
       "tier": "parallel",
-      "setup_order": 13,
+      "setup_order": 14,
       "queried_components": [
         "GlobalTransformComponent",
         "SpriteComponent"
@@ -235,9 +235,22 @@
       "name": "RenderTextSystem",
       "source": "src/Systems/RenderTextSystem.h",
       "tier": "serial",
-      "setup_order": 14,
+      "setup_order": 16,
       "queried_components": [
         "TextLabelComponent"
+      ],
+      "emits": [],
+      "subscribes": [],
+      "lua_surface": false
+    },
+    {
+      "name": "RenderUISpriteSystem",
+      "source": "src/Systems/RenderUISpriteSystem.h",
+      "tier": "serial",
+      "setup_order": 15,
+      "queried_components": [
+        "UIRectComponent",
+        "SpriteComponent"
       ],
       "emits": [],
       "subscribes": [],
@@ -291,6 +304,16 @@
       "subscribes": [
         "MouseInputEvent"
       ],
+      "lua_surface": false
+    },
+    {
+      "name": "UILayoutSystem",
+      "source": "src/Systems/UILayoutSystem.h",
+      "tier": "bulk",
+      "setup_order": 13,
+      "queried_components": [],
+      "emits": [],
+      "subscribes": [],
       "lua_surface": false
     },
     {


### PR DESCRIPTION
## Summary

- Adds `UICanvasComponent`, `UIAnchorComponent`, `UIRectComponent` and a `UILayoutSystem` that resolves anchor math each frame via the existing Registry hierarchy walk
- Installs a `ui` Lua module with `ui.canvas()`, `ui.anchor()` (10 named presets + explicit table), and a stubbed `ui.flex()`
- `UIButtonSystem` now hit-tests against `UIRectComponent` when present, with the legacy `BoxColliderComponent` path kept as fallback (backward-compatible)
- `RenderTextSystem` uses `UIRectComponent` as text origin when present; `RenderUISpriteSystem` handles sprites whose position is driven by layout (separate from the parallel world-sprite path)

## Lua API

```lua
-- Full-screen HUD canvas
local hud = load_entity({ components = {} })
ui.canvas(hud, { fixed = true })

-- Panel filling the canvas with a 10px margin
local panel = load_entity({ components = {} })
registry.set_parent(panel, hud)
ui.anchor(panel, "fill", { margin = 10 })

-- Button anchored to bottom-right, 120×40
local btn = load_entity({ components = { ui_button = { on_click = function() print("click") end } } })
registry.set_parent(btn, panel)
ui.anchor(btn, "bottom_right", { width = 120, height = 40 })

-- Text label centered in the panel
local label = load_entity({ components = { text_label = { text = "Score: 0", font_id = "main", is_fixed = true } } })
registry.set_parent(label, panel)
ui.anchor(label, "center", { width = 100, height = 20 })

-- Sprite background filling the canvas
local bg = load_entity({ components = { sprite = { asset_id = "hud_bg", is_fixed = true } } })
registry.set_parent(bg, hud)
ui.anchor(bg, "fill")
```

## Test plan

- [ ] Build passes (`cmake --preset editor-debug && cmake --build build/editor-debug`)
- [ ] `OctarineLuaApiTest` passes — `ui_canvas`, `ui_anchor`, `ui_rect` components visible; `UIModule` in modules.json
- [ ] `OctarineLuaBehaviorTest` passes — no regression on existing component bindings
- [ ] Manual: canvas + text label with `"fill"` anchor renders at full viewport size
- [ ] Manual: `"bottom_right"` button fires `on_click` callback on click, not outside
- [ ] Manual: nested panel → button rect is relative to panel, not canvas root
- [ ] Manual: `"fill"` sprite stretches to canvas rect without camera offset
- [ ] Manual: existing scene with `UIButtonComponent + BoxColliderComponent` still works unchanged
- [ ] `ui.flex({})` logs a warning and does not crash