### PR TITLE
Add UI z-ordering (Phase 2 of UI layout)

### DIFF
--- a/components.json
+++ b/components.json
@@ -120,6 +120,12 @@
       "usertype": "ui_rect_component",
       "has_accessor": "registry.has_ui_rect",
       "get_accessor": "registry.get_ui_rect"
+    },
+    {
+      "lua_key": "ui_z_index",
+      "usertype": "ui_z_index_component",
+      "has_accessor": "registry.has_ui_z_index",
+      "get_accessor": "registry.get_ui_z_index"
     }
   ]
 }

--- a/lua_api.smoke.lua
+++ b/lua_api.smoke.lua
@@ -1721,6 +1721,8 @@ function registry.get_ui_canvas(...) end
 
 function registry.get_ui_rect(...) end
 
+function registry.get_ui_z_index(...) end
+
 function registry.has_animation(...) end
 
 function registry.has_audio_listener(...) end
@@ -1760,6 +1762,8 @@ function registry.has_ui_button(...) end
 function registry.has_ui_canvas(...) end
 
 function registry.has_ui_rect(...) end
+
+function registry.has_ui_z_index(...) end
 
 function registry.set_parent(...) end
 
@@ -1817,6 +1821,8 @@ function ui.canvas(...) end
 
 function ui.flex(...) end
 
+function ui.z_index(...) end
+
 
 ---@class ui_anchor_component
 ui_anchor_component = {}
@@ -1832,6 +1838,10 @@ ui_canvas_component = {}
 
 ---@class ui_rect_component
 ui_rect_component = {}
+
+
+---@class ui_z_index_component
+ui_z_index_component = {}
 
 
 ---@class vec2

--- a/src/Components/UICanvasComponent.h
+++ b/src/Components/UICanvasComponent.h
@@ -4,7 +4,9 @@ struct UICanvasComponent {
   bool isFixed = true;
   float width = 0.f;   // 0 = use viewport width at layout time
   float height = 0.f;  // 0 = use viewport height at layout time
+  int baseLayer = 0;   // base render layer for all entities in this canvas
 
-  explicit UICanvasComponent(const bool t_isFixed = true, const float t_width = 0.f, const float t_height = 0.f)
-      : isFixed(t_isFixed), width(t_width), height(t_height) {}
+  explicit UICanvasComponent(const bool t_isFixed = true, const float t_width = 0.f, const float t_height = 0.f,
+                             const int t_baseLayer = 0)
+      : isFixed(t_isFixed), width(t_width), height(t_height), baseLayer(t_baseLayer) {}
 };

--- a/src/Components/UIRectComponent.h
+++ b/src/Components/UIRectComponent.h
@@ -7,10 +7,11 @@ struct UIRectComponent {
   float top = 0.f;
   float right = 0.f;
   float bottom = 0.f;
+  int layer = 0;  // computed by UILayoutSystem from canvas.baseLayer + accumulated UIZIndexComponent.z
 
   explicit UIRectComponent(const float t_left = 0.f, const float t_top = 0.f, const float t_right = 0.f,
-                           const float t_bottom = 0.f)
-      : left(t_left), top(t_top), right(t_right), bottom(t_bottom) {}
+                           const float t_bottom = 0.f, const int t_layer = 0)
+      : left(t_left), top(t_top), right(t_right), bottom(t_bottom), layer(t_layer) {}
 
   [[nodiscard]] float Width() const { return right - left; }
   [[nodiscard]] float Height() const { return bottom - top; }

--- a/src/Components/UIZIndexComponent.h
+++ b/src/Components/UIZIndexComponent.h
@@ -1,0 +1,7 @@
+#pragma once
+
+struct UIZIndexComponent {
+  int z = 0;
+
+  explicit UIZIndexComponent(const int t_z = 0) : z(t_z) {}
+};

--- a/src/Lua/Bindings/RegisterAllBindings.cpp
+++ b/src/Lua/Bindings/RegisterAllBindings.cpp
@@ -21,6 +21,7 @@
 #include "Lua/Bindings/UIButtonComponentLuaBinding.h"
 #include "Lua/Bindings/UICanvasComponentLuaBinding.h"
 #include "Lua/Bindings/UIRectComponentLuaBinding.h"
+#include "Lua/Bindings/UIZIndexComponentLuaBinding.h"
 
 void RegisterAllLuaBindings() {
   LuaComponentRegistry::clear();
@@ -44,4 +45,5 @@ void RegisterAllLuaBindings() {
   LuaComponentRegistry::registerComponent<UICanvasComponent>();
   LuaComponentRegistry::registerComponent<UIAnchorComponent>();
   LuaComponentRegistry::registerComponent<UIRectComponent>();
+  LuaComponentRegistry::registerComponent<UIZIndexComponent>();
 }

--- a/src/Lua/Bindings/UICanvasComponentLuaBinding.h
+++ b/src/Lua/Bindings/UICanvasComponentLuaBinding.h
@@ -13,13 +13,14 @@ struct LuaBinding<UICanvasComponent> {
   static UICanvasComponent fromLua(const sol::object& data) {
     const auto t = data.as<sol::table>();
     using namespace LuaComponentHelpers;
-    return UICanvasComponent(SafeGetOptionalValue<bool>(t, "is_fixed", true),
-                             SafeGetOptionalValue<float>(t, "width", 0.f),
-                             SafeGetOptionalValue<float>(t, "height", 0.f));
+    return UICanvasComponent(
+        SafeGetOptionalValue<bool>(t, "is_fixed", true), SafeGetOptionalValue<float>(t, "width", 0.f),
+        SafeGetOptionalValue<float>(t, "height", 0.f), SafeGetOptionalValue<int>(t, "base_layer", 0));
   }
 
   static void bindUsertype(sol::state& lua) {
     lua.new_usertype<UICanvasComponent>(kUsertypeName, "is_fixed", &UICanvasComponent::isFixed, "width",
-                                        &UICanvasComponent::width, "height", &UICanvasComponent::height);
+                                        &UICanvasComponent::width, "height", &UICanvasComponent::height, "base_layer",
+                                        &UICanvasComponent::baseLayer);
   }
 };

--- a/src/Lua/Bindings/UIRectComponentLuaBinding.h
+++ b/src/Lua/Bindings/UIRectComponentLuaBinding.h
@@ -18,7 +18,8 @@ struct LuaBinding<UIRectComponent> {
         kUsertypeName, "left", sol::property([](const UIRectComponent& r) { return r.left; }), "top",
         sol::property([](const UIRectComponent& r) { return r.top; }), "right",
         sol::property([](const UIRectComponent& r) { return r.right; }), "bottom",
-        sol::property([](const UIRectComponent& r) { return r.bottom; }), "width",
+        sol::property([](const UIRectComponent& r) { return r.bottom; }), "layer",
+        sol::property([](const UIRectComponent& r) { return r.layer; }), "width",
         sol::property(&UIRectComponent::Width), "height", sol::property(&UIRectComponent::Height), "center",
         sol::property(&UIRectComponent::Center));
   }

--- a/src/Lua/Bindings/UIZIndexComponentLuaBinding.h
+++ b/src/Lua/Bindings/UIZIndexComponentLuaBinding.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <sol/sol.hpp>
+
+#include "Components/UIZIndexComponent.h"
+#include "Lua/Bindings/LuaBinding.h"
+
+template <>
+struct LuaBinding<UIZIndexComponent> {
+  static constexpr const char* kLuaKey = "ui_z_index";
+  static constexpr const char* kUsertypeName = "ui_z_index_component";
+
+  static UIZIndexComponent fromLua(const sol::object& data) {
+    using namespace LuaComponentHelpers;
+    if (data.get_type() == sol::type::number) {
+      return UIZIndexComponent(data.as<int>());
+    }
+    const auto t = data.as<sol::table>();
+    return UIZIndexComponent(SafeGetOptionalValue<int>(t, "z", 0));
+  }
+
+  static void bindUsertype(sol::state& lua) {
+    lua.new_usertype<UIZIndexComponent>(kUsertypeName, "z", &UIZIndexComponent::z);
+  }
+};

--- a/src/Lua/Modules/UIModuleLuaBinding.cpp
+++ b/src/Lua/Modules/UIModuleLuaBinding.cpp
@@ -5,6 +5,7 @@
 #include "Components/UIAnchorComponent.h"
 #include "Components/UICanvasComponent.h"
 #include "Components/UIRectComponent.h"
+#include "Components/UIZIndexComponent.h"
 #include "ECS/Registry.h"
 #include "General/Logger.h"
 #include "Lua/LuaBindingContext.h"
@@ -53,6 +54,7 @@ void LuaModuleBinding<UIModule>::install(sol::state& lua, LuaBindingContext& ctx
       canvas.isFixed = (*opts)["fixed"].get_or(true);
       canvas.width = static_cast<float>((*opts)["width"].get_or(0.0));
       canvas.height = static_cast<float>((*opts)["height"].get_or(0.0));
+      canvas.baseLayer = (*opts)["base_layer"].get_or(0);
     }
     r->AddComponent(entity, canvas);
     if (!r->HasComponent<UIRectComponent>(entity)) {
@@ -87,6 +89,15 @@ void LuaModuleBinding<UIModule>::install(sol::state& lua, LuaBindingContext& ctx
                       Logger::Warn("ui.anchor: second argument must be a preset name (string) or an anchor table.");
                     }
                   });
+
+  ui.set_function("z_index", [&ctx](const Entity entity, const int z) {
+    Registry* r = ctx.GetRegistry();
+    if (r->HasComponent<UIZIndexComponent>(entity)) {
+      r->GetComponent<UIZIndexComponent>(entity).z = z;
+    } else {
+      r->AddComponent(entity, UIZIndexComponent{z});
+    }
+  });
 
   // Phase 4 slot — warns and does nothing until flex containers are implemented.
   ui.set_function("flex", [](const Entity /*entity*/, const sol::optional<sol::table>& /*opts*/) {

--- a/src/Systems/RenderTextSystem.h
+++ b/src/Systems/RenderTextSystem.h
@@ -81,10 +81,12 @@ class RenderTextSystem {
     // text.position acts as a local pixel offset within the rect (e.g., padding).
     glm::vec2 origin = text.position;
     bool effectivelyFixed = text.isFixed;
+    int renderLayer = text.layer;
     if (registry->HasComponent<UIRectComponent>(entity)) {
       const auto& rect = registry->GetComponent<UIRectComponent>(entity);
       origin = glm::vec2(rect.left, rect.top) + text.position;
       effectivelyFixed = true;
+      renderLayer = rect.layer;
     } else if (registry->HasComponent<GlobalTransformComponent>(entity)) {
       const auto& transform = registry->GetComponent<GlobalTransformComponent>(entity);
       origin += transform.position;
@@ -109,7 +111,7 @@ class RenderTextSystem {
     const float x = effectivelyFixed ? origin.x : origin.x - camera.x;
     const float y = effectivelyFixed ? origin.y : origin.y - camera.y;
 
-    auto& cmd = renderQueue.EmplaceText(static_cast<unsigned int>(text.layer), text.position.y, it->second.texture);
+    auto& cmd = renderQueue.EmplaceText(static_cast<unsigned int>(renderLayer), text.position.y, it->second.texture);
     cmd.destRect = {x, y, it->second.width, it->second.height};
     cmd.texture = it->second.texture;
   }

--- a/src/Systems/RenderUISpriteSystem.h
+++ b/src/Systems/RenderUISpriteSystem.h
@@ -45,8 +45,7 @@ class RenderUISpriteSystem {
     const float destW = rect.Width();
     const float destH = rect.Height();
 
-    auto& cmd =
-        renderQueue_->EmplaceSprite(static_cast<unsigned int>(sprite.layer), rect.top, texture, sprite.blendMode);
+    auto& cmd = renderQueue_->EmplaceSprite(static_cast<unsigned int>(rect.layer), rect.top, texture, sprite.blendMode);
     cmd.destX = rect.left;
     cmd.destY = rect.top;
     cmd.destW = destW;

--- a/src/Systems/UILayoutSystem.h
+++ b/src/Systems/UILayoutSystem.h
@@ -7,6 +7,7 @@
 #include "Components/UIAnchorComponent.h"
 #include "Components/UICanvasComponent.h"
 #include "Components/UIRectComponent.h"
+#include "Components/UIZIndexComponent.h"
 #include "ECS/Iterable.h"
 #include "ECS/Query.h"
 #include "ECS/Registry.h"
@@ -24,7 +25,7 @@ class UILayoutSystem {
     canvasQuery_->ForEach([&](const Entity canvasEntity, const UICanvasComponent& canvas) {
       const float cw = (canvas.width > 0.f) ? canvas.width : static_cast<float>(gameConfig.windowWidth);
       const float ch = (canvas.height > 0.f) ? canvas.height : static_cast<float>(gameConfig.windowHeight);
-      const UIRectComponent canvasRect{0.f, 0.f, cw, ch};
+      const UIRectComponent canvasRect{0.f, 0.f, cw, ch, canvas.baseLayer};
       WriteRect(registry, canvasEntity, canvasRect);
       ResolveChildren(registry, canvasEntity, canvasRect);
     });
@@ -53,17 +54,23 @@ class UILayoutSystem {
       auto [parent, parentRect] = pending.back();
       pending.pop_back();
       registry->ForEachChild(parent, [&](const Entity child) {
-        UIRectComponent childRect = parentRect;
+        UIRectComponent childRect = parentRect;  // inherit layer from parent
+        bool modified = false;
         if (registry->HasComponent<UIAnchorComponent>(child)) {
           const auto& anchor = registry->GetComponent<UIAnchorComponent>(child);
           const float pw = parentRect.Width();
           const float ph = parentRect.Height();
-          childRect = UIRectComponent{
-              parentRect.left + pw * anchor.anchorLeft + anchor.offsetLeft,
-              parentRect.top + ph * anchor.anchorTop + anchor.offsetTop,
-              parentRect.left + pw * anchor.anchorRight + anchor.offsetRight,
-              parentRect.top + ph * anchor.anchorBottom + anchor.offsetBottom,
-          };
+          childRect.left = parentRect.left + pw * anchor.anchorLeft + anchor.offsetLeft;
+          childRect.top = parentRect.top + ph * anchor.anchorTop + anchor.offsetTop;
+          childRect.right = parentRect.left + pw * anchor.anchorRight + anchor.offsetRight;
+          childRect.bottom = parentRect.top + ph * anchor.anchorBottom + anchor.offsetBottom;
+          modified = true;
+        }
+        if (registry->HasComponent<UIZIndexComponent>(child)) {
+          childRect.layer += registry->GetComponent<UIZIndexComponent>(child).z;
+          modified = true;
+        }
+        if (modified) {
           WriteRect(registry, child, childRect);
         }
         pending.emplace_back(child, childRect);


### PR DESCRIPTION
## Summary

- Adds `UIZIndexComponent { int z; }` to declare render stacking order for UI entities
- `UILayoutSystem` now propagates a resolved layer through the hierarchy: `canvas.baseLayer` accumulates child `UIZIndexComponent.z` offsets at each z-index node; all descendants inherit the accumulated layer
- `RenderUISpriteSystem` and `RenderTextSystem` use `UIRectComponent.layer` (computed by UILayoutSystem) as the render sort-key layer for UI entities, so z-index overrides the sprite/text component's layer for layout-driven entities
- `UICanvasComponent` gains a `baseLayer` field (default 0) so different canvases can occupy different layer ranges

## Lua surface

```lua
-- Establish a canvas at render layer 50
ui.canvas(entity, {fixed = true, base_layer = 50})

-- Give a child entity z-index 10 (renders above siblings with lower z)
ui.z_index(child, 10)

-- Read the computed layer from Lua
local rect = registry.get_ui_rect(entity)
print(rect.layer)

-- Direct component access
registry.has_ui_z_index(entity)
registry.get_ui_z_index(entity).z = 5
```

## Test plan

- [ ] LuaApiSmokeTest passes (gates components.json and lua_api.smoke.lua drift)
- [ ] Full build passes with no clang-format or clang-tidy violations
- [ ] UI entities with higher `ui.z_index` render on top of siblings with lower z
- [ ] `canvas.baseLayer` shifts all children of that canvas to the correct layer range
- [ ] Entities with no UIZIndexComponent continue to inherit parent layer unchanged