### PR TITLE
Security hardening: Lua sandbox, localhost dev-listen, path traversal, pak overflow

### DIFF
--- a/src/AssetManager/AssetCatalog.cpp
+++ b/src/AssetManager/AssetCatalog.cpp
@@ -71,6 +71,9 @@ std::string FormatFontSize(float size) {
 // Control characters (< 0x20 or DEL) use \xNN hex escapes; backslash and double-quote are
 // prefixed with a backslash. Lua 5.1+ parses \xNN in string literals.
 std::string EscapeLua(const std::string& s) {
+  constexpr unsigned char kFirstPrintable = ' ';  // 0x20
+  constexpr unsigned char kDel = '\x7f';
+  constexpr std::size_t kHexBufSize = 8;  // "\\xNN" + nul with room to spare
   std::string out;
   out.reserve(s.size());
   for (const char raw : s) {
@@ -78,8 +81,8 @@ std::string EscapeLua(const std::string& s) {
     if (c == '\\' || c == '"') {
       out.push_back('\\');
       out.push_back(raw);
-    } else if (c < 0x20 || c == 0x7f) {
-      char buf[8];
+    } else if (c < kFirstPrintable || c == kDel) {
+      char buf[kHexBufSize];
       std::snprintf(buf, sizeof(buf), "\\x%02x", c);
       out.append(buf);
     } else {

--- a/src/AssetManager/AssetCatalog.cpp
+++ b/src/AssetManager/AssetCatalog.cpp
@@ -68,12 +68,22 @@ std::string FormatFontSize(float size) {
 }
 
 // Escape a string for embedding inside a Lua double-quoted literal in the emitted manifest.
+// Control characters (< 0x20 or DEL) use \xNN hex escapes; backslash and double-quote are
+// prefixed with a backslash. Lua 5.1+ parses \xNN in string literals.
 std::string EscapeLua(const std::string& s) {
   std::string out;
   out.reserve(s.size());
-  for (const char c : s) {
-    if (c == '\\' || c == '"') out.push_back('\\');
-    out.push_back(c);
+  for (const unsigned char c : s) {
+    if (c == '\\' || c == '"') {
+      out.push_back('\\');
+      out.push_back(static_cast<char>(c));
+    } else if (c < 0x20 || c == 0x7f) {
+      char buf[8];
+      std::snprintf(buf, sizeof(buf), "\\x%02x", c);
+      out.append(buf);
+    } else {
+      out.push_back(static_cast<char>(c));
+    }
   }
   return out;
 }

--- a/src/AssetManager/AssetCatalog.cpp
+++ b/src/AssetManager/AssetCatalog.cpp
@@ -73,16 +73,17 @@ std::string FormatFontSize(float size) {
 std::string EscapeLua(const std::string& s) {
   std::string out;
   out.reserve(s.size());
-  for (const unsigned char c : s) {
+  for (const char raw : s) {
+    const auto c = static_cast<unsigned char>(raw);
     if (c == '\\' || c == '"') {
       out.push_back('\\');
-      out.push_back(static_cast<char>(c));
+      out.push_back(raw);
     } else if (c < 0x20 || c == 0x7f) {
       char buf[8];
       std::snprintf(buf, sizeof(buf), "\\x%02x", c);
       out.append(buf);
     } else {
-      out.push_back(static_cast<char>(c));
+      out.push_back(raw);
     }
   }
   return out;

--- a/src/AssetManager/AssetManager.cpp
+++ b/src/AssetManager/AssetManager.cpp
@@ -329,8 +329,14 @@ MIX_Audio *AssetManager::GetAudioClip(const std::string &assetId) const { return
 TTF_Font *AssetManager::GetFont(const std::string &assetId) const { return font_store_.Get(assetId); }
 
 std::string AssetManager::GetFullPath(const std::string &relativePath) const {
+  const std::filesystem::path inputPath(relativePath);
+  // Absolute paths come from the catalog (already resolved). Only relative paths from
+  // user/Lua input need a traversal check to prevent escaping the asset root.
+  if (inputPath.is_absolute()) {
+    return relativePath;
+  }
   const std::filesystem::path basePath = std::filesystem::path(base_path_).lexically_normal();
-  const std::filesystem::path assetPath = (basePath / relativePath).lexically_normal();
+  const std::filesystem::path assetPath = (basePath / inputPath).lexically_normal();
   const auto rel = assetPath.lexically_relative(basePath);
   if (rel.empty() || *rel.begin() == "..") {
     Logger::Error("AssetManager::GetFullPath: path traversal rejected: " + relativePath);

--- a/src/AssetManager/AssetManager.cpp
+++ b/src/AssetManager/AssetManager.cpp
@@ -329,8 +329,13 @@ MIX_Audio *AssetManager::GetAudioClip(const std::string &assetId) const { return
 TTF_Font *AssetManager::GetFont(const std::string &assetId) const { return font_store_.Get(assetId); }
 
 std::string AssetManager::GetFullPath(const std::string &relativePath) const {
-  const std::filesystem::path basePath = base_path_;
-  const std::filesystem::path assetPath = basePath / relativePath;
+  const std::filesystem::path basePath = std::filesystem::path(base_path_).lexically_normal();
+  const std::filesystem::path assetPath = (basePath / relativePath).lexically_normal();
+  const auto rel = assetPath.lexically_relative(basePath);
+  if (rel.empty() || *rel.begin() == "..") {
+    Logger::Error("AssetManager::GetFullPath: path traversal rejected: " + relativePath);
+    return {};
+  }
   return assetPath.string();
 }
 

--- a/src/AssetManager/AssetPak.cpp
+++ b/src/AssetManager/AssetPak.cpp
@@ -230,7 +230,7 @@ bool AssetPak::Open(const std::string& pakPath) {
     }
     std::string relPath(reinterpret_cast<const char*>(tocCursor), pathLen);
     tocCursor += pathLen;
-    if (e.offset + e.size > header.tocOffset) {
+    if (e.size > header.tocOffset || e.offset > header.tocOffset - e.size) {
       Logger::Error("AssetPak::Open: entry '" + relPath + "' overlaps TOC region");
       SDL_free(buf);
       entries_.clear();

--- a/src/Dev/DevListenServer.cpp
+++ b/src/Dev/DevListenServer.cpp
@@ -334,7 +334,7 @@ bool DevListenServer::Start(const ServerOptions& opts) {
   sockaddr_in addr{};
   addr.sin_family = AF_INET;
   addr.sin_port = htons(opts.port);
-  addr.sin_addr.s_addr = opts.listen_all ? htonl(INADDR_ANY) : htonl(INADDR_LOOPBACK);
+  addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
 
   if (::bind(s, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) == kSocketError) {
     Logger::Error("DevListenServer: bind() failed (err=" + std::to_string(LastSocketError()) +
@@ -363,12 +363,7 @@ bool DevListenServer::Start(const ServerOptions& opts) {
     impl_->bound_port = ntohs(bound.sin_port);
   }
 
-  if (opts.listen_all) {
-    Logger::Warn("DevListenServer: bound 0.0.0.0:" + std::to_string(impl_->bound_port) +
-                 " — exposed to LAN. Prefer 127.0.0.1 unless cross-host dev is intentional.");
-  } else {
-    Logger::Info("DevListenServer: bound 127.0.0.1:" + std::to_string(impl_->bound_port));
-  }
+  Logger::Info("DevListenServer: bound 127.0.0.1:" + std::to_string(impl_->bound_port));
 
   impl_->listen_sock = s;
   impl_->stop_requested.store(false, std::memory_order_release);

--- a/src/Dev/DevListenServer.h
+++ b/src/Dev/DevListenServer.h
@@ -4,7 +4,7 @@
 
 // DevListenServer — editor dev-iteration TCP listener (compile-time stripped from shipped builds
 // via #ifndef OCTARINE_SHIPPED). When enabled, owns a background listener thread bound to
-// 127.0.0.1:<port> (or 0.0.0.0:<port> with --dev-listen-all) and serves a tiny length-prefixed
+// 127.0.0.1:<port> and serves a tiny length-prefixed
 // binary protocol:
 //
 //     each message:  uint32 LE length | uint32 LE op | body[length-4]
@@ -43,8 +43,8 @@ using CommandHandler =
     std::function<void(OpCode op, const std::vector<char>& body, std::uint32_t& reply_op, std::string& reply_body)>;
 
 struct ServerOptions {
-  std::uint16_t port = 0;   // 0 = pick ephemeral (BoundPort() reads back after Start)
-  bool listen_all = false;  // false = bind 127.0.0.1; true = 0.0.0.0 (warned at Start)
+  std::uint16_t port = 0;  // 0 = pick ephemeral (BoundPort() reads back after Start)
+                           // Always binds 127.0.0.1 — no LAN-exposure option.
 };
 
 class DevListenServer {

--- a/src/Engine/EngineBootstrap.cpp
+++ b/src/Engine/EngineBootstrap.cpp
@@ -74,7 +74,7 @@ int LuaDofileViaSDL(lua_State* L) {
 
 namespace engine_bootstrap {
 void InstallLuaLibraries(sol::state& lua) {
-  lua.open_libraries(sol::lib::base, sol::lib::os, sol::lib::math, sol::lib::io, sol::lib::string, sol::lib::table);
+  lua.open_libraries(sol::lib::base, sol::lib::math, sol::lib::string, sol::lib::table);
 
   // Override Lua's stock `dofile` so chunks load through SDL_IO too. Must run after
   // open_libraries (which installs the default dofile we're replacing).

--- a/src/Game/Game.cpp
+++ b/src/Game/Game.cpp
@@ -244,7 +244,6 @@ void Game::StartDevListenServer() {
   if (dev_listen_port_ > 0) {
     octarine::dev::ServerOptions opts;
     opts.port = static_cast<std::uint16_t>(dev_listen_port_);
-    opts.listen_all = dev_listen_all_;
     if (!devListen.Start(opts)) {
       Logger::Error("DevListenServer failed to start; --dev-listen flag had no effect.");
     }

--- a/src/Game/Game.h
+++ b/src/Game/Game.h
@@ -70,13 +70,9 @@ class Game : public LuaBindingContext {
   void SetUseManifest(bool useManifest) { use_manifest_ = useManifest; }
 
 #ifndef OCTARINE_SHIPPED
-  // Dev-only: opt into the DevListenServer (Stage 6 of EditorBuildAndDeployPlan). port=0 leaves
-  // the server stopped. listenAll=true binds 0.0.0.0; default 127.0.0.1. Called by Main from
-  // --dev-listen / --dev-listen-all and stripped from shipped binaries.
-  void SetDevListen(int port, bool listenAll) {
-    dev_listen_port_ = port;
-    dev_listen_all_ = listenAll;
-  }
+  // Dev-only: opt into the DevListenServer. port=0 leaves the server stopped; >0 binds on
+  // 127.0.0.1:<port>. Called by Main from --dev-listen and stripped from shipped binaries.
+  void SetDevListen(int port) { dev_listen_port_ = port; }
 #endif
 
   [[nodiscard]] SDL_Renderer* GetRenderer() const override { return runtime_.SdlRenderer(); }
@@ -133,7 +129,6 @@ class Game : public LuaBindingContext {
   bool use_manifest_ = false;
 #ifndef OCTARINE_SHIPPED
   int dev_listen_port_ = 0;
-  bool dev_listen_all_ = false;
 #endif
   int bake_validation_failures_ = 0;
 

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -13,8 +13,7 @@ int main(const int argc, char* argv[]) {
   std::string gamePath;
   std::string startupMode;
   bool useManifest = false;
-  int devListenPort = 0;      // 0 = disabled; >0 = bind on that TCP port
-  bool devListenAll = false;  // false = 127.0.0.1; true = 0.0.0.0 (LAN-exposed)
+  int devListenPort = 0;  // 0 = disabled; >0 = bind on that TCP port
 
   // Parse command-line arguments
   for (int i = 1; i < argc; ++i) {
@@ -55,13 +54,6 @@ int main(const int argc, char* argv[]) {
         return 1;
       }
 #endif
-    } else if (currentArg == "--dev-listen-all") {
-#ifdef OCTARINE_SHIPPED
-      Logger::Warn("--dev-listen-all is stripped from shipped builds; ignoring.");
-#else
-      devListenAll = true;
-      Logger::Warn("--dev-listen-all set; will bind 0.0.0.0 instead of 127.0.0.1.");
-#endif
     } else if (currentArg.starts_with("-")) {
       Logger::Warn("Unknown command-line argument: " + currentArg);
     } else {
@@ -80,10 +72,9 @@ int main(const int argc, char* argv[]) {
   game.SetStartupMode(startupMode);
   game.SetUseManifest(useManifest);
 #ifndef OCTARINE_SHIPPED
-  game.SetDevListen(devListenPort, devListenAll);
+  game.SetDevListen(devListenPort);
 #else
   (void)devListenPort;
-  (void)devListenAll;
 #endif
 
   if (game.Initialize(gamePath)) {

--- a/tests/DevListenServerTest.cpp
+++ b/tests/DevListenServerTest.cpp
@@ -146,8 +146,7 @@ int main() {
   using namespace octarine::dev;
   DevListenServer server;
   ServerOptions opts;
-  opts.port = 0;            // ephemeral
-  opts.listen_all = false;  // loopback only
+  opts.port = 0;  // ephemeral; always binds 127.0.0.1
 
   Check(server.Start(opts), "Start() on ephemeral port succeeds");
   const std::uint16_t port = server.BoundPort();


### PR DESCRIPTION
## Summary

- **Remove `sol::lib::os` and `sol::lib::io`** from the engine Lua state — any game script could previously call `os.execute()` (arbitrary shell) or `io.open()` (arbitrary file r/w). The SDL-backed `read_file_lines()` module already covers the only legitimate file-reading use case.
- **Remove `--dev-listen-all` flag** and hard-code `INADDR_LOOPBACK` in `DevListenServer` — the unauthenticated Lua REPL must not bind to `0.0.0.0`; localhost-only is the correct and sufficient scope for dev tooling.
- **Path traversal fix in `GetFullPath()`** — add `lexically_relative` containment check to reject `../` escape attempts before any SDL/filesystem call reaches the OS.
- **Unsigned overflow fix in `AssetPak::Open`** — replace `e.offset + e.size > header.tocOffset` (wraps on malicious `.ocpk`) with an overflow-safe two-step subtraction check.
- **`EscapeLua()` control-character escaping** — expand from `\` and `"` only to hex-escape all control characters (`< 0x20`, `0x7f`), preventing Lua injection via asset IDs with embedded newlines.

## Test plan

- [ ] All 17 CTest tests pass (confirmed locally via `octarine-verify.sh`)
- [ ] CI build green across all presets
- [ ] `DevListenServerTest` passes with the stripped `listen_all` field
- [ ] No game scripts use `os.*` or `io.*` (confirmed by audit — none exist)