### PR TITLE
chore: apply clang-format to establish clean formatting baseline

### DIFF
--- a/scripts/octarine-icon-tool/main.cpp
+++ b/scripts/octarine-icon-tool/main.cpp
@@ -22,10 +22,6 @@
 #define STB_IMAGE_IMPLEMENTATION
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #define STB_IMAGE_RESIZE_IMPLEMENTATION
-#include "stb_image.h"
-#include "stb_image_write.h"
-#include "stb_image_resize2.h"
-
 #include <algorithm>
 #include <cstdint>
 #include <cstdio>
@@ -34,220 +30,215 @@
 #include <string>
 #include <vector>
 
+#include "stb_image.h"
+#include "stb_image_resize2.h"
+#include "stb_image_write.h"
+
 namespace {
 
 struct LoadedImage {
-    std::vector<unsigned char> rgba;
-    int w = 0;
-    int h = 0;
+  std::vector<unsigned char> rgba;
+  int w = 0;
+  int h = 0;
 };
 
 bool loadImage(const char* path, LoadedImage& out) {
-    int w = 0;
-    int h = 0;
-    int comp = 0;
-    unsigned char* data = stbi_load(path, &w, &h, &comp, 4);
-    if (data == nullptr) {
-        std::fprintf(stderr, "octarine-icon-tool: failed to load `%s`: %s\n",
-                     path, stbi_failure_reason());
-        return false;
-    }
-    out.w = w;
-    out.h = h;
-    out.rgba.assign(data, data + static_cast<size_t>(w) * static_cast<size_t>(h) * 4);
-    stbi_image_free(data);
-    return true;
+  int w = 0;
+  int h = 0;
+  int comp = 0;
+  unsigned char* data = stbi_load(path, &w, &h, &comp, 4);
+  if (data == nullptr) {
+    std::fprintf(stderr, "octarine-icon-tool: failed to load `%s`: %s\n", path, stbi_failure_reason());
+    return false;
+  }
+  out.w = w;
+  out.h = h;
+  out.rgba.assign(data, data + static_cast<size_t>(w) * static_cast<size_t>(h) * 4);
+  stbi_image_free(data);
+  return true;
 }
 
 // Resize preserving aspect ratio, centered on an NxN transparent RGBA canvas.
 bool resizeToSquare(const LoadedImage& src, int n, std::vector<unsigned char>& out) {
-    if (n <= 0 || src.w <= 0 || src.h <= 0) {
-        std::fprintf(stderr, "octarine-icon-tool: bad dimensions (src=%dx%d, target=%d)\n",
-                     src.w, src.h, n);
-        return false;
-    }
-    const double scale = static_cast<double>(n) / std::max(src.w, src.h);
-    const int fw = std::max(1, static_cast<int>(src.w * scale + 0.5));
-    const int fh = std::max(1, static_cast<int>(src.h * scale + 0.5));
+  if (n <= 0 || src.w <= 0 || src.h <= 0) {
+    std::fprintf(stderr, "octarine-icon-tool: bad dimensions (src=%dx%d, target=%d)\n", src.w, src.h, n);
+    return false;
+  }
+  const double scale = static_cast<double>(n) / std::max(src.w, src.h);
+  const int fw = std::max(1, static_cast<int>(src.w * scale + 0.5));
+  const int fh = std::max(1, static_cast<int>(src.h * scale + 0.5));
 
-    std::vector<unsigned char> fit(static_cast<size_t>(fw) * static_cast<size_t>(fh) * 4);
-    auto* ok = stbir_resize_uint8_srgb(
-            src.rgba.data(), src.w, src.h, 0,
-            fit.data(), fw, fh, 0,
-            STBIR_RGBA);
-    if (ok == nullptr) {
-        std::fprintf(stderr, "octarine-icon-tool: stbir_resize failed\n");
-        return false;
-    }
+  std::vector<unsigned char> fit(static_cast<size_t>(fw) * static_cast<size_t>(fh) * 4);
+  auto* ok = stbir_resize_uint8_srgb(src.rgba.data(), src.w, src.h, 0, fit.data(), fw, fh, 0, STBIR_RGBA);
+  if (ok == nullptr) {
+    std::fprintf(stderr, "octarine-icon-tool: stbir_resize failed\n");
+    return false;
+  }
 
-    out.assign(static_cast<size_t>(n) * static_cast<size_t>(n) * 4, 0);
-    const int x0 = (n - fw) / 2;
-    const int y0 = (n - fh) / 2;
-    for (int y = 0; y < fh; ++y) {
-        std::memcpy(
-                &out[(static_cast<size_t>(y0 + y) * n + x0) * 4],
-                &fit[static_cast<size_t>(y) * fw * 4],
+  out.assign(static_cast<size_t>(n) * static_cast<size_t>(n) * 4, 0);
+  const int x0 = (n - fw) / 2;
+  const int y0 = (n - fh) / 2;
+  for (int y = 0; y < fh; ++y) {
+    std::memcpy(&out[(static_cast<size_t>(y0 + y) * n + x0) * 4], &fit[static_cast<size_t>(y) * fw * 4],
                 static_cast<size_t>(fw) * 4);
-    }
-    return true;
+  }
+  return true;
 }
 
 bool writePngToFile(const char* path, int n, const std::vector<unsigned char>& rgba) {
-    if (stbi_write_png(path, n, n, 4, rgba.data(), n * 4) == 0) {
-        std::fprintf(stderr, "octarine-icon-tool: stbi_write_png failed for `%s`\n", path);
-        return false;
-    }
-    return true;
+  if (stbi_write_png(path, n, n, 4, rgba.data(), n * 4) == 0) {
+    std::fprintf(stderr, "octarine-icon-tool: stbi_write_png failed for `%s`\n", path);
+    return false;
+  }
+  return true;
 }
 
 struct MemBuffer {
-    std::vector<unsigned char> data;
+  std::vector<unsigned char> data;
 };
 
 void memWriteCb(void* context, void* data, int size) {
-    auto* buf = static_cast<MemBuffer*>(context);
-    auto* bytes = static_cast<unsigned char*>(data);
-    buf->data.insert(buf->data.end(), bytes, bytes + size);
+  auto* buf = static_cast<MemBuffer*>(context);
+  auto* bytes = static_cast<unsigned char*>(data);
+  buf->data.insert(buf->data.end(), bytes, bytes + size);
 }
 
 bool writePngToMem(int n, const std::vector<unsigned char>& rgba, MemBuffer& out) {
-    if (stbi_write_png_to_func(&memWriteCb, &out, n, n, 4, rgba.data(), n * 4) == 0) {
-        std::fprintf(stderr, "octarine-icon-tool: stbi_write_png_to_func failed\n");
-        return false;
-    }
-    return true;
+  if (stbi_write_png_to_func(&memWriteCb, &out, n, n, 4, rgba.data(), n * 4) == 0) {
+    std::fprintf(stderr, "octarine-icon-tool: stbi_write_png_to_func failed\n");
+    return false;
+  }
+  return true;
 }
 
 void writeU16Le(std::FILE* f, uint16_t v) {
-    unsigned char b[2] = {
-            static_cast<unsigned char>(v & 0xFF),
-            static_cast<unsigned char>((v >> 8) & 0xFF),
-    };
-    std::fwrite(b, 1, 2, f);
+  unsigned char b[2] = {
+      static_cast<unsigned char>(v & 0xFF),
+      static_cast<unsigned char>((v >> 8) & 0xFF),
+  };
+  std::fwrite(b, 1, 2, f);
 }
 
 void writeU32Le(std::FILE* f, uint32_t v) {
-    unsigned char b[4] = {
-            static_cast<unsigned char>(v & 0xFF),
-            static_cast<unsigned char>((v >> 8) & 0xFF),
-            static_cast<unsigned char>((v >> 16) & 0xFF),
-            static_cast<unsigned char>((v >> 24) & 0xFF),
-    };
-    std::fwrite(b, 1, 4, f);
+  unsigned char b[4] = {
+      static_cast<unsigned char>(v & 0xFF),
+      static_cast<unsigned char>((v >> 8) & 0xFF),
+      static_cast<unsigned char>((v >> 16) & 0xFF),
+      static_cast<unsigned char>((v >> 24) & 0xFF),
+  };
+  std::fwrite(b, 1, 4, f);
 }
 
-bool writeIco(const char* path,
-              const std::vector<MemBuffer>& imgs,
-              const std::vector<int>& sizes) {
-    std::FILE* f = std::fopen(path, "wb");
-    if (f == nullptr) {
-        std::fprintf(stderr, "octarine-icon-tool: failed to open `%s` for write\n", path);
-        return false;
-    }
+bool writeIco(const char* path, const std::vector<MemBuffer>& imgs, const std::vector<int>& sizes) {
+  std::FILE* f = std::fopen(path, "wb");
+  if (f == nullptr) {
+    std::fprintf(stderr, "octarine-icon-tool: failed to open `%s` for write\n", path);
+    return false;
+  }
 
-    writeU16Le(f, 0);                                   // reserved
-    writeU16Le(f, 1);                                   // type = ICO
-    writeU16Le(f, static_cast<uint16_t>(imgs.size()));  // image count
+  writeU16Le(f, 0);                                   // reserved
+  writeU16Le(f, 1);                                   // type = ICO
+  writeU16Le(f, static_cast<uint16_t>(imgs.size()));  // image count
 
-    uint32_t dataOffset = 6 + 16u * static_cast<uint32_t>(imgs.size());
-    for (size_t i = 0; i < imgs.size(); ++i) {
-        const int s = sizes[i];
-        // ICONDIRENTRY width/height: 0 encodes 256.
-        const unsigned char dim = (s >= 256) ? 0 : static_cast<unsigned char>(s);
-        std::fwrite(&dim, 1, 1, f);                                // width
-        std::fwrite(&dim, 1, 1, f);                                // height
-        const unsigned char zero = 0;
-        std::fwrite(&zero, 1, 1, f);                               // color count (palette)
-        std::fwrite(&zero, 1, 1, f);                               // reserved
-        writeU16Le(f, 1);                                          // planes
-        writeU16Le(f, 32);                                         // bpp
-        writeU32Le(f, static_cast<uint32_t>(imgs[i].data.size())); // payload size
-        writeU32Le(f, dataOffset);                                 // payload offset
-        dataOffset += static_cast<uint32_t>(imgs[i].data.size());
-    }
-    for (const auto& m : imgs) {
-        std::fwrite(m.data.data(), 1, m.data.size(), f);
-    }
-    std::fclose(f);
-    return true;
+  uint32_t dataOffset = 6 + 16u * static_cast<uint32_t>(imgs.size());
+  for (size_t i = 0; i < imgs.size(); ++i) {
+    const int s = sizes[i];
+    // ICONDIRENTRY width/height: 0 encodes 256.
+    const unsigned char dim = (s >= 256) ? 0 : static_cast<unsigned char>(s);
+    std::fwrite(&dim, 1, 1, f);  // width
+    std::fwrite(&dim, 1, 1, f);  // height
+    const unsigned char zero = 0;
+    std::fwrite(&zero, 1, 1, f);                                // color count (palette)
+    std::fwrite(&zero, 1, 1, f);                                // reserved
+    writeU16Le(f, 1);                                           // planes
+    writeU16Le(f, 32);                                          // bpp
+    writeU32Le(f, static_cast<uint32_t>(imgs[i].data.size()));  // payload size
+    writeU32Le(f, dataOffset);                                  // payload offset
+    dataOffset += static_cast<uint32_t>(imgs[i].data.size());
+  }
+  for (const auto& m : imgs) {
+    std::fwrite(m.data.data(), 1, m.data.size(), f);
+  }
+  std::fclose(f);
+  return true;
 }
 
 int cmdResize(int argc, char** argv) {
-    if (argc != 5) {
-        std::fprintf(stderr, "usage: octarine-icon-tool resize INPUT OUTPUT SIZE\n");
-        return 2;
-    }
-    LoadedImage src;
-    if (!loadImage(argv[2], src)) {
-        return 1;
-    }
-    const int n = std::atoi(argv[4]);
-    if (n <= 0) {
-        std::fprintf(stderr, "octarine-icon-tool: bad size `%s`\n", argv[4]);
-        return 2;
-    }
-    std::vector<unsigned char> out;
-    if (!resizeToSquare(src, n, out)) {
-        return 1;
-    }
-    return writePngToFile(argv[3], n, out) ? 0 : 1;
+  if (argc != 5) {
+    std::fprintf(stderr, "usage: octarine-icon-tool resize INPUT OUTPUT SIZE\n");
+    return 2;
+  }
+  LoadedImage src;
+  if (!loadImage(argv[2], src)) {
+    return 1;
+  }
+  const int n = std::atoi(argv[4]);
+  if (n <= 0) {
+    std::fprintf(stderr, "octarine-icon-tool: bad size `%s`\n", argv[4]);
+    return 2;
+  }
+  std::vector<unsigned char> out;
+  if (!resizeToSquare(src, n, out)) {
+    return 1;
+  }
+  return writePngToFile(argv[3], n, out) ? 0 : 1;
 }
 
 int cmdIco(int argc, char** argv) {
-    if (argc != 5) {
-        std::fprintf(stderr, "usage: octarine-icon-tool ico INPUT OUTPUT SIZE[,SIZE,...]\n");
-        return 2;
+  if (argc != 5) {
+    std::fprintf(stderr, "usage: octarine-icon-tool ico INPUT OUTPUT SIZE[,SIZE,...]\n");
+    return 2;
+  }
+  LoadedImage src;
+  if (!loadImage(argv[2], src)) {
+    return 1;
+  }
+  std::vector<int> sizes;
+  const char* p = argv[4];
+  while (*p != '\0') {
+    char* end = nullptr;
+    const long v = std::strtol(p, &end, 10);
+    if (end == p || v <= 0 || v > 1024) {
+      std::fprintf(stderr, "octarine-icon-tool: bad ico size near `%s`\n", p);
+      return 2;
     }
-    LoadedImage src;
-    if (!loadImage(argv[2], src)) {
-        return 1;
+    sizes.push_back(static_cast<int>(v));
+    p = end;
+    if (*p == ',') {
+      ++p;
     }
-    std::vector<int> sizes;
-    const char* p = argv[4];
-    while (*p != '\0') {
-        char* end = nullptr;
-        const long v = std::strtol(p, &end, 10);
-        if (end == p || v <= 0 || v > 1024) {
-            std::fprintf(stderr, "octarine-icon-tool: bad ico size near `%s`\n", p);
-            return 2;
-        }
-        sizes.push_back(static_cast<int>(v));
-        p = end;
-        if (*p == ',') {
-            ++p;
-        }
-    }
-    if (sizes.empty()) {
-        std::fprintf(stderr, "octarine-icon-tool: ico needs at least one size\n");
-        return 2;
-    }
+  }
+  if (sizes.empty()) {
+    std::fprintf(stderr, "octarine-icon-tool: ico needs at least one size\n");
+    return 2;
+  }
 
-    std::vector<MemBuffer> imgs(sizes.size());
-    for (size_t i = 0; i < sizes.size(); ++i) {
-        std::vector<unsigned char> rgba;
-        if (!resizeToSquare(src, sizes[i], rgba)) {
-            return 1;
-        }
-        if (!writePngToMem(sizes[i], rgba, imgs[i])) {
-            return 1;
-        }
+  std::vector<MemBuffer> imgs(sizes.size());
+  for (size_t i = 0; i < sizes.size(); ++i) {
+    std::vector<unsigned char> rgba;
+    if (!resizeToSquare(src, sizes[i], rgba)) {
+      return 1;
     }
-    return writeIco(argv[3], imgs, sizes) ? 0 : 1;
+    if (!writePngToMem(sizes[i], rgba, imgs[i])) {
+      return 1;
+    }
+  }
+  return writeIco(argv[3], imgs, sizes) ? 0 : 1;
 }
 
 }  // namespace
 
 int main(int argc, char** argv) {
-    if (argc < 2) {
-        std::fprintf(stderr, "usage: octarine-icon-tool {resize|ico} ...\n");
-        return 2;
-    }
-    if (std::strcmp(argv[1], "resize") == 0) {
-        return cmdResize(argc, argv);
-    }
-    if (std::strcmp(argv[1], "ico") == 0) {
-        return cmdIco(argc, argv);
-    }
-    std::fprintf(stderr, "octarine-icon-tool: unknown command `%s`\n", argv[1]);
+  if (argc < 2) {
+    std::fprintf(stderr, "usage: octarine-icon-tool {resize|ico} ...\n");
     return 2;
+  }
+  if (std::strcmp(argv[1], "resize") == 0) {
+    return cmdResize(argc, argv);
+  }
+  if (std::strcmp(argv[1], "ico") == 0) {
+    return cmdIco(argc, argv);
+  }
+  std::fprintf(stderr, "octarine-icon-tool: unknown command `%s`\n", argv[1]);
+  return 2;
 }

--- a/tests/AssetPipelineTest.cpp
+++ b/tests/AssetPipelineTest.cpp
@@ -5,14 +5,17 @@
 // Tests the metadata default-fill rules and catalog building.
 // Checks are pointed at a fixture directory.
 
-#include <sol/sol.hpp>
+#include <SDL3/SDL.h>
+#include <SDL3_ttf/SDL_ttf.h>
 
+#include <cmath>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <optional>
 #include <set>
+#include <sol/sol.hpp>
 #include <string>
 #include <vector>
 
@@ -24,163 +27,152 @@
 #include "AssetManager/AtlasBaker.h"
 #include "AssetManager/AudioNormalizer.h"
 #include "AssetManager/GlyphAtlas.h"
-#include "stb/stb_image_write.h"  // header-only; IMPL lives in AtlasBaker.cpp
 #include "AssetManager/SceneAssetScanner.h"
-#include <SDL3/SDL.h>
-#include <cmath>
-#include <SDL3_ttf/SDL_ttf.h>
+#include "stb/stb_image_write.h"  // header-only; IMPL lives in AtlasBaker.cpp
 
-namespace
-{
-    int g_failures = 0;
+namespace {
+int g_failures = 0;
 
-    void Check(const bool condition, const std::string& what)
-    {
-        if (condition)
-        {
-            std::cout << "  ok   " << what << "\n";
-        }
-        else
-        {
-            std::cerr << "  FAIL " << what << "\n";
-            ++g_failures;
-        }
-    }
-} // namespace
+void Check(const bool condition, const std::string& what) {
+  if (condition) {
+    std::cout << "  ok   " << what << "\n";
+  } else {
+    std::cerr << "  FAIL " << what << "\n";
+    ++g_failures;
+  }
+}
+}  // namespace
 
-int main()
-{
-    std::cout << "[metadata] default-fill\n";
+int main() {
+  std::cout << "[metadata] default-fill\n";
 
-    // Texture: no sidecar value + no project default -> nearest, no atlas.
-    {
-        TextureMeta m;
-        m.applyDefaults(std::nullopt);
-        Check(m.scaleMode == ScaleMode::Nearest, "texture scaleMode defaults to nearest");
-        Check(!m.atlas.has_value(), "texture atlas defaults to none");
-    }
-    // Texture: project default applies when the sidecar omits scaleMode.
-    {
-        TextureMeta m;
-        m.applyDefaults(ScaleMode::Linear);
-        Check(m.scaleMode == ScaleMode::Linear, "texture scaleMode inherits project default");
-    }
-    // Texture: an explicit sidecar value beats the project default.
-    {
-        TextureMeta m;
-        m.scaleMode = ScaleMode::Nearest;
-        m.applyDefaults(ScaleMode::Linear);
-        Check(m.scaleMode == ScaleMode::Nearest, "explicit texture scaleMode beats default");
-    }
-    // Font: empty sizes -> { kDefaultFontSize }.
-    {
-        FontMeta m;
-        m.applyDefaults();
-        Check(m.sizes.size() == 1 && m.sizes[0] == kDefaultFontSize, "font sizes default to { 16 }");
-    }
-    // Font: provided sizes preserved.
-    {
-        FontMeta m;
-        m.sizes = {5.0F, 10.0F};
-        m.applyDefaults();
-        Check(m.sizes.size() == 2, "font sizes preserved when provided");
-    }
-    // Audio: stream defaults to false (full decode).
-    {
-        AudioMeta m;
-        m.applyDefaults();
-        Check(!m.stream, "audio stream defaults to false");
-    }
+  // Texture: no sidecar value + no project default -> nearest, no atlas.
+  {
+    TextureMeta m;
+    m.applyDefaults(std::nullopt);
+    Check(m.scaleMode == ScaleMode::Nearest, "texture scaleMode defaults to nearest");
+    Check(!m.atlas.has_value(), "texture atlas defaults to none");
+  }
+  // Texture: project default applies when the sidecar omits scaleMode.
+  {
+    TextureMeta m;
+    m.applyDefaults(ScaleMode::Linear);
+    Check(m.scaleMode == ScaleMode::Linear, "texture scaleMode inherits project default");
+  }
+  // Texture: an explicit sidecar value beats the project default.
+  {
+    TextureMeta m;
+    m.scaleMode = ScaleMode::Nearest;
+    m.applyDefaults(ScaleMode::Linear);
+    Check(m.scaleMode == ScaleMode::Nearest, "explicit texture scaleMode beats default");
+  }
+  // Font: empty sizes -> { kDefaultFontSize }.
+  {
+    FontMeta m;
+    m.applyDefaults();
+    Check(m.sizes.size() == 1 && m.sizes[0] == kDefaultFontSize, "font sizes default to { 16 }");
+  }
+  // Font: provided sizes preserved.
+  {
+    FontMeta m;
+    m.sizes = {5.0F, 10.0F};
+    m.applyDefaults();
+    Check(m.sizes.size() == 2, "font sizes preserved when provided");
+  }
+  // Audio: stream defaults to false (full decode).
+  {
+    AudioMeta m;
+    m.applyDefaults();
+    Check(!m.stream, "audio stream defaults to false");
+  }
 
-    std::cout << "[scale-mode] string conversion\n";
-    Check(std::string(toScaleModeString(ScaleMode::Nearest)) == "nearest", "ScaleMode::Nearest -> \"nearest\"");
-    Check(std::string(toScaleModeString(ScaleMode::Linear)) == "linear", "ScaleMode::Linear -> \"linear\"");
+  std::cout << "[scale-mode] string conversion\n";
+  Check(std::string(toScaleModeString(ScaleMode::Nearest)) == "nearest", "ScaleMode::Nearest -> \"nearest\"");
+  Check(std::string(toScaleModeString(ScaleMode::Linear)) == "linear", "ScaleMode::Linear -> \"linear\"");
 
 #ifdef ASSET_TEST_FIXTURE_DIR
-    std::cout << "[catalog] build against fixture dir\n";
-    {
-        sol::state lua;
-        lua.open_libraries(sol::lib::base, sol::lib::table);
+  std::cout << "[catalog] build against fixture dir\n";
+  {
+    sol::state lua;
+    lua.open_libraries(sol::lib::base, sol::lib::table);
 
-        AssetCatalog catalog;
-        // Project default = nearest; sidecars override per-file.
-        const bool ok = catalog.Build(ASSET_TEST_FIXTURE_DIR, lua, std::optional<ScaleMode>(ScaleMode::Nearest));
-        Check(ok, "catalog build reports no id collisions");
+    AssetCatalog catalog;
+    // Project default = nearest; sidecars override per-file.
+    const bool ok = catalog.Build(ASSET_TEST_FIXTURE_DIR, lua, std::optional<ScaleMode>(ScaleMode::Nearest));
+    Check(ok, "catalog build reports no id collisions");
 
-        // 3 textures (hero, boss, branding) + 3 fonts (main-16, title-12, title-24) + 2 audio
-        // (jump default-decode, music meta.stream=true).
-        Check(catalog.Size() == 8, "catalog discovered 8 entries");
+    // 3 textures (hero, boss, branding) + 3 fonts (main-16, title-12, title-24) + 2 audio
+    // (jump default-decode, music meta.stream=true).
+    Check(catalog.Size() == 8, "catalog discovered 8 entries");
 
-        const CatalogEntry* hero = catalog.Find("hero");
-        Check(hero != nullptr && hero->type == AssetType::Texture, "hero is a texture");
-        Check(hero != nullptr && hero->scaleMode == ScaleMode::Linear, "hero scale_mode from sidecar (linear)");
+    const CatalogEntry* hero = catalog.Find("hero");
+    Check(hero != nullptr && hero->type == AssetType::Texture, "hero is a texture");
+    Check(hero != nullptr && hero->scaleMode == ScaleMode::Linear, "hero scale_mode from sidecar (linear)");
 
-        const CatalogEntry* boss = catalog.Find("boss");
-        Check(boss != nullptr && boss->scaleMode == ScaleMode::Nearest, "boss inherits project default (nearest)");
+    const CatalogEntry* boss = catalog.Find("boss");
+    Check(boss != nullptr && boss->scaleMode == ScaleMode::Nearest, "boss inherits project default (nearest)");
 
-        Check(catalog.Contains("branding"), "logo.png meta.id override -> 'branding'");
-        Check(!catalog.Contains("logo"), "overridden id does not also appear under the stem");
+    Check(catalog.Contains("branding"), "logo.png meta.id override -> 'branding'");
+    Check(!catalog.Contains("logo"), "overridden id does not also appear under the stem");
 
-        Check(catalog.Contains("main-16"), "main.ttf default size -> 'main-16'");
-        Check(catalog.Contains("title-12") && catalog.Contains("title-24"), "title.ttf expands per size with id base");
+    Check(catalog.Contains("main-16"), "main.ttf default size -> 'main-16'");
+    Check(catalog.Contains("title-12") && catalog.Contains("title-24"), "title.ttf expands per size with id base");
 
-        const CatalogEntry* jump = catalog.Find("jump");
-        Check(jump != nullptr && jump->type == AssetType::Audio, "jump.wav is audio");
-        Check(jump != nullptr && !jump->stream, "jump defaults to non-streaming");
+    const CatalogEntry* jump = catalog.Find("jump");
+    Check(jump != nullptr && jump->type == AssetType::Audio, "jump.wav is audio");
+    Check(jump != nullptr && !jump->stream, "jump defaults to non-streaming");
 
-        const CatalogEntry* music = catalog.Find("music");
-        Check(music != nullptr && music->type == AssetType::Audio, "music.wav is audio");
-        Check(music != nullptr && music->stream, "music.wav meta.stream=true propagates to catalog");
+    const CatalogEntry* music = catalog.Find("music");
+    Check(music != nullptr && music->type == AssetType::Audio, "music.wav is audio");
+    Check(music != nullptr && music->stream, "music.wav meta.stream=true propagates to catalog");
+  }
+
+  std::cout << "[manifest] baked manifest matches the directory scan\n";
+  {
+    sol::state lua;
+    lua.open_libraries(sol::lib::base, sol::lib::table);
+
+    // Scan the fixture, bake it to a manifest, then reload from that manifest re-rooted against the
+    // same base. The two catalogs must be entry-for-entry identical (scan/manifest parity).
+    AssetCatalog scanned;
+    scanned.Build(ASSET_TEST_FIXTURE_DIR, lua, std::optional<ScaleMode>(ScaleMode::Nearest));
+    Check(!scanned.IsFromManifest(), "directory scan does not report manifest origin");
+
+    const std::string manifestPath =
+        (std::filesystem::temp_directory_path() / "octarine_test_asset_manifest.lua").string();
+    Check(scanned.WriteManifest(manifestPath, ASSET_TEST_FIXTURE_DIR), "WriteManifest succeeds");
+
+    AssetCatalog loaded;
+    sol::state lua2;
+    lua2.open_libraries(sol::lib::base, sol::lib::table);
+    Check(loaded.LoadManifest(manifestPath, lua2, ASSET_TEST_FIXTURE_DIR), "LoadManifest succeeds");
+    Check(loaded.IsFromManifest(), "manifest load reports manifest origin");
+    Check(loaded.Size() == scanned.Size(), "manifest entry count matches the scan");
+
+    bool parity = true;
+    for (const auto& [id, want] : scanned.Entries()) {
+      const CatalogEntry* got = loaded.Find(id);
+      if (got == nullptr || got->type != want.type || got->fullPath != want.fullPath ||
+          got->scaleMode != want.scaleMode || got->atlas != want.atlas || got->fontSize != want.fontSize ||
+          got->stream != want.stream) {
+        parity = false;
+        std::cerr << "    mismatch on id '" << id << "'\n";
+      }
     }
+    Check(parity, "every manifest entry matches its scanned counterpart");
 
-    std::cout << "[manifest] baked manifest matches the directory scan\n";
-    {
-        sol::state lua;
-        lua.open_libraries(sol::lib::base, sol::lib::table);
-
-        // Scan the fixture, bake it to a manifest, then reload from that manifest re-rooted against the
-        // same base. The two catalogs must be entry-for-entry identical (scan/manifest parity).
-        AssetCatalog scanned;
-        scanned.Build(ASSET_TEST_FIXTURE_DIR, lua, std::optional<ScaleMode>(ScaleMode::Nearest));
-        Check(!scanned.IsFromManifest(), "directory scan does not report manifest origin");
-
-        const std::string manifestPath =
-            (std::filesystem::temp_directory_path() / "octarine_test_asset_manifest.lua").string();
-        Check(scanned.WriteManifest(manifestPath, ASSET_TEST_FIXTURE_DIR), "WriteManifest succeeds");
-
-        AssetCatalog loaded;
-        sol::state lua2;
-        lua2.open_libraries(sol::lib::base, sol::lib::table);
-        Check(loaded.LoadManifest(manifestPath, lua2, ASSET_TEST_FIXTURE_DIR), "LoadManifest succeeds");
-        Check(loaded.IsFromManifest(), "manifest load reports manifest origin");
-        Check(loaded.Size() == scanned.Size(), "manifest entry count matches the scan");
-
-        bool parity = true;
-        for (const auto& [id, want] : scanned.Entries())
-        {
-            const CatalogEntry* got = loaded.Find(id);
-            if (got == nullptr || got->type != want.type || got->fullPath != want.fullPath ||
-                got->scaleMode != want.scaleMode || got->atlas != want.atlas || got->fontSize != want.fontSize ||
-                got->stream != want.stream)
-            {
-                parity = false;
-                std::cerr << "    mismatch on id '" << id << "'\n";
-            }
-        }
-        Check(parity, "every manifest entry matches its scanned counterpart");
-
-        std::error_code ec;
-        std::filesystem::remove(manifestPath, ec);
-    }
+    std::error_code ec;
+    std::filesystem::remove(manifestPath, ec);
+  }
 #else
-    std::cerr << "  WARN ASSET_TEST_FIXTURE_DIR not defined; skipping catalog build checks\n";
+  std::cerr << "  WARN ASSET_TEST_FIXTURE_DIR not defined; skipping catalog build checks\n";
 #endif
 
-    std::cout << "[scanner] scene dependency collection\n";
-    {
-        sol::state lua;
-        lua.open_libraries(sol::lib::base);
-        const auto scene = lua.script(R"lua(
+  std::cout << "[scanner] scene dependency collection\n";
+  {
+    sol::state lua;
+    lua.open_libraries(sol::lib::base);
+    const auto scene = lua.script(R"lua(
       return {
         tilemap = { texture_asset_id = "tilemap-tex" },
         preload = { "bullet-tex", "spawn-font-10" },
@@ -200,257 +192,245 @@ int main()
       }
     )lua");
 
-        const auto ids = SceneAssetScanner::Collect(scene);
-        Check(ids.count("tilemap-tex") == 1, "scanner picks up tilemap texture");
-        Check(ids.count("bullet-tex") == 1 && ids.count("spawn-font-10") == 1, "scanner unions the preload list");
-        Check(ids.count("player-tex") == 1, "scanner reads nested sprite texture_asset_id");
-        Check(ids.count("enemy-tex") == 1, "scanner reads sibling-entity sprite");
-        Check(ids.count("engine-hum") == 1, "scanner reads audio_source clip_id");
-        Check(ids.count("hud-font") == 1, "scanner reads text_label font_id");
-        Check(ids.size() == 7, "scanner dedupes repeated ids (7 unique)");
-    }
+    const auto ids = SceneAssetScanner::Collect(scene);
+    Check(ids.count("tilemap-tex") == 1, "scanner picks up tilemap texture");
+    Check(ids.count("bullet-tex") == 1 && ids.count("spawn-font-10") == 1, "scanner unions the preload list");
+    Check(ids.count("player-tex") == 1, "scanner reads nested sprite texture_asset_id");
+    Check(ids.count("enemy-tex") == 1, "scanner reads sibling-entity sprite");
+    Check(ids.count("engine-hum") == 1, "scanner reads audio_source clip_id");
+    Check(ids.count("hud-font") == 1, "scanner reads text_label font_id");
+    Check(ids.size() == 7, "scanner dedupes repeated ids (7 unique)");
+  }
 
 #ifdef ASSET_TEST_FIXTURE_DIR
-    std::cout << "[validation] reference checks against catalog\n";
-    {
-        sol::state lua;
-        lua.open_libraries(sol::lib::base, sol::lib::table);
+  std::cout << "[validation] reference checks against catalog\n";
+  {
+    sol::state lua;
+    lua.open_libraries(sol::lib::base, sol::lib::table);
 
-        AssetManager am;
-        am.GetCatalog().Build(ASSET_TEST_FIXTURE_DIR, lua, std::optional<ScaleMode>(ScaleMode::Nearest));
+    AssetManager am;
+    am.GetCatalog().Build(ASSET_TEST_FIXTURE_DIR, lua, std::optional<ScaleMode>(ScaleMode::Nearest));
 
-        const std::vector<AssetReference> refs = {
-            {"hero", "entity 'A' sprite.texture_asset_id"}, // valid
-            {"main-16", "entity 'B' text_label.font_id"}, // valid
-            {"nope", "entity 'C' sprite.texture_asset_id"}, // missing from catalog
-        };
-        Check(am.Validate(refs) == 1, "validation flags exactly the one unknown id");
+    const std::vector<AssetReference> refs = {
+        {"hero", "entity 'A' sprite.texture_asset_id"},  // valid
+        {"main-16", "entity 'B' text_label.font_id"},    // valid
+        {"nope", "entity 'C' sprite.texture_asset_id"},  // missing from catalog
+    };
+    Check(am.Validate(refs) == 1, "validation flags exactly the one unknown id");
 
-        const std::vector<AssetReference> clean = {{"hero", "x"}, {"branding", "y"}};
-        Check(am.Validate(clean) == 0, "validation passes a clean reference set");
+    const std::vector<AssetReference> clean = {{"hero", "x"}, {"branding", "y"}};
+    Check(am.Validate(clean) == 0, "validation passes a clean reference set");
 
-        // Refcount accounting on the no-load paths (real SDL loads need a renderer + real files, so
-        // those are exercised by the runtime scene-swap check, not here).
-        Check(am.RefCount("hero") == 0, "untracked id starts at refcount 0");
-        Check(!am.Acquire("totally-missing-id", nullptr, nullptr), "Acquire of an unknown id fails");
-        Check(am.RefCount("totally-missing-id") == 0, "failed Acquire leaves no refcount entry");
-        am.Release("never-acquired"); // must be a safe no-op
-        Check(am.RefCount("never-acquired") == 0, "Release of an untracked id is a no-op");
-    }
+    // Refcount accounting on the no-load paths (real SDL loads need a renderer + real files, so
+    // those are exercised by the runtime scene-swap check, not here).
+    Check(am.RefCount("hero") == 0, "untracked id starts at refcount 0");
+    Check(!am.Acquire("totally-missing-id", nullptr, nullptr), "Acquire of an unknown id fails");
+    Check(am.RefCount("totally-missing-id") == 0, "failed Acquire leaves no refcount entry");
+    am.Release("never-acquired");  // must be a safe no-op
+    Check(am.RefCount("never-acquired") == 0, "Release of an untracked id is a no-op");
+  }
 
-    std::cout << "[assets-table] id proxy raises on typo\n";
-    {
-        sol::state lua;
-        lua.open_libraries(sol::lib::base, sol::lib::table);
+  std::cout << "[assets-table] id proxy raises on typo\n";
+  {
+    sol::state lua;
+    lua.open_libraries(sol::lib::base, sol::lib::table);
 
-        AssetCatalog catalog;
-        catalog.Build(ASSET_TEST_FIXTURE_DIR, lua, std::optional<ScaleMode>(ScaleMode::Nearest));
-        catalog.InstallLuaIdTable(lua);
+    AssetCatalog catalog;
+    catalog.Build(ASSET_TEST_FIXTURE_DIR, lua, std::optional<ScaleMode>(ScaleMode::Nearest));
+    catalog.InstallLuaIdTable(lua);
 
-        const sol::protected_function_result good = lua.safe_script("return assets.hero", sol::script_pass_on_error);
-        Check(good.valid() && good.get<std::string>() == "hero", "assets.hero resolves to its id");
+    const sol::protected_function_result good = lua.safe_script("return assets.hero", sol::script_pass_on_error);
+    Check(good.valid() && good.get<std::string>() == "hero", "assets.hero resolves to its id");
 
-        const sol::protected_function_result bad = lua.safe_script("return assets.definitely_missing",
-                                                                   sol::script_pass_on_error);
-        Check(!bad.valid(), "assets.<unknown> raises instead of returning nil");
-    }
+    const sol::protected_function_result bad =
+        lua.safe_script("return assets.definitely_missing", sol::script_pass_on_error);
+    Check(!bad.valid(), "assets.<unknown> raises instead of returning nil");
+  }
 #endif
 
-    std::cout << "[pak] round-trip pack/open via fixture catalog\n";
+  std::cout << "[pak] round-trip pack/open via fixture catalog\n";
+  {
+    // SDL needed for SDL_LoadFile / SDL_IOFromConstMem during Open/OpenIO.
+    SDL_Init(0);
+
+    sol::state lua;
+    lua.open_libraries(sol::lib::base, sol::lib::table);
+
+    AssetCatalog catalog;
+    catalog.Build(ASSET_TEST_FIXTURE_DIR, lua, std::optional<ScaleMode>(ScaleMode::Nearest));
+    Check(catalog.Size() > 0, "pak round-trip: fixture catalog has entries");
+
+    const std::filesystem::path tmpDir = std::filesystem::temp_directory_path() / "octarine_asset_pak_test";
+    std::error_code ec;
+    std::filesystem::create_directories(tmpDir, ec);
+    const std::string pakPath = (tmpDir / "asset_bundle.pak").string();
+
+    const bool packed = AssetPak::Pack(catalog, pakPath, ASSET_TEST_FIXTURE_DIR);
+    Check(packed, "AssetPak::Pack succeeds");
+
+    AssetPak pak;
+    Check(pak.Open(pakPath), "AssetPak::Open succeeds on freshly packed file");
+    // The pak dedupes by source file: a font that appears in the catalog at multiple sizes
+    // shares one underlying file + one pak entry. Compare against unique fullPath count, not
+    // raw catalog.Size().
+    std::set<std::string> uniqueFullPaths;
+    for (const auto& [id, entry] : catalog.Entries()) {
+      uniqueFullPaths.insert(entry.fullPath);
+    }
+    Check(pak.Size() == uniqueFullPaths.size(), "pak entry count matches unique source-file count");
+
+    // Byte-compare every entry: read original file off disk, fetch the pak slice via OpenIO,
+    // confirm length + contents match. Proves the offset/size TOC + memory-mapped slice
+    // serve the same bytes the loose tree would have.
+    int compared = 0;
+    int mismatch = 0;
+    for (const auto& [id, entry] : catalog.Entries()) {
+      const std::filesystem::path rel = std::filesystem::relative(std::filesystem::path(entry.fullPath),
+                                                                  std::filesystem::path(ASSET_TEST_FIXTURE_DIR));
+      const std::string relStr = rel.generic_string();
+
+      std::ifstream src(entry.fullPath, std::ios::binary);
+      const std::vector<char> srcBytes((std::istreambuf_iterator<char>(src)), std::istreambuf_iterator<char>());
+
+      SDL_IOStream* io = pak.OpenIO(relStr);
+      if (io == nullptr) {
+        ++mismatch;
+        continue;
+      }
+      std::vector<char> pakBytes(srcBytes.size());
+      const size_t got = SDL_ReadIO(io, pakBytes.data(), pakBytes.size());
+      SDL_CloseIO(io);
+      if (got != srcBytes.size() || std::memcmp(pakBytes.data(), srcBytes.data(), got) != 0) {
+        ++mismatch;
+      }
+      ++compared;
+    }
+    Check(compared == static_cast<int>(catalog.Size()), "every catalog entry resolves through the pak");
+    Check(mismatch == 0, "every pak entry's bytes match the source file exactly");
+
+    std::filesystem::remove_all(tmpDir, ec);
+    SDL_Quit();
+  }
+
+  std::cout << "[glyph atlas] synthetic Lua + PNG round-trip\n";
+  {
+    // AtlasBaker against a real TTF is exercised by the bake smoke against
+    // Octarine-Engine-Example in CI — the fixture font under tests/fixtures/assets/fonts/
+    // is a stub ASCII placeholder, not a real face. Here we test only the GlyphAtlas loader
+    // shape: a synthetic 4×4 RGBA PNG + a hand-rolled metrics Lua file should round-trip
+    // through `GlyphAtlas::Load` cleanly.
+    SDL_Init(0);
+
+    const std::filesystem::path tmpDir = std::filesystem::temp_directory_path() / "octarine_atlas_synthetic_test";
+    std::error_code ec;
+    std::filesystem::create_directories(tmpDir, ec);
+    const std::string pngPath = (tmpDir / "synth.atlas.png").string();
+    const std::string luaPath = (tmpDir / "synth.atlas.lua").string();
+
+    // 4×4 fully-opaque white via stbi_write — easier than handcrafting a PNG byte stream.
     {
-        // SDL needed for SDL_LoadFile / SDL_IOFromConstMem during Open/OpenIO.
-        SDL_Init(0);
-
-        sol::state lua;
-        lua.open_libraries(sol::lib::base, sol::lib::table);
-
-        AssetCatalog catalog;
-        catalog.Build(ASSET_TEST_FIXTURE_DIR, lua, std::optional<ScaleMode>(ScaleMode::Nearest));
-        Check(catalog.Size() > 0, "pak round-trip: fixture catalog has entries");
-
-        const std::filesystem::path tmpDir =
-            std::filesystem::temp_directory_path() / "octarine_asset_pak_test";
-        std::error_code ec;
-        std::filesystem::create_directories(tmpDir, ec);
-        const std::string pakPath = (tmpDir / "asset_bundle.pak").string();
-
-        const bool packed = AssetPak::Pack(catalog, pakPath, ASSET_TEST_FIXTURE_DIR);
-        Check(packed, "AssetPak::Pack succeeds");
-
-        AssetPak pak;
-        Check(pak.Open(pakPath), "AssetPak::Open succeeds on freshly packed file");
-        // The pak dedupes by source file: a font that appears in the catalog at multiple sizes
-        // shares one underlying file + one pak entry. Compare against unique fullPath count, not
-        // raw catalog.Size().
-        std::set<std::string> uniqueFullPaths;
-        for (const auto& [id, entry] : catalog.Entries()) {
-            uniqueFullPaths.insert(entry.fullPath);
-        }
-        Check(pak.Size() == uniqueFullPaths.size(), "pak entry count matches unique source-file count");
-
-        // Byte-compare every entry: read original file off disk, fetch the pak slice via OpenIO,
-        // confirm length + contents match. Proves the offset/size TOC + memory-mapped slice
-        // serve the same bytes the loose tree would have.
-        int compared = 0;
-        int mismatch = 0;
-        for (const auto& [id, entry] : catalog.Entries())
-        {
-            const std::filesystem::path rel = std::filesystem::relative(
-                std::filesystem::path(entry.fullPath),
-                std::filesystem::path(ASSET_TEST_FIXTURE_DIR));
-            const std::string relStr = rel.generic_string();
-
-            std::ifstream src(entry.fullPath, std::ios::binary);
-            const std::vector<char> srcBytes((std::istreambuf_iterator<char>(src)),
-                                              std::istreambuf_iterator<char>());
-
-            SDL_IOStream* io = pak.OpenIO(relStr);
-            if (io == nullptr)
-            {
-                ++mismatch;
-                continue;
-            }
-            std::vector<char> pakBytes(srcBytes.size());
-            const size_t got = SDL_ReadIO(io, pakBytes.data(), pakBytes.size());
-            SDL_CloseIO(io);
-            if (got != srcBytes.size() || std::memcmp(pakBytes.data(), srcBytes.data(), got) != 0)
-            {
-                ++mismatch;
-            }
-            ++compared;
-        }
-        Check(compared == static_cast<int>(catalog.Size()), "every catalog entry resolves through the pak");
-        Check(mismatch == 0, "every pak entry's bytes match the source file exactly");
-
-        std::filesystem::remove_all(tmpDir, ec);
-        SDL_Quit();
+      std::vector<unsigned char> pixels(4 * 4 * 4, 255);
+      Check(stbi_write_png(pngPath.c_str(), 4, 4, 4, pixels.data(), 16) != 0,
+            "synthetic 4x4 atlas PNG written via stbi_write_png");
+    }
+    {
+      std::ofstream lua(luaPath);
+      lua << "return {\n"
+          << "  size = 16,\n  atlas_width = 4,\n  atlas_height = 4,\n  line_skip = 16,\n"
+          << "  glyphs = {\n"
+          << "    [65] = { x=0, y=0, w=4, h=4, advance=5, minx=0, miny=0 },\n"
+          << "  },\n}\n";
     }
 
-    std::cout << "[glyph atlas] synthetic Lua + PNG round-trip\n";
+    GlyphAtlas atlas;
+    Check(atlas.Load(pngPath, luaPath), "GlyphAtlas::Load round-trips synthetic atlas");
+    Check(atlas.IsLoaded(), "GlyphAtlas::IsLoaded true after Load");
+    Check(atlas.Size() == 1, "synthetic atlas reports exactly one glyph");
+    Check(atlas.Contains(static_cast<std::uint32_t>('A')), "synthetic atlas contains 'A'");
+    Check(!atlas.Contains(static_cast<std::uint32_t>('B')), "synthetic atlas correctly excludes 'B'");
+    Check(atlas.AtlasWidth() == 4 && atlas.AtlasHeight() == 4, "synthetic atlas reports 4x4 dims");
+    Check(atlas.LineSkip() == 16, "synthetic atlas reports line_skip=16");
+
+    const GlyphAtlas::Glyph* gA = atlas.Find(static_cast<std::uint32_t>('A'));
+    Check(gA != nullptr && gA->advance == 5.0F, "'A' glyph advance round-trips");
+
+    // AtlasBaker's DefaultAsciiPrintable helper is independent of TTF availability.
+    const auto cps = AtlasBaker::DefaultAsciiPrintable();
+    Check(cps.size() == 95, "DefaultAsciiPrintable returns 95 codepoints (0x20..0x7E)");
+    Check(cps.front() == 0x20 && cps.back() == 0x7E, "DefaultAsciiPrintable spans space..tilde");
+
+    std::filesystem::remove_all(tmpDir, ec);
+    SDL_Quit();
+  }
+
+  std::cout << "[audio normalize] BS.1770 measure + gain round-trip\n";
+  {
+    // Synthesize 2 seconds of a quiet 1 kHz sine wave (amplitude 0.1 in [-1,1], 48 kHz mono),
+    // measure its loudness, normalize to -16 LUFS, measure again. The bake step writes WAVs
+    // via AudioNormalizer's same path, so this exercises ReadWav/WriteWav + the full BS.1770
+    // chain end-to-end.
+    const std::filesystem::path tmpDir = std::filesystem::temp_directory_path() / "octarine_audio_norm_test";
+    std::error_code ec;
+    std::filesystem::create_directories(tmpDir, ec);
+    const std::string srcPath = (tmpDir / "quiet_tone.wav").string();
+    const std::string dstPath = (tmpDir / "normalized.wav").string();
+
     {
-        // AtlasBaker against a real TTF is exercised by the bake smoke against
-        // Octarine-Engine-Example in CI — the fixture font under tests/fixtures/assets/fonts/
-        // is a stub ASCII placeholder, not a real face. Here we test only the GlyphAtlas loader
-        // shape: a synthetic 4×4 RGBA PNG + a hand-rolled metrics Lua file should round-trip
-        // through `GlyphAtlas::Load` cleanly.
-        SDL_Init(0);
-
-        const std::filesystem::path tmpDir =
-            std::filesystem::temp_directory_path() / "octarine_atlas_synthetic_test";
-        std::error_code ec;
-        std::filesystem::create_directories(tmpDir, ec);
-        const std::string pngPath = (tmpDir / "synth.atlas.png").string();
-        const std::string luaPath = (tmpDir / "synth.atlas.lua").string();
-
-        // 4×4 fully-opaque white via stbi_write — easier than handcrafting a PNG byte stream.
-        {
-            std::vector<unsigned char> pixels(4 * 4 * 4, 255);
-            Check(stbi_write_png(pngPath.c_str(), 4, 4, 4, pixels.data(), 16) != 0,
-                  "synthetic 4x4 atlas PNG written via stbi_write_png");
-        }
-        {
-            std::ofstream lua(luaPath);
-            lua << "return {\n"
-                << "  size = 16,\n  atlas_width = 4,\n  atlas_height = 4,\n  line_skip = 16,\n"
-                << "  glyphs = {\n"
-                << "    [65] = { x=0, y=0, w=4, h=4, advance=5, minx=0, miny=0 },\n"
-                << "  },\n}\n";
-        }
-
-        GlyphAtlas atlas;
-        Check(atlas.Load(pngPath, luaPath), "GlyphAtlas::Load round-trips synthetic atlas");
-        Check(atlas.IsLoaded(), "GlyphAtlas::IsLoaded true after Load");
-        Check(atlas.Size() == 1, "synthetic atlas reports exactly one glyph");
-        Check(atlas.Contains(static_cast<std::uint32_t>('A')), "synthetic atlas contains 'A'");
-        Check(!atlas.Contains(static_cast<std::uint32_t>('B')), "synthetic atlas correctly excludes 'B'");
-        Check(atlas.AtlasWidth() == 4 && atlas.AtlasHeight() == 4, "synthetic atlas reports 4x4 dims");
-        Check(atlas.LineSkip() == 16, "synthetic atlas reports line_skip=16");
-
-        const GlyphAtlas::Glyph* gA = atlas.Find(static_cast<std::uint32_t>('A'));
-        Check(gA != nullptr && gA->advance == 5.0F, "'A' glyph advance round-trips");
-
-        // AtlasBaker's DefaultAsciiPrintable helper is independent of TTF availability.
-        const auto cps = AtlasBaker::DefaultAsciiPrintable();
-        Check(cps.size() == 95, "DefaultAsciiPrintable returns 95 codepoints (0x20..0x7E)");
-        Check(cps.front() == 0x20 && cps.back() == 0x7E, "DefaultAsciiPrintable spans space..tilde");
-
-        std::filesystem::remove_all(tmpDir, ec);
-        SDL_Quit();
+      constexpr std::uint32_t sampleRate = 48000;
+      constexpr std::uint32_t frames = sampleRate * 2;  // 2 seconds
+      constexpr double amplitude = 0.1;
+      constexpr double freq = 1000.0;
+      std::vector<std::int16_t> samples(frames);
+      for (std::uint32_t i = 0; i < frames; ++i) {
+        const double t = static_cast<double>(i) / sampleRate;
+        const double v = amplitude * std::sin(2.0 * 3.14159265358979323846 * freq * t);
+        samples[i] = static_cast<std::int16_t>(std::lrint(v * 32767.0));
+      }
+      // Hand-rolled minimal WAV writer mirroring AudioNormalizer's expected shape.
+      std::ofstream f(srcPath, std::ios::binary);
+      const auto dataBytes = static_cast<std::uint32_t>(samples.size() * 2);
+      const std::uint32_t fileSize = 36 + dataBytes;
+      const std::uint16_t numChannels = 1;
+      const std::uint16_t bitsPerSample = 16;
+      const std::uint16_t blockAlign = numChannels * (bitsPerSample / 8);
+      const std::uint32_t byteRate = sampleRate * blockAlign;
+      const std::uint16_t audioFormat = 1;
+      const std::uint32_t fmtSize = 16;
+      f.write("RIFF", 4);
+      f.write(reinterpret_cast<const char*>(&fileSize), 4);
+      f.write("WAVE", 4);
+      f.write("fmt ", 4);
+      f.write(reinterpret_cast<const char*>(&fmtSize), 4);
+      f.write(reinterpret_cast<const char*>(&audioFormat), 2);
+      f.write(reinterpret_cast<const char*>(&numChannels), 2);
+      f.write(reinterpret_cast<const char*>(&sampleRate), 4);
+      f.write(reinterpret_cast<const char*>(&byteRate), 4);
+      f.write(reinterpret_cast<const char*>(&blockAlign), 2);
+      f.write(reinterpret_cast<const char*>(&bitsPerSample), 2);
+      f.write("data", 4);
+      f.write(reinterpret_cast<const char*>(&dataBytes), 4);
+      f.write(reinterpret_cast<const char*>(samples.data()), dataBytes);
     }
 
-    std::cout << "[audio normalize] BS.1770 measure + gain round-trip\n";
-    {
-        // Synthesize 2 seconds of a quiet 1 kHz sine wave (amplitude 0.1 in [-1,1], 48 kHz mono),
-        // measure its loudness, normalize to -16 LUFS, measure again. The bake step writes WAVs
-        // via AudioNormalizer's same path, so this exercises ReadWav/WriteWav + the full BS.1770
-        // chain end-to-end.
-        const std::filesystem::path tmpDir =
-            std::filesystem::temp_directory_path() / "octarine_audio_norm_test";
-        std::error_code ec;
-        std::filesystem::create_directories(tmpDir, ec);
-        const std::string srcPath = (tmpDir / "quiet_tone.wav").string();
-        const std::string dstPath = (tmpDir / "normalized.wav").string();
+    const double preLufs = AudioNormalizer::MeasureWavLufs(srcPath);
+    Check(std::isfinite(preLufs), "BS.1770 measures synthetic quiet sine to a finite LUFS");
+    Check(preLufs < -20.0, "synthetic quiet sine measures well below -20 LUFS");
 
-        {
-            constexpr std::uint32_t sampleRate = 48000;
-            constexpr std::uint32_t frames = sampleRate * 2;  // 2 seconds
-            constexpr double amplitude = 0.1;
-            constexpr double freq = 1000.0;
-            std::vector<std::int16_t> samples(frames);
-            for (std::uint32_t i = 0; i < frames; ++i) {
-                const double t = static_cast<double>(i) / sampleRate;
-                const double v = amplitude * std::sin(2.0 * 3.14159265358979323846 * freq * t);
-                samples[i] = static_cast<std::int16_t>(std::lrint(v * 32767.0));
-            }
-            // Hand-rolled minimal WAV writer mirroring AudioNormalizer's expected shape.
-            std::ofstream f(srcPath, std::ios::binary);
-            const std::uint32_t dataBytes = static_cast<std::uint32_t>(samples.size() * 2);
-            const std::uint32_t fileSize = 36 + dataBytes;
-            const std::uint16_t numChannels = 1;
-            const std::uint16_t bitsPerSample = 16;
-            const std::uint16_t blockAlign = numChannels * (bitsPerSample / 8);
-            const std::uint32_t byteRate = sampleRate * blockAlign;
-            const std::uint16_t audioFormat = 1;
-            const std::uint32_t fmtSize = 16;
-            f.write("RIFF", 4);
-            f.write(reinterpret_cast<const char*>(&fileSize), 4);
-            f.write("WAVE", 4);
-            f.write("fmt ", 4);
-            f.write(reinterpret_cast<const char*>(&fmtSize), 4);
-            f.write(reinterpret_cast<const char*>(&audioFormat), 2);
-            f.write(reinterpret_cast<const char*>(&numChannels), 2);
-            f.write(reinterpret_cast<const char*>(&sampleRate), 4);
-            f.write(reinterpret_cast<const char*>(&byteRate), 4);
-            f.write(reinterpret_cast<const char*>(&blockAlign), 2);
-            f.write(reinterpret_cast<const char*>(&bitsPerSample), 2);
-            f.write("data", 4);
-            f.write(reinterpret_cast<const char*>(&dataBytes), 4);
-            f.write(reinterpret_cast<const char*>(samples.data()), dataBytes);
-        }
+    const double targetLufs = -16.0;
+    Check(AudioNormalizer::NormalizeWav(srcPath, dstPath, targetLufs),
+          "AudioNormalizer::NormalizeWav writes the normalized WAV");
 
-        const double preLufs = AudioNormalizer::MeasureWavLufs(srcPath);
-        Check(std::isfinite(preLufs), "BS.1770 measures synthetic quiet sine to a finite LUFS");
-        Check(preLufs < -20.0, "synthetic quiet sine measures well below -20 LUFS");
+    const double postLufs = AudioNormalizer::MeasureWavLufs(dstPath);
+    Check(std::isfinite(postLufs), "normalized output measures to a finite LUFS");
+    Check(std::abs(postLufs - targetLufs) < 1.0, "normalized output lands within 1 LU of the -16 LUFS target");
 
-        const double targetLufs = -16.0;
-        Check(AudioNormalizer::NormalizeWav(srcPath, dstPath, targetLufs),
-              "AudioNormalizer::NormalizeWav writes the normalized WAV");
+    std::filesystem::remove_all(tmpDir, ec);
+  }
 
-        const double postLufs = AudioNormalizer::MeasureWavLufs(dstPath);
-        Check(std::isfinite(postLufs), "normalized output measures to a finite LUFS");
-        Check(std::abs(postLufs - targetLufs) < 1.0,
-              "normalized output lands within 1 LU of the -16 LUFS target");
-
-        std::filesystem::remove_all(tmpDir, ec);
-    }
-
-    if (g_failures == 0)
-    {
-        std::cout << "\nAsset pipeline test: PASS\n";
-    }
-    else
-    {
-        std::cerr << "\nAsset pipeline test: " << g_failures << " FAILED\n";
-    }
-    return g_failures;
+  if (g_failures == 0) {
+    std::cout << "\nAsset pipeline test: PASS\n";
+  } else {
+    std::cerr << "\nAsset pipeline test: " << g_failures << " FAILED\n";
+  }
+  return g_failures;
 }

--- a/tests/ProcessTest.cpp
+++ b/tests/ProcessTest.cpp
@@ -4,79 +4,70 @@
 // Hard skip: if `cmake` is not on PATH the executable returns 0 with a SKIP line on stderr —
 // CI environments without cmake on PATH should not flunk this test.
 
-#include "Process/Process.h"
-
 #include <chrono>
 #include <iostream>
 #include <string>
 #include <thread>
 
-namespace
-{
-    int g_failures = 0;
+#include "Process/Process.h"
 
-    void Check(const bool cond, const std::string& what)
-    {
-        if (cond)
-        {
-            std::cout << "  ok   " << what << "\n";
-        }
-        else
-        {
-            std::cerr << "  FAIL " << what << "\n";
-            ++g_failures;
-        }
-    }
-} // namespace
+namespace {
+int g_failures = 0;
 
-int main()
-{
-    using namespace octarine::process;
+void Check(const bool cond, const std::string& what) {
+  if (cond) {
+    std::cout << "  ok   " << what << "\n";
+  } else {
+    std::cerr << "  FAIL " << what << "\n";
+    ++g_failures;
+  }
+}
+}  // namespace
 
-    {
-        SpawnOptions opts;
-        opts.argv = {"cmake", "--version"};
-        auto proc = Process::Spawn(opts);
-        if (!proc)
-        {
-            std::cerr << "SKIP: `cmake` not available on PATH\n";
-            return 0;
-        }
+int main() {
+  using namespace octarine::process;
 
-        std::string stdout_capture;
-        proc->OnStdout([&](std::string_view sv) { stdout_capture.append(sv); });
-
-        const int code = proc->Wait();
-        Check(code == 0, "cmake --version exits with code 0");
-        Check(stdout_capture.find("cmake version") != std::string::npos,
-              "stdout contains 'cmake version'");
+  {
+    SpawnOptions opts;
+    opts.argv = {"cmake", "--version"};
+    auto proc = Process::Spawn(opts);
+    if (!proc) {
+      std::cerr << "SKIP: `cmake` not available on PATH\n";
+      return 0;
     }
 
-    {
-        SpawnOptions opts;
-        opts.argv = {"definitely-not-a-real-binary-octarine"};
-        auto proc = Process::Spawn(opts);
-        Check(!proc.has_value(), "spawning a missing program returns nullopt");
-    }
+    std::string stdout_capture;
+    proc->OnStdout([&](std::string_view sv) { stdout_capture.append(sv); });
 
-    {
-        // Argv quoting: a single arg containing spaces and quotes round-trips. cmake's -E echo
-        // prints argv joined by spaces; the engine layer only cares that argv survives intact.
-        // We round-trip through `cmake -E echo` so this same test exercises the Windows quoting
-        // path end-to-end.
-        SpawnOptions opts;
-        opts.argv = {"cmake", "-E", "echo", "hello \"weird\" world"};
-        auto proc = Process::Spawn(opts);
-        if (proc)
-        {
-            std::string out;
-            proc->OnStdout([&](std::string_view sv) { out.append(sv); });
-            const int code = proc->Wait();
-            Check(code == 0, "cmake -E echo exits cleanly with quoted arg");
-            Check(out.find("hello \"weird\" world") != std::string::npos,
-                  "argv quoting preserves embedded quotes and spaces");
-        }
-    }
+    const int code = proc->Wait();
+    Check(code == 0, "cmake --version exits with code 0");
+    Check(stdout_capture.find("cmake version") != std::string::npos, "stdout contains 'cmake version'");
+  }
 
-    return g_failures == 0 ? 0 : 1;
+  {
+    SpawnOptions opts;
+    opts.argv = {"definitely-not-a-real-binary-octarine"};
+    auto proc = Process::Spawn(opts);
+    Check(!proc.has_value(), "spawning a missing program returns nullopt");
+  }
+
+  {
+    // Argv quoting: a single arg containing spaces and quotes round-trips. cmake's -E echo
+    // prints argv joined by spaces; the engine layer only cares that argv survives intact.
+    // We round-trip through `cmake -E echo` so this same test exercises the Windows quoting
+    // path end-to-end.
+    SpawnOptions opts;
+    opts.argv = {"cmake", "-E", "echo", "hello \"weird\" world"};
+    auto proc = Process::Spawn(opts);
+    if (proc) {
+      std::string out;
+      proc->OnStdout([&](std::string_view sv) { out.append(sv); });
+      const int code = proc->Wait();
+      Check(code == 0, "cmake -E echo exits cleanly with quoted arg");
+      Check(out.find("hello \"weird\" world") != std::string::npos,
+            "argv quoting preserves embedded quotes and spaces");
+    }
+  }
+
+  return g_failures == 0 ? 0 : 1;
 }

--- a/tests/ProjectIniTest.cpp
+++ b/tests/ProjectIniTest.cpp
@@ -2,124 +2,116 @@
 // Registered with ctest as ProjectIniTest. Mirrors the parsing tolerance + shipping-validation
 // rules of cmake/OctarinePackage.cmake and android/app/build.gradle.
 
-#include "Project/ProjectIni.h"
-
 #include <algorithm>
 #include <iostream>
 #include <string>
 
+#include "Project/ProjectIni.h"
+
 using octarine::project::ProjectIni;
 
-namespace
-{
-    int g_failures = 0;
+namespace {
+int g_failures = 0;
 
-    void Check(const bool cond, const std::string& what)
-    {
-        if (cond)
-        {
-            std::cout << "  ok   " << what << "\n";
-        }
-        else
-        {
-            std::cerr << "  FAIL " << what << "\n";
-            ++g_failures;
-        }
-    }
+void Check(const bool cond, const std::string& what) {
+  if (cond) {
+    std::cout << "  ok   " << what << "\n";
+  } else {
+    std::cerr << "  FAIL " << what << "\n";
+    ++g_failures;
+  }
+}
 
-    bool Contains(const std::vector<std::string>& v, const std::string& needle)
-    {
-        return std::any_of(v.begin(), v.end(),
-                           [&](const std::string& s) { return s.find(needle) != std::string::npos; });
-    }
-} // namespace
+bool Contains(const std::vector<std::string>& v, const std::string& needle) {
+  return std::any_of(v.begin(), v.end(), [&](const std::string& s) { return s.find(needle) != std::string::npos; });
+}
+}  // namespace
 
-int main()
-{
-    // Happy path: every known key parses + lands on the matching field.
-    {
-        const std::string body =
-            "# top comment\n"
-            "name = Octarine Example\n"
-            "package_id = com.octarine.example\n"
-            "version_name = 1.2.3\n"
-            "version_code = 42\n"
-            "vendor=Mateo\n"
-            "description = A small example\n"
-            "orientation = landscape\n"
-            "fullscreen = true\n"
-            "permissions = internet,recording\n"
-            "category = game\n"
-            "icon = assets/icon.png\n"
-            "\n"
-            "# trailing comment\n";
+int main() {
+  // Happy path: every known key parses + lands on the matching field.
+  {
+    const std::string body =
+        "# top comment\n"
+        "name = Octarine Example\n"
+        "package_id = com.octarine.example\n"
+        "version_name = 1.2.3\n"
+        "version_code = 42\n"
+        "vendor=Mateo\n"
+        "description = A small example\n"
+        "orientation = landscape\n"
+        "fullscreen = true\n"
+        "permissions = internet,recording\n"
+        "category = game\n"
+        "icon = assets/icon.png\n"
+        "\n"
+        "# trailing comment\n";
 
-        std::vector<std::string> warns;
-        const ProjectIni ini = ProjectIni::Parse(body, &warns);
-        Check(warns.empty(), "no parse warnings on well-formed file");
-        Check(ini.name == "Octarine Example", "name parsed");
-        Check(ini.package_id == "com.octarine.example", "package_id parsed");
-        Check(ini.version_name == "1.2.3", "version_name parsed");
-        Check(ini.version_code == "42", "version_code parsed");
-        Check(ini.vendor == "Mateo", "vendor parsed (no spaces around =)");
-        Check(ini.description == "A small example", "description parsed");
-        Check(ini.orientation == "landscape", "orientation parsed");
-        Check(ini.fullscreen == "true", "fullscreen parsed");
-        Check(ini.permissions == "internet,recording", "permissions parsed");
-        Check(ini.category == "game", "category parsed");
-        Check(ini.icon == "assets/icon.png", "icon parsed");
+    std::vector<std::string> warns;
+    const ProjectIni ini = ProjectIni::Parse(body, &warns);
+    Check(warns.empty(), "no parse warnings on well-formed file");
+    Check(ini.name == "Octarine Example", "name parsed");
+    Check(ini.package_id == "com.octarine.example", "package_id parsed");
+    Check(ini.version_name == "1.2.3", "version_name parsed");
+    Check(ini.version_code == "42", "version_code parsed");
+    Check(ini.vendor == "Mateo", "vendor parsed (no spaces around =)");
+    Check(ini.description == "A small example", "description parsed");
+    Check(ini.orientation == "landscape", "orientation parsed");
+    Check(ini.fullscreen == "true", "fullscreen parsed");
+    Check(ini.permissions == "internet,recording", "permissions parsed");
+    Check(ini.category == "game", "category parsed");
+    Check(ini.icon == "assets/icon.png", "icon parsed");
 
-        Check(ini.ValidateForShipping().empty(), "valid project passes ValidateForShipping");
-    }
+    Check(ini.ValidateForShipping().empty(), "valid project passes ValidateForShipping");
+  }
 
-    // Unknown keys preserved in `all` map but don't fall on a typed field.
-    {
-        const ProjectIni ini = ProjectIni::Parse("future_key = experimental\nname = X\n");
-        auto it = ini.all.find("future_key");
-        Check(it != ini.all.end() && it->second == "experimental", "unknown keys retained in `all`");
-    }
+  // Unknown keys preserved in `all` map but don't fall on a typed field.
+  {
+    const ProjectIni ini = ProjectIni::Parse("future_key = experimental\nname = X\n");
+    auto it = ini.all.find("future_key");
+    Check(it != ini.all.end() && it->second == "experimental", "unknown keys retained in `all`");
+  }
 
-    // Malformed line surfaces in warnings but doesn't break the parse.
-    {
-        std::vector<std::string> warns;
-        const ProjectIni ini = ProjectIni::Parse("not an assignment\nname = OK\n", &warns);
-        Check(ini.name == "OK", "subsequent lines parse after a malformed line");
-        Check(!warns.empty() && Contains(warns, "malformed"), "malformed line surfaces in warnings");
-    }
+  // Malformed line surfaces in warnings but doesn't break the parse.
+  {
+    std::vector<std::string> warns;
+    const ProjectIni ini = ProjectIni::Parse("not an assignment\nname = OK\n", &warns);
+    Check(ini.name == "OK", "subsequent lines parse after a malformed line");
+    Check(!warns.empty() && Contains(warns, "malformed"), "malformed line surfaces in warnings");
+  }
 
-    // Validation: missing required keys.
-    {
-        const ProjectIni ini;
-        const auto errs = ini.ValidateForShipping();
-        Check(Contains(errs, "name"), "missing name reported");
-        Check(Contains(errs, "version_name"), "missing version_name reported");
-        Check(Contains(errs, "package_id"), "missing package_id reported");
-    }
+  // Validation: missing required keys.
+  {
+    const ProjectIni ini;
+    const auto errs = ini.ValidateForShipping();
+    Check(Contains(errs, "name"), "missing name reported");
+    Check(Contains(errs, "version_name"), "missing version_name reported");
+    Check(Contains(errs, "package_id"), "missing package_id reported");
+  }
 
-    // Validation: package_id must be reverse-DNS.
-    {
-        ProjectIni ini;
-        ini.name = "X";
-        ini.version_name = "1.0";
-        ini.package_id = "not-a-valid-id";
-        const auto errs = ini.ValidateForShipping();
-        Check(Contains(errs, "reverse-DNS"), "non-reverse-DNS package_id rejected");
-    }
-    {
-        ProjectIni ini;
-        ini.name = "X";
-        ini.version_name = "1.0";
-        ini.package_id = "com.studio.MyGame"; // uppercase rejected by the CMake/Gradle regex too
-        const auto errs = ini.ValidateForShipping();
-        Check(!errs.empty(), "uppercase in package_id rejected (matches CMake/Gradle regex)");
-    }
-    {
-        ProjectIni ini;
-        ini.name = "X";
-        ini.version_name = "1.0";
-        ini.package_id = "com.studio.mygame";
-        Check(ini.ValidateForShipping().empty(), "valid reverse-DNS package_id accepted");
-    }
+  // Validation: package_id must be reverse-DNS.
+  {
+    ProjectIni ini;
+    ini.name = "X";
+    ini.version_name = "1.0";
+    ini.package_id = "not-a-valid-id";
+    const auto errs = ini.ValidateForShipping();
+    Check(Contains(errs, "reverse-DNS"), "non-reverse-DNS package_id rejected");
+  }
+  {
+    ProjectIni ini;
+    ini.name = "X";
+    ini.version_name = "1.0";
+    ini.package_id = "com.studio.MyGame";  // uppercase rejected by the CMake/Gradle regex too
+    const auto errs = ini.ValidateForShipping();
+    Check(!errs.empty(), "uppercase in package_id rejected (matches CMake/Gradle regex)");
+  }
+  {
+    ProjectIni ini;
+    ini.name = "X";
+    ini.version_name = "1.0";
+    ini.package_id = "com.studio.mygame";
+    Check(ini.ValidateForShipping().empty(), "valid reverse-DNS package_id accepted");
+  }
 
-    return g_failures == 0 ? 0 : 1;
+  return g_failures == 0 ? 0 : 1;
 }


### PR DESCRIPTION
## Summary

Apply `clang-format` (pinned 18.1.8) across the source tree to establish a clean formatting baseline, so future PRs show only intentional changes instead of style noise.

Reformatted: `scripts/octarine-icon-tool/main.cpp` and three test files (`AssetPipelineTest.cpp`, `ProcessTest.cpp`, `ProjectIniTest.cpp`). The rest of the ~640 source files were already compliant.

## Notes

- **AssetPipelineTest.cpp** also switches one cast-initialized local to `auto` (`modernize-use-auto`). The bulk reformat pulled that pre-existing line into the diff, tripping the blocking changed-lines clang-tidy gate; the fix is what clang-tidy recommends.
- **EditorDevicesPanel.cpp is intentionally excluded.** Its only reformat was a single joined line, but any edit there trips the changed-lines clang-tidy gate on the pre-existing cognitive complexity of `DrawDevicesWindow` (247 vs. threshold 15). Refactoring that function is out of scope for a formatting pass, so the file is left untouched — the autoformat bot will tidy it whenever it's next genuinely modified.

## Test plan

- [ ] CI green (no logic changed beyond the one `auto`)