### PR TITLE
Add table serialization: storage.write_table/read_table, project.write_table

### DIFF
--- a/lua_api.smoke.lua
+++ b/lua_api.smoke.lua
@@ -1675,6 +1675,8 @@ function project.path(...) end
 
 function project.write_file(...) end
 
+function project.write_table(...) end
+
 
 ---@class projectile_emitter_component
 projectile_emitter_component = {}
@@ -1823,9 +1825,13 @@ function storage.list(...) end
 
 function storage.read(...) end
 
+function storage.read_table(...) end
+
 function storage.remove(...) end
 
 function storage.write(...) end
+
+function storage.write_table(...) end
 
 
 ---@class text_label_component

--- a/src/AssetManager/AssetCatalog.cpp
+++ b/src/AssetManager/AssetCatalog.cpp
@@ -12,6 +12,7 @@
 
 #include "Game/GameConfig.h"
 #include "General/Logger.h"
+#include "General/LuaEscape.h"
 
 namespace {
 namespace fs = std::filesystem;
@@ -65,31 +66,6 @@ std::string FormatFontSize(float size) {
   s.erase(s.find_last_not_of('0') + 1, std::string::npos);
   if (!s.empty() && s.back() == '.') s.pop_back();
   return s;
-}
-
-// Escape a string for embedding inside a Lua double-quoted literal in the emitted manifest.
-// Control characters (< 0x20 or DEL) use \xNN hex escapes; backslash and double-quote are
-// prefixed with a backslash. Lua 5.1+ parses \xNN in string literals.
-std::string EscapeLua(const std::string& s) {
-  constexpr unsigned char kFirstPrintable = ' ';  // 0x20
-  constexpr unsigned char kDel = '\x7f';
-  constexpr std::size_t kHexBufSize = 8;  // "\\xNN" + nul with room to spare
-  std::string out;
-  out.reserve(s.size());
-  for (const char raw : s) {
-    const auto c = static_cast<unsigned char>(raw);
-    if (c == '\\' || c == '"') {
-      out.push_back('\\');
-      out.push_back(raw);
-    } else if (c < kFirstPrintable || c == kDel) {
-      char buf[kHexBufSize];
-      std::snprintf(buf, sizeof(buf), "\\x%02x", c);
-      out.append(buf);
-    } else {
-      out.push_back(raw);
-    }
-  }
-  return out;
 }
 
 TextureMeta ParseTextureMeta(const sol::table& t) {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,6 +24,7 @@ set(OCTARINE_CORE_SOURCES
         General/Logger.cpp
         General/FileSandbox.cpp
         General/FileWatcher.cpp
+        General/LuaEscape.cpp
         General/SystemMemory.cpp
         ECS/Registry.cpp
         Game/GameConfig.cpp
@@ -113,6 +114,7 @@ target_link_libraries(octarine_renderer PUBLIC
 # -----------------------------------------------------------------------------
 octarine_library(octarine_lua
         Lua/LuaApiManifest.cpp
+        Lua/LuaTableSerializer.cpp
         Lua/Bindings/InputSystemLuaBinding.cpp
         Lua/Bindings/RegisterAllBindings.cpp
         Lua/HotReload/ScriptHotReload.cpp

--- a/src/General/LuaEscape.cpp
+++ b/src/General/LuaEscape.cpp
@@ -1,0 +1,26 @@
+#include "General/LuaEscape.h"
+
+#include <cstddef>
+#include <cstdio>
+
+std::string EscapeLua(const std::string& s) {
+  constexpr unsigned char kFirstPrintable = ' ';  // 0x20
+  constexpr unsigned char kDel = '\x7f';
+  constexpr std::size_t kHexBufSize = 8;  // "\\xNN" + nul with room to spare
+  std::string out;
+  out.reserve(s.size());
+  for (const char raw : s) {
+    const auto c = static_cast<unsigned char>(raw);
+    if (c == '\\' || c == '"') {
+      out.push_back('\\');
+      out.push_back(raw);
+    } else if (c < kFirstPrintable || c == kDel) {
+      char buf[kHexBufSize];
+      std::snprintf(buf, sizeof(buf), "\\x%02x", c);
+      out.append(buf);
+    } else {
+      out.push_back(raw);
+    }
+  }
+  return out;
+}

--- a/src/General/LuaEscape.h
+++ b/src/General/LuaEscape.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <string>
+
+// Escape a string for embedding inside a Lua double-quoted literal. Control characters (< 0x20
+// or DEL) use \xNN hex escapes; backslash and double-quote are prefixed with a backslash. Lua
+// 5.1+ parses \xNN in string literals. Shared by the asset-manifest emitter (AssetCatalog) and
+// the Lua table serializer behind storage.write_table — both emit Lua source from untrusted
+// strings, so the escaping rules must not drift apart.
+std::string EscapeLua(const std::string& s);

--- a/src/Lua/LuaTableSerializer.cpp
+++ b/src/Lua/LuaTableSerializer.cpp
@@ -1,0 +1,178 @@
+#include "Lua/LuaTableSerializer.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "General/LuaEscape.h"
+
+namespace {
+
+// Deep saves are fine; anything past this is almost certainly a cycle the visited-set missed
+// (e.g. through metatables) or runaway generated data.
+constexpr int kMaxDepth = 64;
+
+// Format a Lua number preserving the integer/float subtype split. Detected via lua_isinteger on
+// the actual stack value — sol's is<int64_t> conversion rules vary with safety config, the VM's
+// answer doesn't. Non-finite floats have no Lua literal, so emit constant expressions that need
+// no environment.
+std::string NumberToLua(const sol::object& obj) {
+  lua_State* state = obj.lua_state();
+  obj.push(state);
+  const bool isInteger = lua_isinteger(state, -1) != 0;
+  const lua_Integer intValue = isInteger ? lua_tointeger(state, -1) : 0;
+  const lua_Number numValue = isInteger ? 0 : lua_tonumber(state, -1);
+  lua_pop(state, 1);
+
+  if (isInteger) {
+    return std::to_string(static_cast<long long>(intValue));
+  }
+  // Classify non-finite values via the IEEE-754 bit pattern, not std::isinf/isnan — the release
+  // build compiles with -ffast-math, under which those predicates may constant-fold to false and
+  // let "inf"/"nan" (not valid Lua) leak into the output.
+  const auto value = static_cast<double>(numValue);
+  uint64_t bits = 0;
+  static_assert(sizeof(bits) == sizeof(value));
+  std::memcpy(&bits, &value, sizeof(bits));
+  constexpr uint64_t kExponentMask = 0x7ff0000000000000ULL;
+  constexpr uint64_t kMantissaMask = 0x000fffffffffffffULL;
+  constexpr int kSignBitShift = 63;
+  if ((bits & kExponentMask) == kExponentMask) {
+    if ((bits & kMantissaMask) != 0) return "0/0";         // NaN
+    return (bits >> kSignBitShift) != 0 ? "-1/0" : "1/0";  // +/- infinity
+  }
+  constexpr int kBufSize = 32;  // %.17g worst case is 24 chars + nul
+  char buf[kBufSize];
+  std::snprintf(buf, sizeof(buf), "%.17g", value);
+  return buf;
+}
+
+std::string KeyToLua(const sol::object& key, std::string* error) {
+  switch (key.get_type()) {
+    case sol::type::number:
+      return "[" + NumberToLua(key) + "]";
+    case sol::type::string:
+      return "[\"" + EscapeLua(key.as<std::string>()) + "\"]";
+    case sol::type::boolean:
+      return key.as<bool>() ? "[true]" : "[false]";
+    default:
+      *error = "unsupported key type: " + std::string(sol::type_name(key.lua_state(), key.get_type()));
+      return {};
+  }
+}
+
+// Gather the table's keys in deterministic emission order: numbers ascending, then strings
+// lexicographic, then false, true. pairs() order is unspecified, and write_table output should
+// diff cleanly in git. Returns false (with *error set) on an unsupported key type.
+bool CollectOrderedKeys(const sol::table& table, std::vector<sol::object>& orderedKeys, std::string* error) {
+  std::vector<std::pair<double, sol::object>> numberKeys;
+  std::vector<std::pair<std::string, sol::object>> stringKeys;
+  std::vector<sol::object> boolKeys;
+  for (const auto& [key, unused] : table) {
+    switch (key.get_type()) {
+      case sol::type::number:
+        numberKeys.emplace_back(key.as<double>(), key);
+        break;
+      case sol::type::string:
+        stringKeys.emplace_back(key.as<std::string>(), key);
+        break;
+      case sol::type::boolean:
+        boolKeys.push_back(key);
+        break;
+      default:
+        KeyToLua(key, error);  // sets *error
+        return false;
+    }
+  }
+  std::sort(numberKeys.begin(), numberKeys.end(), [](const auto& a, const auto& b) { return a.first < b.first; });
+  std::sort(stringKeys.begin(), stringKeys.end(), [](const auto& a, const auto& b) { return a.first < b.first; });
+  std::sort(boolKeys.begin(), boolKeys.end(),
+            [](const sol::object& a, const sol::object& b) { return !a.as<bool>() && b.as<bool>(); });
+
+  orderedKeys.reserve(numberKeys.size() + stringKeys.size() + boolKeys.size());
+  for (auto& [unused, key] : numberKeys) orderedKeys.push_back(std::move(key));
+  for (auto& [unused, key] : stringKeys) orderedKeys.push_back(std::move(key));
+  for (auto& key : boolKeys) orderedKeys.push_back(std::move(key));
+  return true;
+}
+
+bool SerializeValue(const sol::object& value, std::string& out, std::string* error, int depth,
+                    std::unordered_set<const void*>& visited);
+
+// Mutually recursive with SerializeValue by design — tables nest. Bounded by kMaxDepth and the
+// visited set, so the recursion cannot run away.
+// NOLINTNEXTLINE(misc-no-recursion)
+bool SerializeTable(const sol::table& table, std::string& out, std::string* error, const int depth,
+                    std::unordered_set<const void*>& visited) {
+  if (depth > kMaxDepth) {
+    *error = "table nesting exceeds " + std::to_string(kMaxDepth) + " levels";
+    return false;
+  }
+  if (!visited.insert(table.pointer()).second) {
+    *error = "cyclic table reference";
+    return false;
+  }
+
+  std::vector<sol::object> orderedKeys;
+  if (!CollectOrderedKeys(table, orderedKeys, error)) return false;
+
+  const std::string indent(static_cast<size_t>(depth + 1) * 2, ' ');
+  out += "{";
+  bool first = true;
+  for (const auto& key : orderedKeys) {
+    const std::string keyText = KeyToLua(key, error);
+    if (keyText.empty()) return false;
+    out += first ? "\n" : ",\n";
+    first = false;
+    out += indent;
+    out += keyText;
+    out += " = ";
+    if (!SerializeValue(table.get<sol::object>(key), out, error, depth + 1, visited)) return false;
+  }
+  if (!first) {
+    out += "\n";
+    out += std::string(static_cast<size_t>(depth) * 2, ' ');
+  }
+  out += "}";
+
+  visited.erase(table.pointer());
+  return true;
+}
+
+// NOLINTNEXTLINE(misc-no-recursion) — see SerializeTable.
+bool SerializeValue(const sol::object& value, std::string& out, std::string* error, const int depth,
+                    std::unordered_set<const void*>& visited) {
+  switch (value.get_type()) {
+    case sol::type::table:
+      return SerializeTable(value.as<sol::table>(), out, error, depth, visited);
+    case sol::type::string:
+      out += "\"" + EscapeLua(value.as<std::string>()) + "\"";
+      return true;
+    case sol::type::number:
+      out += NumberToLua(value);
+      return true;
+    case sol::type::boolean:
+      out += value.as<bool>() ? "true" : "false";
+      return true;
+    default:
+      *error = "unsupported value type: " + std::string(sol::type_name(value.lua_state(), value.get_type()));
+      return false;
+  }
+}
+
+}  // namespace
+
+namespace lua_table_serializer {
+
+bool Serialize(const sol::table& table, std::string& out, std::string* error) {
+  std::string localError;
+  if (error == nullptr) error = &localError;
+  std::unordered_set<const void*> visited;
+  return SerializeTable(table, out, error, 0, visited);
+}
+
+}  // namespace lua_table_serializer

--- a/src/Lua/LuaTableSerializer.h
+++ b/src/Lua/LuaTableSerializer.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <sol/sol.hpp>
+#include <string>
+
+// Serializes a Lua table to a loadable Lua literal (the body after `return `). Backs
+// storage.write_table / project.write_table; the inverse is a plain load() of the file with an
+// empty environment (see StorageModuleLuaBinding), so the emitted text must be pure data — no
+// identifiers, no library calls.
+//
+// Supported: nested tables, strings, numbers (integer subtype preserved; non-finite values emit
+// the env-free expressions 1/0, -1/0, 0/0), booleans. Keys may be numbers, strings, or booleans.
+// Functions, userdata, threads, and cyclic tables are errors — the caller gets false + a message
+// rather than a silently incomplete save.
+//
+// Output is deterministic (number keys ascending, then string keys lexicographic, then false,
+// true) so emitted files diff cleanly under version control — project.write_table output is
+// expected to be committed to game repos.
+namespace lua_table_serializer {
+
+// Appends the serialized form of `table` to `out`. Returns false on unsupported types, cycles,
+// or nesting deeper than an internal sanity bound, with a human-readable reason in *error.
+bool Serialize(const sol::table& table, std::string& out, std::string* error);
+
+}  // namespace lua_table_serializer

--- a/src/Lua/Modules/ProjectModuleLuaBinding.cpp
+++ b/src/Lua/Modules/ProjectModuleLuaBinding.cpp
@@ -5,20 +5,39 @@
 #include "General/FileSandbox.h"
 #include "General/Logger.h"
 #include "Lua/LuaBindingContext.h"
+#include "Lua/LuaTableSerializer.h"
 
 namespace {
-bool WriteFile(LuaBindingContext& ctx, const std::string& relativePath, const std::string& contents) {
+std::string ResolveProjectPath(LuaBindingContext& ctx, const std::string& relativePath, const char* op) {
   const std::string root = ctx.GetProjectPath();
   if (root.empty()) {
-    Logger::Error("project.write_file: no project loaded");
-    return false;
+    Logger::Error(std::string("project.") + op + ": no project loaded");
+    return {};
   }
   const std::string fullPath = file_sandbox::Resolve(root, relativePath);
   if (fullPath.empty()) {
-    Logger::Error("project.write_file: path rejected: " + relativePath);
+    Logger::Error(std::string("project.") + op + ": path rejected: " + relativePath);
+  }
+  return fullPath;
+}
+
+bool WriteFile(LuaBindingContext& ctx, const std::string& relativePath, const std::string& contents) {
+  const std::string fullPath = ResolveProjectPath(ctx, relativePath, "write_file");
+  if (fullPath.empty()) return false;
+  return file_sandbox::WriteFileAtomic(fullPath, contents);
+}
+
+bool WriteTable(LuaBindingContext& ctx, const std::string& relativePath, const sol::table& value) {
+  const std::string fullPath = ResolveProjectPath(ctx, relativePath, "write_table");
+  if (fullPath.empty()) return false;
+  std::string text = "return ";
+  std::string error;
+  if (!lua_table_serializer::Serialize(value, text, &error)) {
+    Logger::Error("project.write_table: " + relativePath + ": " + error);
     return false;
   }
-  return file_sandbox::WriteFileAtomic(fullPath, contents);
+  text += "\n";
+  return file_sandbox::WriteFileAtomic(fullPath, text);
 }
 }  // namespace
 
@@ -33,6 +52,9 @@ void LuaModuleBinding<ProjectModule>::install(sol::state& lua, LuaBindingContext
   project.set_function("path", [&ctx]() -> std::string { return ctx.GetProjectPath(); });
   project.set_function("write_file", [&ctx](const std::string& path, const std::string& contents) -> bool {
     return WriteFile(ctx, path, contents);
+  });
+  project.set_function("write_table", [&ctx](const std::string& path, const sol::table& value) -> bool {
+    return WriteTable(ctx, path, value);
   });
   lua["project"] = project;
 }

--- a/src/Lua/Modules/StorageModuleLuaBinding.cpp
+++ b/src/Lua/Modules/StorageModuleLuaBinding.cpp
@@ -11,6 +11,7 @@
 #include "General/FileSandbox.h"
 #include "General/Logger.h"
 #include "Lua/LuaBindingContext.h"
+#include "Lua/LuaTableSerializer.h"
 
 namespace {
 // Resolve a script-supplied relative path inside the per-user save-data root. Empty result
@@ -58,6 +59,48 @@ bool Remove(LuaBindingContext& ctx, const std::string& relativePath) {
   return std::filesystem::remove(fullPath, ec);
 }
 
+bool WriteTable(LuaBindingContext& ctx, const std::string& relativePath, const sol::table& value) {
+  const std::string fullPath = ResolveStoragePath(ctx, relativePath, "write_table");
+  if (fullPath.empty()) return false;
+  std::string text = "return ";
+  std::string error;
+  if (!lua_table_serializer::Serialize(value, text, &error)) {
+    Logger::Error("storage.write_table: " + relativePath + ": " + error);
+    return false;
+  }
+  text += "\n";
+  return file_sandbox::WriteFileAtomic(fullPath, text);
+}
+
+sol::optional<sol::table> ReadTable(LuaBindingContext& ctx, const std::string& relativePath, sol::this_state s) {
+  const auto text = Read(ctx, relativePath);
+  if (!text) return sol::nullopt;
+  sol::state_view lua(s);
+  sol::load_result chunk = lua.load(*text, "@" + relativePath, sol::load_mode::text);
+  if (!chunk.valid()) {
+    const sol::error err = chunk;
+    Logger::Error("storage.read_table: " + relativePath + ": " + std::string(err.what()));
+    return sol::nullopt;
+  }
+  auto fn = chunk.get<sol::protected_function>();
+  // Empty environment: a save file is user-editable data, not code. The chunk sees no globals
+  // at all (no os/io/load/print), so a tampered file can only compute and return a value.
+  sol::environment env(lua, sol::create);
+  sol::set_environment(env, fn);
+  sol::protected_function_result result = fn();
+  if (!result.valid()) {
+    const sol::error err = result;
+    Logger::Error("storage.read_table: " + relativePath + ": " + std::string(err.what()));
+    return sol::nullopt;
+  }
+  const auto value = result.get<sol::object>();
+  if (value.get_type() != sol::type::table) {
+    Logger::Error("storage.read_table: " + relativePath + ": file did not return a table");
+    return sol::nullopt;
+  }
+  return value.as<sol::table>();
+}
+
 // Names of the direct children of `relativePath` (files and subdirectories), sorted for stable
 // iteration order. Empty table when the directory doesn't exist.
 sol::table List(LuaBindingContext& ctx, const std::string& relativePath, sol::this_state s) {
@@ -86,6 +129,12 @@ void LuaModuleBinding<StorageModule>::install(sol::state& lua, LuaBindingContext
   });
   storage.set_function("read",
                        [&ctx](const std::string& path) -> sol::optional<std::string> { return Read(ctx, path); });
+  storage.set_function("write_table", [&ctx](const std::string& path, const sol::table& value) -> bool {
+    return WriteTable(ctx, path, value);
+  });
+  storage.set_function("read_table", [&ctx](const std::string& path, sol::this_state s) -> sol::optional<sol::table> {
+    return ReadTable(ctx, path, s);
+  });
   storage.set_function("exists", [&ctx](const std::string& path) -> bool { return Exists(ctx, path); });
   storage.set_function("remove", [&ctx](const std::string& path) -> bool { return Remove(ctx, path); });
   // Path optional: storage.list() lists the save-data root itself.

--- a/tests/FileSandboxTest.cpp
+++ b/tests/FileSandboxTest.cpp
@@ -99,6 +99,73 @@ void TestStorageModule(LuaBindingContext& host, const std::filesystem::path& sav
   Check(!std::filesystem::exists(saveRoot / "saves/slot1.json"), "storage.remove deleted the file");
 }
 
+void TestTableRoundtrip(LuaBindingContext& host) {
+  sol::state lua;
+  lua.open_libraries(sol::lib::base, sol::lib::string, sol::lib::table, sol::lib::math);
+  LuaModuleBinding<StorageModule>::install(lua, host);
+
+  Check(lua.script(R"(
+    local state = {
+      level = 3, hp = 72.5, name = 'Rince"wind\n', alive = true,
+      inventory = { 'sword', 'luggage' },
+      flags = { [false] = 'no', [true] = 'yes' },
+      big = 2^53, neg = -7, huge = math.huge,
+    }
+    return storage.write_table('saves/state.lua', state)
+  )")
+            .get<bool>(),
+        "storage.write_table");
+
+  Check(lua.script(R"(
+    local s = storage.read_table('saves/state.lua')
+    return s ~= nil
+      and s.level == 3 and s.hp == 72.5 and s.name == 'Rince"wind\n' and s.alive == true
+      and s.inventory[1] == 'sword' and s.inventory[2] == 'luggage'
+      and s.flags[false] == 'no' and s.flags[true] == 'yes'
+      and s.big == 2^53 and s.neg == -7 and s.huge == math.huge
+  )")
+            .get<bool>(),
+        "storage.read_table roundtrips every value");
+
+  Check(lua.script("return storage.read_table('saves/nope.lua') == nil").get<bool>(),
+        "storage.read_table returns nil for a missing file");
+
+  // A save file is data, not code: a tampered file that calls anything fails to load (its
+  // environment is empty), and one that returns a non-table is rejected.
+  Check(lua.script(R"(
+    storage.write('saves/evil.lua', 'print("pwned") return {}')
+    return storage.read_table('saves/evil.lua') == nil
+  )")
+            .get<bool>(),
+        "storage.read_table runs tampered files without any globals");
+  Check(lua.script(R"(
+    storage.write('saves/notatable.lua', 'return 42')
+    return storage.read_table('saves/notatable.lua') == nil
+  )")
+            .get<bool>(),
+        "storage.read_table rejects a non-table result");
+
+  // Unserializable inputs fail loudly instead of writing a partial save.
+  Check(!lua.script("return storage.write_table('saves/fn.lua', { f = function() end })").get<bool>(),
+        "storage.write_table rejects function values");
+  Check(!lua.script(R"(
+    local t = {}
+    t.self = t
+    return storage.write_table('saves/cycle.lua', t)
+  )")
+             .get<bool>(),
+        "storage.write_table rejects cyclic tables");
+
+  // Determinism: serializing the same logical table twice yields identical bytes.
+  Check(lua.script(R"(
+    storage.write_table('saves/a.lua', { z = 1, a = 2, [3] = 'c', [1] = 'a' })
+    storage.write_table('saves/b.lua', { [1] = 'a', a = 2, [3] = 'c', z = 1 })
+    return storage.read('saves/a.lua') == storage.read('saves/b.lua')
+  )")
+            .get<bool>(),
+        "storage.write_table output is deterministic");
+}
+
 void TestProjectModule(const std::string& saveRoot, const std::filesystem::path& projectRoot) {
   {
     sol::state lua;
@@ -141,6 +208,9 @@ int main() {
   std::cout << "[storage module]\n";
   FakeHost host(saveRoot.string(), projectRoot.string(), /*editorMode=*/false);
   TestStorageModule(host, saveRoot);
+
+  std::cout << "[table serialization]\n";
+  TestTableRoundtrip(host);
 
   std::cout << "[project module]\n";
   TestProjectModule(saveRoot.string(), projectRoot);

--- a/tests/LuaApiSmokeTest.cpp
+++ b/tests/LuaApiSmokeTest.cpp
@@ -156,12 +156,13 @@ int main() {
   Check(TableHasFunction(lua, "input", "is_key_down"), "input.is_key_down (InputSystem surface)");
 
   std::cout << "[file write surface] storage.* (all builds) + project.* (editor sessions)\n";
-  for (const auto* fn : {"write", "read", "exists", "remove", "list"}) {
+  for (const auto* fn : {"write", "read", "write_table", "read_table", "exists", "remove", "list"}) {
     Check(TableHasFunction(lua, "storage", fn), std::string("storage.") + fn);
   }
 #ifdef OCTARINE_WITH_EDITOR
   Check(TableHasFunction(lua, "project", "path"), "project.path (editor session)");
   Check(TableHasFunction(lua, "project", "write_file"), "project.write_file (editor session)");
+  Check(TableHasFunction(lua, "project", "write_table"), "project.write_table (editor session)");
 #endif
 
   std::cout << "[manifest] generator runs\n";


### PR DESCRIPTION
## Summary

Follow-up to #171/#172: saving structured state previously meant every game hand-rolling a Lua table serializer. The engine now owns the format end to end — one call each way, with safety and determinism guarantees enforced in C++:

```lua
storage.write_table('saves/slot1.lua', { level = 3, hp = 72.5, inventory = { 'sword', 'luggage' } })
local state = storage.read_table('saves/slot1.lua')  -- nil on missing/corrupt/tampered
```

`project.write_table` mirrors it for editor tooling (same editor-session gate as the rest of `project.*`).

## Design points

- **Loading is data-only.** `read_table` executes the file in an *empty environment* (text mode): a user-edited save sees no globals — no `os`/`io`/`load`/`print` — it can only compute and return a value. Non-table results are rejected. This keeps the spirit of the #171 sandbox.
- **Round-trip fidelity.** Lua 5.4 integer/float subtypes preserved via `lua_isinteger` on the VM value; floats emitted with `%.17g`; non-finite values emitted as environment-free expressions (`1/0`, `-1/0`, `0/0`). Non-finite classification reads the IEEE-754 bit pattern directly because the release build's `-ffast-math` constant-folds `std::isinf`/`isnan` to false — caught by the new tests, which is exactly the class of bug that motivated putting this in the engine.
- **Fails loudly, never partially.** Functions, userdata, threads, cyclic tables, and runaway nesting return `false` with a logged reason; nothing is written. Writes go through the existing atomic path (`.tmp` + rename).
- **Deterministic output.** Keys emitted in sorted order (numbers ascending, then strings, then booleans) so `project.write_table` files diff cleanly in git.
- **One escaping rule set.** `EscapeLua` hoisted from `AssetCatalog.cpp` into `src/General/LuaEscape` and shared by the manifest emitter and the serializer.

## Testing

`scripts/octarine-verify.sh --full` passes (20/20 ctest, bake smoke, drift gate, format, tidy). FileSandboxTest grows: full-fidelity roundtrip (nested tables, escaped strings, int/float/bool, bool keys, `math.huge`), tamper rejection (file calling `print` fails to run), non-table rejection, function/cycle rejection, and byte-identical determinism. Catalogs regenerated.