### PR TITLE
Add sandboxed Lua file-write surface: storage and project modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -453,6 +453,21 @@ if (OCTARINE_ENABLE_TESTS)
     endif ()
     add_test(NAME ProjectIniTest COMMAND OctarineProjectIniTest)
 
+    # Sandboxed Lua file-write surface: file_sandbox containment/atomic-write helpers, then the
+    # storage.* / project.* modules end-to-end through a fake LuaBindingContext host (including
+    # the editor-session gate). Links octarine_lua for the module bindings + sol2.
+    add_executable(OctarineFileSandboxTest tests/FileSandboxTest.cpp)
+    set_target_properties(OctarineFileSandboxTest PROPERTIES
+            CXX_STANDARD 20
+            CXX_STANDARD_REQUIRED ON
+            CXX_EXTENSIONS OFF
+    )
+    target_link_libraries(OctarineFileSandboxTest PRIVATE octarine_lua)
+    if (MSVC)
+        target_compile_options(OctarineFileSandboxTest PRIVATE /MP /bigobj /permissive- /wd4201 /wd5321)
+    endif ()
+    add_test(NAME FileSandboxTest COMMAND OctarineFileSandboxTest)
+
     # adb wrapper parser test: standalone — Adb + its Process/Logger deps. Exercises the pure
     # `adb devices -l` parser; no device or adb binary required.
     add_executable(OctarineAdbTest

--- a/lua_api.smoke.lua
+++ b/lua_api.smoke.lua
@@ -1668,6 +1668,14 @@ function play_sound(...) end
 position_component = {}
 
 
+---@class project
+project = {}
+
+function project.path(...) end
+
+function project.write_file(...) end
+
+
 ---@class projectile_emitter_component
 projectile_emitter_component = {}
 
@@ -1805,6 +1813,20 @@ square_primitive_component = {}
 
 
 function stop_scene(...) end
+
+---@class storage
+storage = {}
+
+function storage.exists(...) end
+
+function storage.list(...) end
+
+function storage.read(...) end
+
+function storage.remove(...) end
+
+function storage.write(...) end
+
 
 ---@class text_label_component
 text_label_component = {}

--- a/modules.json
+++ b/modules.json
@@ -40,6 +40,16 @@
       "name": "UI",
       "binding_header": "src/Lua/Modules/UIModuleLuaBinding.h",
       "globals": ["ui"]
+    },
+    {
+      "name": "Storage",
+      "binding_header": "src/Lua/Modules/StorageModuleLuaBinding.h",
+      "globals": ["storage"]
+    },
+    {
+      "name": "Project",
+      "binding_header": "src/Lua/Modules/ProjectModuleLuaBinding.h",
+      "globals": ["project"]
     }
   ]
 }

--- a/scripts/octarine-verify.sh
+++ b/scripts/octarine-verify.sh
@@ -150,7 +150,8 @@ test_targets=(
   OctarineEcsTest OctarineEcsHierarchyTest OctarineSystemLogicTest OctarineEventBusTest
   OctarineCollisionSystemTest OctarineCollisionResponseTest OctarineProjectileEmitSystemTest
   OctarineAssetRefcounterTest OctarineDevListenServerTest OctarineLuaBehaviorTest
-  OctarineFileWatcherTest OctarineGameBakeTest
+  OctarineFileWatcherTest OctarineGameBakeTest OctarineFileSandboxTest
+  OctarineRenderQueueTest OctarineAssetStoreTest
 )
 
 if [[ $do_build -eq 1 ]]; then

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,6 +22,7 @@
 # -----------------------------------------------------------------------------
 set(OCTARINE_CORE_SOURCES
         General/Logger.cpp
+        General/FileSandbox.cpp
         General/FileWatcher.cpp
         General/SystemMemory.cpp
         ECS/Registry.cpp
@@ -121,8 +122,10 @@ octarine_library(octarine_lua
         Lua/Modules/GameModuleLuaBinding.cpp
         Lua/Modules/IoModuleLuaBinding.cpp
         Lua/Modules/LogModuleLuaBinding.cpp
+        Lua/Modules/ProjectModuleLuaBinding.cpp
         Lua/Modules/RegisterAllModules.cpp
         Lua/Modules/SceneModuleLuaBinding.cpp
+        Lua/Modules/StorageModuleLuaBinding.cpp
         Lua/Modules/UIModuleLuaBinding.cpp
 )
 target_link_libraries(octarine_lua PUBLIC

--- a/src/Game/Game.cpp
+++ b/src/Game/Game.cpp
@@ -9,6 +9,7 @@
 #include <set>
 #include <sol/sol.hpp>
 #include <string>
+#include <string_view>
 #include <unordered_set>
 
 #include "AssetManager/AssetCatalog.h"
@@ -48,6 +49,7 @@
 #include "General/Logger.h"
 #include "General/PerfUtils.h"
 #include "General/Rect.h"
+#include "Project/ProjectIni.h"
 #include "Renderer/RenderQueue.h"
 #include "Renderer/Renderer.h"
 #include "Renderer/SpriteRenderCache.h"
@@ -261,6 +263,53 @@ bool Game::CreateWindowAndScene(bool projectLoaded) {
     return false;
   }
   return renderer_->CreateScene(runtime_.SdlRenderer(), gameConfig.windowWidth, gameConfig.windowHeight);
+}
+
+bool Game::IsEditorMode() const {
+  const auto* config = registry_->TryGet<GameConfig>();
+  return config != nullptr && config->IsEditorMode();
+}
+
+std::string Game::GetProjectPath() const {
+  const auto* config = registry_->TryGet<GameConfig>();
+  return config != nullptr ? config->GetAssetPath() : std::string{};
+}
+
+std::string Game::GetSaveDataPath() {
+  if (!save_data_path_.empty()) {
+    return save_data_path_;
+  }
+
+  // Identity precedence: project.ini vendor/name > config.ini GameTitle > engine defaults.
+  // project.ini is read via SDL so it resolves inside an APK or .app bundle the same way
+  // config.ini does.
+  std::string org = "Octarine";
+  std::string app = "Engine";
+  if (const auto* config = registry_->TryGet<GameConfig>(); config != nullptr && config->HasLoadedConfig()) {
+    if (!config->GetGameTitle().empty()) {
+      app = config->GetGameTitle();
+    }
+    const std::string iniPath = config->GetAssetPath() + "/project.ini";
+    size_t dataSize = 0;
+    if (void* data = SDL_LoadFile(iniPath.c_str(), &dataSize)) {
+      const auto ini = octarine::project::ProjectIni::Parse(std::string_view(static_cast<const char*>(data), dataSize));
+      SDL_free(data);
+      if (!ini.vendor.empty()) {
+        org = ini.vendor;
+      }
+      if (!ini.name.empty()) {
+        app = ini.name;
+      }
+    }
+  }
+
+  if (char* prefPath = SDL_GetPrefPath(org.c_str(), app.c_str())) {
+    save_data_path_ = prefPath;
+    SDL_free(prefPath);
+  } else {
+    Logger::Error("Game::GetSaveDataPath: SDL_GetPrefPath failed: " + std::string(SDL_GetError()));
+  }
+  return save_data_path_;
 }
 
 void Game::Destroy() {

--- a/src/Game/Game.h
+++ b/src/Game/Game.h
@@ -101,6 +101,14 @@ class Game : public LuaBindingContext {
   // uses this to decide whether Play should resume a paused scene or (re)start a stopped one.
   [[nodiscard]] bool IsSceneRunning() const { return scene_loader_->IsSceneRunning(); }
 
+  // Sandbox roots + session kind for the Lua file-write modules (storage.* / project.*). All
+  // three tolerate a missing GameConfig singleton (headless tests construct Game without
+  // Initialize). GetSaveDataPath resolves once and caches — see the .cpp for the identity
+  // precedence (project.ini vendor/name > config.ini GameTitle > engine defaults).
+  [[nodiscard]] bool IsEditorMode() const override;
+  [[nodiscard]] std::string GetProjectPath() const override;
+  std::string GetSaveDataPath() override;
+
   // Run any scene swap queued (deferred) during this frame's input/system passes. FrameLoop calls
   // this at the top of Update, before systems run, so the swap happens outside any ForEach.
   void FlushPendingSceneLoad() { scene_loader_->FlushPendingSceneLoad(); }
@@ -134,6 +142,7 @@ class Game : public LuaBindingContext {
 
   sol::state lua;
   std::string startup_mode_;
+  std::string save_data_path_;
   std::unique_ptr<Registry> registry_;
   std::unique_ptr<EventBus> event_bus_;
   std::unique_ptr<Renderer> renderer_;

--- a/src/General/FileSandbox.cpp
+++ b/src/General/FileSandbox.cpp
@@ -1,0 +1,64 @@
+#include "General/FileSandbox.h"
+
+#include <filesystem>
+#include <fstream>
+#include <system_error>
+
+#include "General/Logger.h"
+
+namespace file_sandbox {
+
+std::string Resolve(const std::string& root, const std::string& relative) {
+  if (root.empty()) {
+    return {};
+  }
+  const std::filesystem::path inputPath(relative);
+  if (inputPath.is_absolute()) {
+    return {};
+  }
+  const std::filesystem::path basePath = std::filesystem::path(root).lexically_normal();
+  const std::filesystem::path fullPath = (basePath / inputPath).lexically_normal();
+  const auto rel = fullPath.lexically_relative(basePath);
+  if (rel.empty() || *rel.begin() == "..") {
+    return {};
+  }
+  return fullPath.string();
+}
+
+bool WriteFileAtomic(const std::string& fullPath, const std::string& contents) {
+  const std::filesystem::path target(fullPath);
+  std::error_code ec;
+  if (target.has_parent_path()) {
+    std::filesystem::create_directories(target.parent_path(), ec);
+    if (ec) {
+      Logger::Error("WriteFileAtomic: failed to create directories for " + fullPath + ": " + ec.message());
+      return false;
+    }
+  }
+
+  const std::filesystem::path tempPath = target.string() + ".tmp";
+  {
+    std::ofstream file(tempPath, std::ios::binary | std::ios::trunc);
+    if (!file.is_open()) {
+      Logger::Error("WriteFileAtomic: failed to open " + tempPath.string() + " for writing");
+      return false;
+    }
+    file.write(contents.data(), static_cast<std::streamsize>(contents.size()));
+    if (!file.good()) {
+      Logger::Error("WriteFileAtomic: write failed for " + tempPath.string());
+      file.close();
+      std::filesystem::remove(tempPath, ec);
+      return false;
+    }
+  }
+
+  std::filesystem::rename(tempPath, target, ec);
+  if (ec) {
+    Logger::Error("WriteFileAtomic: rename to " + fullPath + " failed: " + ec.message());
+    std::filesystem::remove(tempPath, ec);
+    return false;
+  }
+  return true;
+}
+
+}  // namespace file_sandbox

--- a/src/General/FileSandbox.h
+++ b/src/General/FileSandbox.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <string>
+
+// Shared helpers for the sandboxed Lua file-write surface (storage.* save data, editor-only
+// project.*). Path containment mirrors AssetManager::GetFullPath's lexical traversal check, but
+// is stricter: absolute inputs are rejected outright since callers only ever hand user/script
+// paths, never catalog-resolved ones.
+namespace file_sandbox {
+
+// Resolve `relative` against `root` and return the joined full path. Returns an empty string
+// when `root` is empty, `relative` is absolute, or the normalized result escapes `root`
+// (`../` traversal). Purely lexical — does not consult the filesystem, so symlinks inside the
+// root are trusted (the roots are app-owned directories).
+std::string Resolve(const std::string& root, const std::string& relative);
+
+// Write `contents` to `fullPath` atomically: write a sibling `.tmp` file, then rename it over
+// the target so a crash mid-write never leaves a truncated file (matters for save data).
+// Creates missing parent directories. Returns false on any failure, leaving no `.tmp` behind.
+bool WriteFileAtomic(const std::string& fullPath, const std::string& contents);
+
+}  // namespace file_sandbox

--- a/src/Lua/LuaBindingContext.h
+++ b/src/Lua/LuaBindingContext.h
@@ -30,6 +30,18 @@ class LuaBindingContext {
   [[nodiscard]] virtual bool IsBakeMode() const = 0;
   virtual void RecordBakeValidationFailures(int failures) = 0;
 
+  // True when this session is the editor. The editor-only `project.*` Lua module consults this
+  // at install time so a player session never gets a project-folder write surface.
+  [[nodiscard]] virtual bool IsEditorMode() const = 0;
+
+  // Root directory of the loaded game project (the GameConfig asset path); empty before a
+  // project loads. Sandbox root for the editor-only `project.*` writes.
+  [[nodiscard]] virtual std::string GetProjectPath() const = 0;
+
+  // Per-user writable save-data root (SDL pref path keyed by the project's identity). Sandbox
+  // root for the `storage.*` Lua module. Non-const: resolved lazily and cached by the host.
+  virtual std::string GetSaveDataPath() = 0;
+
   // Request engine shutdown (the `quit_game` Lua global). Named distinctly from Game's static
   // Quit() so the override doesn't collide with the static member.
   virtual void RequestQuit() = 0;

--- a/src/Lua/Modules/ProjectModuleLuaBinding.cpp
+++ b/src/Lua/Modules/ProjectModuleLuaBinding.cpp
@@ -1,0 +1,38 @@
+#include "Lua/Modules/ProjectModuleLuaBinding.h"
+
+#include <string>
+
+#include "General/FileSandbox.h"
+#include "General/Logger.h"
+#include "Lua/LuaBindingContext.h"
+
+namespace {
+bool WriteFile(LuaBindingContext& ctx, const std::string& relativePath, const std::string& contents) {
+  const std::string root = ctx.GetProjectPath();
+  if (root.empty()) {
+    Logger::Error("project.write_file: no project loaded");
+    return false;
+  }
+  const std::string fullPath = file_sandbox::Resolve(root, relativePath);
+  if (fullPath.empty()) {
+    Logger::Error("project.write_file: path rejected: " + relativePath);
+    return false;
+  }
+  return file_sandbox::WriteFileAtomic(fullPath, contents);
+}
+}  // namespace
+
+void LuaModuleBinding<ProjectModule>::install(sol::state& lua, LuaBindingContext& ctx) {
+  // Editor sessions only. A player session (even in an editor-capable binary) never gets a
+  // project-folder write surface; shipped player builds exclude this module at compile time
+  // (see RegisterAllModules.cpp).
+  if (!ctx.IsEditorMode()) {
+    return;
+  }
+  sol::table project = lua.create_table();
+  project.set_function("path", [&ctx]() -> std::string { return ctx.GetProjectPath(); });
+  project.set_function("write_file", [&ctx](const std::string& path, const std::string& contents) -> bool {
+    return WriteFile(ctx, path, contents);
+  });
+  lua["project"] = project;
+}

--- a/src/Lua/Modules/ProjectModuleLuaBinding.h
+++ b/src/Lua/Modules/ProjectModuleLuaBinding.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "Lua/Modules/LuaModule.h"
+
+struct ProjectModule {};
+
+template <>
+struct LuaModuleBinding<ProjectModule> {
+  static void install(sol::state& lua, LuaBindingContext& ctx);
+};

--- a/src/Lua/Modules/RegisterAllModules.cpp
+++ b/src/Lua/Modules/RegisterAllModules.cpp
@@ -8,13 +8,26 @@
 #include "Lua/Modules/LogModuleLuaBinding.h"
 #include "Lua/Modules/LuaModule.h"
 #include "Lua/Modules/SceneModuleLuaBinding.h"
+#include "Lua/Modules/StorageModuleLuaBinding.h"
 #include "Lua/Modules/UIModuleLuaBinding.h"
+#ifdef OCTARINE_WITH_EDITOR
+#include "Lua/Modules/ProjectModuleLuaBinding.h"
+#endif
 
 const std::vector<LuaModuleDescriptor> kLuaModules = {
-    {"Log", &LuaModuleBinding<LogModule>::install},       {"Io", &LuaModuleBinding<IoModule>::install},
-    {"Assets", &LuaModuleBinding<AssetsModule>::install}, {"Audio", &LuaModuleBinding<AudioModule>::install},
-    {"Entity", &LuaModuleBinding<EntityModule>::install}, {"Scene", &LuaModuleBinding<SceneModule>::install},
-    {"Game", &LuaModuleBinding<GameModule>::install},     {"UI", &LuaModuleBinding<UIModule>::install},
+    {"Log", &LuaModuleBinding<LogModule>::install},
+    {"Io", &LuaModuleBinding<IoModule>::install},
+    {"Assets", &LuaModuleBinding<AssetsModule>::install},
+    {"Audio", &LuaModuleBinding<AudioModule>::install},
+    {"Entity", &LuaModuleBinding<EntityModule>::install},
+    {"Scene", &LuaModuleBinding<SceneModule>::install},
+    {"Game", &LuaModuleBinding<GameModule>::install},
+    {"UI", &LuaModuleBinding<UIModule>::install},
+    {"Storage", &LuaModuleBinding<StorageModule>::install},
+#ifdef OCTARINE_WITH_EDITOR
+    // Editor-only project-folder writes; install() additionally no-ops outside an editor session.
+    {"Project", &LuaModuleBinding<ProjectModule>::install},
+#endif
 };
 
 void RegisterAllLuaModules(sol::state& lua, LuaBindingContext& ctx) {

--- a/src/Lua/Modules/StorageModuleLuaBinding.cpp
+++ b/src/Lua/Modules/StorageModuleLuaBinding.cpp
@@ -1,0 +1,96 @@
+#include "Lua/Modules/StorageModuleLuaBinding.h"
+
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <system_error>
+#include <vector>
+
+#include "General/FileSandbox.h"
+#include "General/Logger.h"
+#include "Lua/LuaBindingContext.h"
+
+namespace {
+// Resolve a script-supplied relative path inside the per-user save-data root. Empty result
+// means rejected (absolute path, ../ escape, or no save root available) — already logged.
+std::string ResolveStoragePath(LuaBindingContext& ctx, const std::string& relativePath, const char* op) {
+  const std::string root = ctx.GetSaveDataPath();
+  if (root.empty()) {
+    Logger::Error(std::string("storage.") + op + ": no save-data root available");
+    return {};
+  }
+  std::string fullPath = file_sandbox::Resolve(root, relativePath);
+  if (fullPath.empty()) {
+    Logger::Error(std::string("storage.") + op + ": path rejected: " + relativePath);
+  }
+  return fullPath;
+}
+
+bool Write(LuaBindingContext& ctx, const std::string& relativePath, const std::string& contents) {
+  const std::string fullPath = ResolveStoragePath(ctx, relativePath, "write");
+  if (fullPath.empty()) return false;
+  return file_sandbox::WriteFileAtomic(fullPath, contents);
+}
+
+sol::optional<std::string> Read(LuaBindingContext& ctx, const std::string& relativePath) {
+  const std::string fullPath = ResolveStoragePath(ctx, relativePath, "read");
+  if (fullPath.empty()) return sol::nullopt;
+  std::ifstream file(fullPath, std::ios::binary);
+  if (!file.is_open()) return sol::nullopt;
+  std::ostringstream buffer;
+  buffer << file.rdbuf();
+  return buffer.str();
+}
+
+bool Exists(LuaBindingContext& ctx, const std::string& relativePath) {
+  const std::string fullPath = ResolveStoragePath(ctx, relativePath, "exists");
+  if (fullPath.empty()) return false;
+  std::error_code ec;
+  return std::filesystem::exists(fullPath, ec);
+}
+
+bool Remove(LuaBindingContext& ctx, const std::string& relativePath) {
+  const std::string fullPath = ResolveStoragePath(ctx, relativePath, "remove");
+  if (fullPath.empty()) return false;
+  std::error_code ec;
+  return std::filesystem::remove(fullPath, ec);
+}
+
+// Names of the direct children of `relativePath` (files and subdirectories), sorted for stable
+// iteration order. Empty table when the directory doesn't exist.
+sol::table List(LuaBindingContext& ctx, const std::string& relativePath, sol::this_state s) {
+  sol::state_view lua(s);
+  sol::table names = lua.create_table();
+  const std::string fullPath = ResolveStoragePath(ctx, relativePath, "list");
+  if (fullPath.empty()) return names;
+
+  std::error_code ec;
+  std::vector<std::string> entries;
+  for (const auto& entry : std::filesystem::directory_iterator(fullPath, ec)) {
+    entries.push_back(entry.path().filename().string());
+  }
+  std::sort(entries.begin(), entries.end());
+  for (size_t i = 0; i < entries.size(); ++i) {
+    names[i + 1] = entries[i];
+  }
+  return names;
+}
+}  // namespace
+
+void LuaModuleBinding<StorageModule>::install(sol::state& lua, LuaBindingContext& ctx) {
+  sol::table storage = lua.create_table();
+  storage.set_function("write", [&ctx](const std::string& path, const std::string& contents) -> bool {
+    return Write(ctx, path, contents);
+  });
+  storage.set_function(
+      "read", [&ctx](const std::string& path) -> sol::optional<std::string> { return Read(ctx, path); });
+  storage.set_function("exists", [&ctx](const std::string& path) -> bool { return Exists(ctx, path); });
+  storage.set_function("remove", [&ctx](const std::string& path) -> bool { return Remove(ctx, path); });
+  // Path optional: storage.list() lists the save-data root itself.
+  storage.set_function("list", [&ctx](sol::optional<std::string> path, sol::this_state s) -> sol::table {
+    return List(ctx, path.value_or(""), s);
+  });
+  lua["storage"] = storage;
+}

--- a/src/Lua/Modules/StorageModuleLuaBinding.cpp
+++ b/src/Lua/Modules/StorageModuleLuaBinding.cpp
@@ -84,8 +84,8 @@ void LuaModuleBinding<StorageModule>::install(sol::state& lua, LuaBindingContext
   storage.set_function("write", [&ctx](const std::string& path, const std::string& contents) -> bool {
     return Write(ctx, path, contents);
   });
-  storage.set_function(
-      "read", [&ctx](const std::string& path) -> sol::optional<std::string> { return Read(ctx, path); });
+  storage.set_function("read",
+                       [&ctx](const std::string& path) -> sol::optional<std::string> { return Read(ctx, path); });
   storage.set_function("exists", [&ctx](const std::string& path) -> bool { return Exists(ctx, path); });
   storage.set_function("remove", [&ctx](const std::string& path) -> bool { return Remove(ctx, path); });
   // Path optional: storage.list() lists the save-data root itself.

--- a/src/Lua/Modules/StorageModuleLuaBinding.cpp
+++ b/src/Lua/Modules/StorageModuleLuaBinding.cpp
@@ -89,7 +89,7 @@ void LuaModuleBinding<StorageModule>::install(sol::state& lua, LuaBindingContext
   storage.set_function("exists", [&ctx](const std::string& path) -> bool { return Exists(ctx, path); });
   storage.set_function("remove", [&ctx](const std::string& path) -> bool { return Remove(ctx, path); });
   // Path optional: storage.list() lists the save-data root itself.
-  storage.set_function("list", [&ctx](sol::optional<std::string> path, sol::this_state s) -> sol::table {
+  storage.set_function("list", [&ctx](const sol::optional<std::string>& path, sol::this_state s) -> sol::table {
     return List(ctx, path.value_or(""), s);
   });
   lua["storage"] = storage;

--- a/src/Lua/Modules/StorageModuleLuaBinding.h
+++ b/src/Lua/Modules/StorageModuleLuaBinding.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "Lua/Modules/LuaModule.h"
+
+struct StorageModule {};
+
+template <>
+struct LuaModuleBinding<StorageModule> {
+  static void install(sol::state& lua, LuaBindingContext& ctx);
+};

--- a/tests/FileSandboxTest.cpp
+++ b/tests/FileSandboxTest.cpp
@@ -1,0 +1,153 @@
+// Unit checks for the sandboxed Lua file-write surface. gtest-free; exit code = failed-check
+// count. Covers the file_sandbox helpers (lexical containment + atomic write) directly, then the
+// storage.* / project.* modules end-to-end through a fake LuaBindingContext host — including the
+// editor-session gate that keeps project.* out of player sessions.
+
+#include <sol/sol.hpp>
+
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "Engine/EngineContext.h"
+#include "General/FileSandbox.h"
+#include "General/Logger.h"
+#include "Lua/LuaBindingContext.h"
+#include "Lua/Modules/ProjectModuleLuaBinding.h"
+#include "Lua/Modules/StorageModuleLuaBinding.h"
+#include "TestHarness.h"
+
+using octarine::test::Check;
+
+namespace {
+
+class FakeHost : public LuaBindingContext {
+ public:
+  FakeHost(std::string saveRoot, std::string projectRoot, const bool editorMode)
+      : save_root_(std::move(saveRoot)), project_root_(std::move(projectRoot)), editor_mode_(editorMode) {}
+
+  [[nodiscard]] Registry* GetRegistry() const override { return nullptr; }
+  [[nodiscard]] SDL_Renderer* GetRenderer() const override { return nullptr; }
+  [[nodiscard]] EngineContext& GetContext() override { return context_; }
+
+  void LoadScene(const std::string& /*scenePath*/) override {}
+  void ReloadScene() override {}
+  void StopScene() override {}
+  void TrackSceneAssets(const std::vector<std::string>& /*assetIds*/) override {}
+
+  [[nodiscard]] bool IsBakeMode() const override { return false; }
+  void RecordBakeValidationFailures(int /*failures*/) override {}
+
+  [[nodiscard]] bool IsEditorMode() const override { return editor_mode_; }
+  [[nodiscard]] std::string GetProjectPath() const override { return project_root_; }
+  std::string GetSaveDataPath() override { return save_root_; }
+
+  void RequestQuit() override {}
+
+ private:
+  EngineContext context_{};
+  std::string save_root_;
+  std::string project_root_;
+  bool editor_mode_;
+};
+
+std::string ReadAll(const std::filesystem::path& path) {
+  std::ifstream file(path, std::ios::binary);
+  std::ostringstream buffer;
+  buffer << file.rdbuf();
+  return buffer.str();
+}
+
+void TestResolve(const std::string& root) {
+  const auto base = std::filesystem::path(root).lexically_normal();
+  Check(file_sandbox::Resolve(root, "a/b.txt") == (base / "a/b.txt").lexically_normal().string(),
+        "Resolve joins a plain relative path");
+  Check(!file_sandbox::Resolve(root, "a/../b.txt").empty(), "Resolve allows ../ that stays inside the root");
+  Check(file_sandbox::Resolve(root, "../escape.txt").empty(), "Resolve rejects ../ escape");
+  Check(file_sandbox::Resolve(root, "a/../../escape.txt").empty(), "Resolve rejects nested ../ escape");
+  Check(file_sandbox::Resolve(root, (base / "abs.txt").string()).empty(), "Resolve rejects absolute paths");
+  Check(file_sandbox::Resolve("", "a.txt").empty(), "Resolve rejects an empty root");
+}
+
+void TestWriteFileAtomic(const std::filesystem::path& root) {
+  const auto target = root / "atomic" / "out.txt";
+  Check(file_sandbox::WriteFileAtomic(target.string(), "first"), "WriteFileAtomic creates parent dirs + file");
+  Check(ReadAll(target) == "first", "WriteFileAtomic wrote the contents");
+  Check(!std::filesystem::exists(target.string() + ".tmp"), "WriteFileAtomic leaves no .tmp behind");
+  Check(file_sandbox::WriteFileAtomic(target.string(), "second"), "WriteFileAtomic overwrites an existing file");
+  Check(ReadAll(target) == "second", "WriteFileAtomic replaced the contents");
+}
+
+void TestStorageModule(LuaBindingContext& host, const std::filesystem::path& saveRoot) {
+  sol::state lua;
+  lua.open_libraries(sol::lib::base, sol::lib::string, sol::lib::table);
+  LuaModuleBinding<StorageModule>::install(lua, host);
+
+  Check(lua["storage"].get_type() == sol::type::table, "storage table installed");
+  Check(lua.script("return storage.write('saves/slot1.json', 'hello')").get<bool>(), "storage.write");
+  Check(std::filesystem::exists(saveRoot / "saves/slot1.json"), "storage.write landed under the save root");
+  Check(lua.script("return storage.read('saves/slot1.json')").get<std::string>() == "hello",
+        "storage.read roundtrip");
+  Check(lua.script("return storage.read('saves/missing.json') == nil").get<bool>(),
+        "storage.read returns nil for a missing file");
+  Check(lua.script("return storage.exists('saves/slot1.json')").get<bool>(), "storage.exists");
+  Check(lua.script("return storage.list('saves')[1]").get<std::string>() == "slot1.json", "storage.list");
+  Check(lua.script("return storage.list()[1]").get<std::string>() == "saves",
+        "storage.list() lists the save root");
+  Check(!lua.script("return storage.write('../evil.txt', 'x')").get<bool>(), "storage.write rejects traversal");
+  Check(!std::filesystem::exists(saveRoot.parent_path() / "evil.txt"), "traversal write created nothing");
+  Check(lua.script("return storage.remove('saves/slot1.json')").get<bool>(), "storage.remove");
+  Check(!std::filesystem::exists(saveRoot / "saves/slot1.json"), "storage.remove deleted the file");
+}
+
+void TestProjectModule(const std::string& saveRoot, const std::filesystem::path& projectRoot) {
+  {
+    sol::state lua;
+    lua.open_libraries(sol::lib::base);
+    FakeHost player(saveRoot, projectRoot.string(), /*editorMode=*/false);
+    LuaModuleBinding<ProjectModule>::install(lua, player);
+    Check(!lua["project"].valid(), "project table absent outside an editor session");
+  }
+
+  sol::state lua;
+  lua.open_libraries(sol::lib::base);
+  FakeHost editor(saveRoot, projectRoot.string(), /*editorMode=*/true);
+  LuaModuleBinding<ProjectModule>::install(lua, editor);
+  Check(lua["project"].get_type() == sol::type::table, "project table installed in an editor session");
+  Check(lua.script("return project.path()").get<std::string>() == projectRoot.string(), "project.path");
+  Check(lua.script("return project.write_file('assets/generated/map.lua', 'return {}')").get<bool>(),
+        "project.write_file");
+  Check(ReadAll(projectRoot / "assets/generated/map.lua") == "return {}", "project.write_file wrote the contents");
+  Check(!lua.script("return project.write_file('../evil.lua', 'x')").get<bool>(),
+        "project.write_file rejects traversal");
+}
+
+}  // namespace
+
+int main() {
+  Logger::Init();
+
+  const auto testRoot = std::filesystem::temp_directory_path() / "octarine-file-sandbox-test";
+  std::filesystem::remove_all(testRoot);
+  const auto saveRoot = testRoot / "save";
+  const auto projectRoot = testRoot / "project";
+  std::filesystem::create_directories(saveRoot);
+  std::filesystem::create_directories(projectRoot);
+
+  std::cout << "[file_sandbox helpers]\n";
+  TestResolve(saveRoot.string());
+  // Outside saveRoot so the storage.list() check below sees only what storage.write created.
+  TestWriteFileAtomic(testRoot / "helper");
+
+  std::cout << "[storage module]\n";
+  FakeHost host(saveRoot.string(), projectRoot.string(), /*editorMode=*/false);
+  TestStorageModule(host, saveRoot);
+
+  std::cout << "[project module]\n";
+  TestProjectModule(saveRoot.string(), projectRoot);
+
+  std::filesystem::remove_all(testRoot);
+  return octarine::test::Result();
+}

--- a/tests/FileSandboxTest.cpp
+++ b/tests/FileSandboxTest.cpp
@@ -3,10 +3,9 @@
 // storage.* / project.* modules end-to-end through a fake LuaBindingContext host — including the
 // editor-session gate that keeps project.* out of player sessions.
 
-#include <sol/sol.hpp>
-
 #include <filesystem>
 #include <fstream>
+#include <sol/sol.hpp>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -88,14 +87,12 @@ void TestStorageModule(LuaBindingContext& host, const std::filesystem::path& sav
   Check(lua["storage"].get_type() == sol::type::table, "storage table installed");
   Check(lua.script("return storage.write('saves/slot1.json', 'hello')").get<bool>(), "storage.write");
   Check(std::filesystem::exists(saveRoot / "saves/slot1.json"), "storage.write landed under the save root");
-  Check(lua.script("return storage.read('saves/slot1.json')").get<std::string>() == "hello",
-        "storage.read roundtrip");
+  Check(lua.script("return storage.read('saves/slot1.json')").get<std::string>() == "hello", "storage.read roundtrip");
   Check(lua.script("return storage.read('saves/missing.json') == nil").get<bool>(),
         "storage.read returns nil for a missing file");
   Check(lua.script("return storage.exists('saves/slot1.json')").get<bool>(), "storage.exists");
   Check(lua.script("return storage.list('saves')[1]").get<std::string>() == "slot1.json", "storage.list");
-  Check(lua.script("return storage.list()[1]").get<std::string>() == "saves",
-        "storage.list() lists the save root");
+  Check(lua.script("return storage.list()[1]").get<std::string>() == "saves", "storage.list() lists the save root");
   Check(!lua.script("return storage.write('../evil.txt', 'x')").get<bool>(), "storage.write rejects traversal");
   Check(!std::filesystem::exists(saveRoot.parent_path() / "evil.txt"), "traversal write created nothing");
   Check(lua.script("return storage.remove('saves/slot1.json')").get<bool>(), "storage.remove");

--- a/tests/LuaApiSmokeTest.cpp
+++ b/tests/LuaApiSmokeTest.cpp
@@ -8,18 +8,18 @@
 //
 // Built only when OCTARINE_ENABLE_TESTS=ON. Exit code is the number of failed checks.
 
-#include <sol/sol.hpp>
-
 #include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <set>
+#include <sol/sol.hpp>
 #include <string>
 #include <vector>
 
 #include "Components/ScriptComponent.h"
 #include "ECS/Registry.h"
 #include "Game/Game.h"
+#include "Game/GameConfig.h"
 #include "General/Logger.h"
 #include "Lua/HotReload/ScriptHotReload.h"
 #ifdef OCTARINE_WITH_EDITOR
@@ -36,233 +36,232 @@
 #include "Systems/InputSystem.h"
 #include "Systems/ScriptSystem.h"
 
-namespace
-{
-    int g_failures = 0;
+namespace {
+int g_failures = 0;
 
-    void Check(const bool condition, const std::string& what)
-    {
-        if (condition)
-        {
-            std::cout << "  ok   " << what << "\n";
-        }
-        else
-        {
-            std::cerr << "  FAIL " << what << "\n";
-            ++g_failures;
-        }
-    }
+void Check(const bool condition, const std::string& what) {
+  if (condition) {
+    std::cout << "  ok   " << what << "\n";
+  } else {
+    std::cerr << "  FAIL " << what << "\n";
+    ++g_failures;
+  }
+}
 
-    bool IsFunction(sol::state& lua, const std::string& name)
-    {
-        const sol::object obj = lua[name];
-        return obj.valid() && obj.get_type() == sol::type::function;
-    }
+bool IsFunction(sol::state& lua, const std::string& name) {
+  const sol::object obj = lua[name];
+  return obj.valid() && obj.get_type() == sol::type::function;
+}
 
-    bool TableHasFunction(sol::state& lua, const std::string& table, const std::string& key)
-    {
-        const sol::object tableObj = lua[table];
-        if (!tableObj.valid() || tableObj.get_type() != sol::type::table) return false;
-        const sol::object fn = tableObj.as<sol::table>()[key];
-        return fn.valid() && fn.get_type() == sol::type::function;
-    }
-} // namespace
+bool TableHasFunction(sol::state& lua, const std::string& table, const std::string& key) {
+  const sol::object tableObj = lua[table];
+  if (!tableObj.valid() || tableObj.get_type() != sol::type::table) return false;
+  const sol::object fn = tableObj.as<sol::table>()[key];
+  return fn.valid() && fn.get_type() == sol::type::function;
+}
+}  // namespace
 
-int main()
-{
-    // Logger::Init brings up the dual main/lua spdlog sinks. ScriptHotReload calls
-    // Logger::ErrorLua on failed reloads; without Init the lua sink shared_ptr is null and the
-    // call AVs. Real binary calls this from Main; tests must do it explicitly.
-    Logger::Init();
+int main() {
+  // Logger::Init brings up the dual main/lua spdlog sinks. ScriptHotReload calls
+  // Logger::ErrorLua on failed reloads; without Init the lua sink shared_ptr is null and the
+  // call AVs. Real binary calls this from Main; tests must do it explicitly.
+  Logger::Init();
 
-    Game game; // SDL-free constructor — allocates Registry/EventBus/Renderer, opens no window.
-    sol::state& lua = game.GetLua();
-    lua.open_libraries(sol::lib::base, sol::lib::math, sol::lib::io, sol::lib::string, sol::lib::table);
-    const auto preBinding = LuaApiManifest::SnapshotGlobals(lua);
+  Game game;  // SDL-free constructor — allocates Registry/EventBus/Renderer, opens no window.
+  sol::state& lua = game.GetLua();
+  lua.open_libraries(sol::lib::base, sol::lib::math, sol::lib::io, sol::lib::string, sol::lib::table);
+  const auto preBinding = LuaApiManifest::SnapshotGlobals(lua);
 
-    // Mirror Game::Setup's binding order: component types, then free-function modules, then
-    // system surfaces.
-    RegisterAllLuaBindings();
+  // Mirror Game::Setup's binding order: component types, then free-function modules, then
+  // system surfaces.
+  RegisterAllLuaBindings();
 #ifdef OCTARINE_WITH_EDITOR
-    RegisterAllComponentInspectors();
+  RegisterAllComponentInspectors();
 #endif
 
-    ScriptSystem scriptSystem;
-    scriptSystem.CreateLuaBindings(lua); // primitives + component usertypes
-
-    // Install modules one at a time, snapshotting globals around each call so LuaModuleRegistry
-    // ends up with an exact "what globals did each module install" record — fed to modules.json.
-    LuaModuleRegistry::clear();
-    for (const auto& m : kLuaModules)
-    {
-        const auto before = LuaApiManifest::SnapshotGlobals(lua);
-        m.install(lua, game);
-        const auto after = LuaApiManifest::SnapshotGlobals(lua);
-        std::vector<std::string> added;
-        for (const auto& name : after)
-        {
-            if (before.find(name) == before.end()) added.push_back(name);
-        }
-        LuaModuleRegistry::registerModule(m.name, std::move(added));
-    }
-
-    InputSystem inputSystem;
-    LuaSystemRegistry::clear();
-    LuaSystemRegistry::registerSystem(inputSystem);
-    LuaSystemRegistry::bindAll(lua); // system surfaces (input.*)
-
-    std::cout << "[components] usertypes + registry accessors\n";
-    const auto& components = LuaComponentRegistry::all();
-    Check(!components.empty(), "component registry is non-empty");
-    for (const auto& entry : components)
-    {
-        const sol::object usertype = lua[entry.usertypeName];
-        Check(usertype.valid(), "usertype '" + entry.usertypeName + "' bound");
-        Check(TableHasFunction(lua, "registry", "has_" + entry.luaKey), "registry.has_" + entry.luaKey);
-        Check(TableHasFunction(lua, "registry", "get_" + entry.luaKey), "registry.get_" + entry.luaKey);
-    }
+  ScriptSystem scriptSystem;
+  scriptSystem.CreateLuaBindings(lua);  // primitives + component usertypes
 
 #ifdef OCTARINE_WITH_EDITOR
-    std::cout << "[inspectors] component inspector registry\n";
-    {
-        const auto& inspectors = ComponentInspectorRegistry::all();
-        Check(!inspectors.empty(), "inspector registry is non-empty");
-
-        std::set<std::string> names;
-        for (const auto& entry : inspectors)
-        {
-            Check(names.insert(entry.displayName).second, "inspector display name unique: " + entry.displayName);
-        }
-
-        // Every addable inspector's makeDefault() must yield a component that has() can find —
-        // catches a broken default ctor or a mis-wired registerComponent<T>().
-        auto* reg = game.GetRegistry();
-        for (const auto& entry : inspectors)
-        {
-            if (!entry.addDefault) continue;
-            const Entity ent = reg->CreateEntity();
-            entry.addDefault(reg, ent);
-            Check(entry.has(reg, ent), "addDefault produces has(): " + entry.displayName);
-        }
-    }
+  // ProjectModule installs only in an editor session (its install() checks IsEditorMode).
+  // Force one here so the module registers its globals and modules.json captures them.
+  game.GetRegistry()->Set<GameConfig>(GameConfig());
+  game.GetRegistry()->Get<GameConfig>().SetIsEditorMode(true);
 #endif
 
-    std::cout << "[modules] each module installs at least one global\n";
-    // If a module's install body becomes empty (or was removed), its captured global list is empty
-    // and this fails. Catches "dropped from RegisterAllModules.cpp" without naming sentinels by hand.
-    Check(!LuaModuleRegistry::all().empty(), "module registry is non-empty");
-    for (const auto& m : LuaModuleRegistry::all())
-    {
-        Check(!m.globals.empty(), m.name + "Module installed at least one global");
+  // Install modules one at a time, snapshotting globals around each call so LuaModuleRegistry
+  // ends up with an exact "what globals did each module install" record — fed to modules.json.
+  LuaModuleRegistry::clear();
+  for (const auto& m : kLuaModules) {
+    const auto before = LuaApiManifest::SnapshotGlobals(lua);
+    m.install(lua, game);
+    const auto after = LuaApiManifest::SnapshotGlobals(lua);
+    std::vector<std::string> added;
+    for (const auto& name : after) {
+      if (before.find(name) == before.end()) added.push_back(name);
+    }
+    LuaModuleRegistry::registerModule(m.name, std::move(added));
+  }
+
+  InputSystem inputSystem;
+  LuaSystemRegistry::clear();
+  LuaSystemRegistry::registerSystem(inputSystem);
+  LuaSystemRegistry::bindAll(lua);  // system surfaces (input.*)
+
+  std::cout << "[components] usertypes + registry accessors\n";
+  const auto& components = LuaComponentRegistry::all();
+  Check(!components.empty(), "component registry is non-empty");
+  for (const auto& entry : components) {
+    const sol::object usertype = lua[entry.usertypeName];
+    Check(usertype.valid(), "usertype '" + entry.usertypeName + "' bound");
+    Check(TableHasFunction(lua, "registry", "has_" + entry.luaKey), "registry.has_" + entry.luaKey);
+    Check(TableHasFunction(lua, "registry", "get_" + entry.luaKey), "registry.get_" + entry.luaKey);
+  }
+
+#ifdef OCTARINE_WITH_EDITOR
+  std::cout << "[inspectors] component inspector registry\n";
+  {
+    const auto& inspectors = ComponentInspectorRegistry::all();
+    Check(!inspectors.empty(), "inspector registry is non-empty");
+
+    std::set<std::string> names;
+    for (const auto& entry : inspectors) {
+      Check(names.insert(entry.displayName).second, "inspector display name unique: " + entry.displayName);
     }
 
-    std::cout << "[primitives + systems]\n";
-    Check(lua["vec2"].valid(), "vec2 usertype bound");
-    Check(lua["entity"].valid(), "entity usertype bound");
-    Check(lua["registry"].valid() && lua["registry"].get_type() == sol::type::table, "registry table present");
-    Check(TableHasFunction(lua, "input", "is_key_down"), "input.is_key_down (InputSystem surface)");
+    // Every addable inspector's makeDefault() must yield a component that has() can find —
+    // catches a broken default ctor or a mis-wired registerComponent<T>().
+    auto* reg = game.GetRegistry();
+    for (const auto& entry : inspectors) {
+      if (!entry.addDefault) continue;
+      const Entity ent = reg->CreateEntity();
+      entry.addDefault(reg, ent);
+      Check(entry.has(reg, ent), "addDefault produces has(): " + entry.displayName);
+    }
+  }
+#endif
 
-    std::cout << "[manifest] generator runs\n";
+  std::cout << "[modules] each module installs at least one global\n";
+  // If a module's install body becomes empty (or was removed), its captured global list is empty
+  // and this fails. Catches "dropped from RegisterAllModules.cpp" without naming sentinels by hand.
+  Check(!LuaModuleRegistry::all().empty(), "module registry is non-empty");
+  for (const auto& m : LuaModuleRegistry::all()) {
+    Check(!m.globals.empty(), m.name + "Module installed at least one global");
+  }
+
+  std::cout << "[primitives + systems]\n";
+  Check(lua["vec2"].valid(), "vec2 usertype bound");
+  Check(lua["entity"].valid(), "entity usertype bound");
+  Check(lua["registry"].valid() && lua["registry"].get_type() == sol::type::table, "registry table present");
+  Check(TableHasFunction(lua, "input", "is_key_down"), "input.is_key_down (InputSystem surface)");
+
+  std::cout << "[file write surface] storage.* (all builds) + project.* (editor sessions)\n";
+  for (const auto* fn : {"write", "read", "exists", "remove", "list"}) {
+    Check(TableHasFunction(lua, "storage", fn), std::string("storage.") + fn);
+  }
+#ifdef OCTARINE_WITH_EDITOR
+  Check(TableHasFunction(lua, "project", "path"), "project.path (editor session)");
+  Check(TableHasFunction(lua, "project", "write_file"), "project.write_file (editor session)");
+#endif
+
+  std::cout << "[manifest] generator runs\n";
 #ifdef LUA_API_SMOKE_OUTPUT
-    const std::string smokeOutPath = LUA_API_SMOKE_OUTPUT;
+  const std::string smokeOutPath = LUA_API_SMOKE_OUTPUT;
 #else
-    const std::string smokeOutPath = "lua_api.smoke.lua";
+  const std::string smokeOutPath = "lua_api.smoke.lua";
 #endif
-    Check(LuaApiManifest::Write(lua, preBinding, smokeOutPath), "manifest written");
+  Check(LuaApiManifest::Write(lua, preBinding, smokeOutPath), "manifest written");
 
 #ifdef LUA_API_COMPONENTS_OUTPUT
-    Check(LuaApiManifest::WriteComponentsJson(LUA_API_COMPONENTS_OUTPUT), "components.json written");
+  Check(LuaApiManifest::WriteComponentsJson(LUA_API_COMPONENTS_OUTPUT), "components.json written");
 #endif
 #ifdef LUA_API_MODULES_OUTPUT
-    Check(LuaApiManifest::WriteModulesJson(LUA_API_MODULES_OUTPUT), "modules.json written");
+  Check(LuaApiManifest::WriteModulesJson(LUA_API_MODULES_OUTPUT), "modules.json written");
 #endif
 
 #ifndef OCTARINE_SHIPPED
-    std::cout << "[hot-reload] ScriptHotReload swap + state preservation + error containment\n";
+  std::cout << "[hot-reload] ScriptHotReload swap + state preservation + error containment\n";
+  {
+    auto* reg = game.GetRegistry();
+    reg->Set<ScriptHotReload>(ScriptHotReload());
+    auto& hotReload = reg->Get<ScriptHotReload>();
+
+    const auto tempDir = std::filesystem::temp_directory_path() / "octarine-hotreload-test";
+    std::error_code ec;
+    std::filesystem::create_directories(tempDir, ec);
+    const auto scriptPath = (tempDir / "fixture.lua").string();
+
+    const auto WriteScript = [&](const std::string& body) {
+      std::ofstream f(scriptPath, std::ios::trunc);
+      f << body;
+      f.close();
+    };
+
+    // v1: on_update writes 'kind = "v1"' into self.data.
+    WriteScript(
+        "return {\n"
+        "  data = { kind = 'initial', persisted = 42 },\n"
+        "  on_update = function(self, e, dt) self.data.kind = 'v1' end,\n"
+        "}\n");
+
+    // Load v1 manually via dofile (mirrors what FromSource does in the binding).
+    sol::protected_function_result loadV1 = lua["dofile"](scriptPath);
+    Check(loadV1.valid(), "fixture v1 loads");
+    sol::table v1Table = loadV1;
+    const sol::protected_function v1Update = v1Table["on_update"];
+
+    // Author-side mutation before reload: bump a value that must survive the swap.
+    v1Table["data"]["persisted"] = 99;
+
+    ScriptComponent sc(v1Table, v1Update, sol::protected_function(sol::lua_nil), scriptPath);
+    const Entity ent = reg->CreateEntity();
+    reg->AddComponent(ent, std::move(sc));
+
+    // Drive v1 once so 'kind' is set to "v1".
     {
-        auto* reg = game.GetRegistry();
-        reg->Set<ScriptHotReload>(ScriptHotReload());
-        auto& hotReload = reg->Get<ScriptHotReload>();
-
-        const auto tempDir = std::filesystem::temp_directory_path() / "octarine-hotreload-test";
-        std::error_code ec;
-        std::filesystem::create_directories(tempDir, ec);
-        const auto scriptPath = (tempDir / "fixture.lua").string();
-
-        const auto WriteScript = [&](const std::string& body) {
-            std::ofstream f(scriptPath, std::ios::trunc);
-            f << body;
-            f.close();
-        };
-
-        // v1: on_update writes 'kind = "v1"' into self.data.
-        WriteScript(
-            "return {\n"
-            "  data = { kind = 'initial', persisted = 42 },\n"
-            "  on_update = function(self, e, dt) self.data.kind = 'v1' end,\n"
-            "}\n");
-
-        // Load v1 manually via dofile (mirrors what FromSource does in the binding).
-        sol::protected_function_result loadV1 = lua["dofile"](scriptPath);
-        Check(loadV1.valid(), "fixture v1 loads");
-        sol::table v1Table = loadV1;
-        const sol::protected_function v1Update = v1Table["on_update"];
-
-        // Author-side mutation before reload: bump a value that must survive the swap.
-        v1Table["data"]["persisted"] = 99;
-
-        ScriptComponent sc(v1Table, v1Update, sol::protected_function(sol::lua_nil), scriptPath);
-        const Entity ent = reg->CreateEntity();
-        reg->AddComponent(ent, std::move(sc));
-
-        // Drive v1 once so 'kind' is set to "v1".
-        {
-            auto& live = reg->GetComponent<ScriptComponent>(ent);
-            live.updateFunction(live.scriptTable, ent, 0.016F);
-            sol::optional<std::string> kindOpt = live.scriptTable["data"]["kind"];
-            Check(kindOpt.value_or("<missing>") == "v1", "v1 on_update fires (kind == 'v1')");
-        }
-
-        // v2: same file, different behavior. Save *should* be picked up by ForceReloadAll.
-        WriteScript(
-            "return {\n"
-            "  data = { kind = 'shadow', persisted = 0 },\n"
-            "  on_update = function(self, e, dt) self.data.kind = 'v2' end,\n"
-            "}\n");
-        hotReload.ForceReloadAll(*reg, lua);
-        {
-            auto& live = reg->GetComponent<ScriptComponent>(ent);
-            live.updateFunction(live.scriptTable, ent, 0.016F);
-            sol::optional<sol::table> dataOpt = live.scriptTable["data"];
-            sol::optional<std::string> kindOpt = dataOpt ? dataOpt->get<sol::optional<std::string>>("kind") : sol::nullopt;
-            Check(kindOpt.value_or("<missing>") == "v2", "v2 on_update fires after reload (kind == 'v2')");
-            sol::optional<int> persistedOpt = dataOpt ? dataOpt->get<sol::optional<int>>("persisted") : sol::nullopt;
-            Check(persistedOpt.value_or(-1) == 99, "scriptTable.data preserved across reload (persisted == 99)");
-            Check(hotReload.LastReload().error.empty(), "successful reload leaves no last-error");
-        }
-
-        // Syntax error: reload must log + leave prior callbacks intact.
-        WriteScript("return { on_update = function(self, e, dt) self.data.kind = 'v3' end,\n");  // missing closing }
-        hotReload.ForceReloadAll(*reg, lua);
-        {
-            auto& live = reg->GetComponent<ScriptComponent>(ent);
-            live.updateFunction(live.scriptTable, ent, 0.016F);
-            sol::optional<std::string> kindOpt = live.scriptTable["data"]["kind"];
-            Check(kindOpt.value_or("<missing>") == "v2", "syntax-error reload preserves prior callback (kind still 'v2')");
-            Check(!hotReload.LastReload().error.empty(), "failed reload records error");
-        }
-
-        std::filesystem::remove_all(tempDir, ec);
+      auto& live = reg->GetComponent<ScriptComponent>(ent);
+      live.updateFunction(live.scriptTable, ent, 0.016F);
+      sol::optional<std::string> kindOpt = live.scriptTable["data"]["kind"];
+      Check(kindOpt.value_or("<missing>") == "v1", "v1 on_update fires (kind == 'v1')");
     }
+
+    // v2: same file, different behavior. Save *should* be picked up by ForceReloadAll.
+    WriteScript(
+        "return {\n"
+        "  data = { kind = 'shadow', persisted = 0 },\n"
+        "  on_update = function(self, e, dt) self.data.kind = 'v2' end,\n"
+        "}\n");
+    hotReload.ForceReloadAll(*reg, lua);
+    {
+      auto& live = reg->GetComponent<ScriptComponent>(ent);
+      live.updateFunction(live.scriptTable, ent, 0.016F);
+      sol::optional<sol::table> dataOpt = live.scriptTable["data"];
+      sol::optional<std::string> kindOpt = dataOpt ? dataOpt->get<sol::optional<std::string>>("kind") : sol::nullopt;
+      Check(kindOpt.value_or("<missing>") == "v2", "v2 on_update fires after reload (kind == 'v2')");
+      sol::optional<int> persistedOpt = dataOpt ? dataOpt->get<sol::optional<int>>("persisted") : sol::nullopt;
+      Check(persistedOpt.value_or(-1) == 99, "scriptTable.data preserved across reload (persisted == 99)");
+      Check(hotReload.LastReload().error.empty(), "successful reload leaves no last-error");
+    }
+
+    // Syntax error: reload must log + leave prior callbacks intact.
+    WriteScript("return { on_update = function(self, e, dt) self.data.kind = 'v3' end,\n");  // missing closing }
+    hotReload.ForceReloadAll(*reg, lua);
+    {
+      auto& live = reg->GetComponent<ScriptComponent>(ent);
+      live.updateFunction(live.scriptTable, ent, 0.016F);
+      sol::optional<std::string> kindOpt = live.scriptTable["data"]["kind"];
+      Check(kindOpt.value_or("<missing>") == "v2", "syntax-error reload preserves prior callback (kind still 'v2')");
+      Check(!hotReload.LastReload().error.empty(), "failed reload records error");
+    }
+
+    std::filesystem::remove_all(tempDir, ec);
+  }
 #endif
 
-    if (g_failures == 0)
-    {
-        std::cout << "\nLua API smoke test: PASS\n";
-    }
-    else
-    {
-        std::cerr << "\nLua API smoke test: " << g_failures << " FAILED\n";
-    }
-    return g_failures;
+  if (g_failures == 0) {
+    std::cout << "\nLua API smoke test: PASS\n";
+  } else {
+    std::cerr << "\nLua API smoke test: " << g_failures << " FAILED\n";
+  }
+  return g_failures;
 }


### PR DESCRIPTION
## Summary

The security hardening (#171) removed Lua's `os`/`io` libraries, leaving scripts with no way to write files. Games need save data and editor tools need to generate project files. This adds two sandboxed write surfaces:

### `storage.*` — save data, available in every build

Rooted at the per-user SDL pref path (`SDL_GetPrefPath`), which resolves to the platform-correct writable location on Windows / Linux / macOS / Android. The directory identity comes from `project.ini` `vendor`/`name` (read via SDL so it works inside an APK or .app bundle), falling back to `config.ini` `GameTitle`, then `Octarine/Engine`.

```lua
storage.write("saves/slot1.json", encoded)  -- atomic, creates parent dirs
local data = storage.read("saves/slot1.json")  -- nil if missing
storage.exists("saves/slot1.json")
storage.remove("saves/slot1.json")
storage.list("saves")  -- sorted child names; storage.list() lists the root
```

### `project.*` — editor tooling, editor sessions only

Rooted at the project directory for tools that generate tilemaps, scaffolding, etc.

```lua
project.write_file("assets/generated/map.lua", contents)
project.path()
```

Gating is layered: the module's `install()` no-ops unless the session is in editor mode, and the registry entry is compiled out of non-editor builds entirely — a shipped player binary contains no project-folder write surface at all.

## Implementation

- **`src/General/FileSandbox.{h,cpp}`** — shared helpers: lexical containment (rejects absolute paths and `../` escapes, mirroring `AssetManager::GetFullPath` from the hardening pass) and atomic writes (`.tmp` + rename, so a crash mid-save never truncates an existing file).
- **`LuaBindingContext`** widened with `IsEditorMode` / `GetProjectPath` / `GetSaveDataPath`; `Game` implements them tolerating a missing `GameConfig` (headless tests construct `Game` without `Initialize`).
- **Smoke test** forces an editor-mode `GameConfig` so `Project` installs and `modules.json` captures it; explicit checks for both tables. The file also picked up a whole-file clang-format pass (the pinned 18.1.8 the CI gate uses; the autoformat workflow would have pushed the same fixup).
- **`tests/FileSandboxTest.cpp`** — containment edge cases, atomic-write behavior, both modules end-to-end through a fake `LuaBindingContext`, and the editor gate (no `project` table in a player session).
- **`scripts/octarine-verify.sh`** — added the new test target plus `OctarineRenderQueueTest` / `OctarineAssetStoreTest`, which were missing from the build list (ctest reported them "Not Run").
- Lua API catalogs (`lua_api.smoke.lua`, `modules.json`) regenerated; `events.json`/`systems.json` unchanged.

## Testing

`scripts/octarine-verify.sh --full` passes end-to-end: 20/20 ctest (including the new FileSandboxTest), bake smoke, Lua-API drift gate, clang-format, clang-tidy clean on changed files.

